### PR TITLE
Move to public calabash-js URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "calabash-js"]
 	path = calabash-js
-	url = git@github.com:calabash/calabash-js.git
+	url = https://github.com/calabash/calabash-js.git


### PR DESCRIPTION
If you don't have commit access, it was not possible to run git submodule
update --init.  Change the submodule to point to the publicly accessible
URL instead.
