### PR TITLE
Scrolling a scroll view with paging enabled should scroll a whole page at a time

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -18,15 +18,19 @@
         UIScrollView* sv = (UIScrollView*) _view;
         CGSize size = sv.frame.size;
         CGPoint offset = sv.contentOffset;
+        CGFloat fraction = 2.0;
+        if ([sv isPagingEnabled]) {
+            fraction = 1.0;
+        }
         
         if ([@"up" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x, offset.y - size.height/2.0) animated:YES];
+            [sv setContentOffset:CGPointMake(offset.x, offset.y - size.height/fraction) animated:YES];
         } else if ([@"down" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x, offset.y + size.height/2.0) animated:YES];            
+            [sv setContentOffset:CGPointMake(offset.x, offset.y + size.height/fraction) animated:YES];            
         } else if ([@"left" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x - size.width/2.0, offset.y) animated:YES];
+            [sv setContentOffset:CGPointMake(offset.x - size.width/fraction, offset.y) animated:YES];
         } else if ([@"right" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x+ size.width/2.0, offset.y) animated:YES];            
+            [sv setContentOffset:CGPointMake(offset.x + size.width/fraction, offset.y) animated:YES];            
         }
         
         return _view;


### PR DESCRIPTION
When paging is enabled on a scroll view, the user can only scroll the view a full page at a time. When Calabash is scrolling a half page at a time by directly setting the content offset, it is overriding this paging behaviour.

I haven't tested this patch as I can't get the calabash-ios-server to build. I get "target specifies product type 'com.apple.product-type.framework.static', but there's no such product type for the 'iphoneos' platform" when I try to build it. I'm using Xcode 4.3.2.
