### PR TITLE
MapKit support

### DIFF
--- a/calabash/Classes/MapKit/MKMapView+Test.h
+++ b/calabash/Classes/MapKit/MKMapView+Test.h
@@ -1,0 +1,13 @@
+//
+//  MKMapView+Test.h
+//  calabash
+//
+//  Created by Nicholas Albion on 3/08/12.
+//  Copyright (c) 2012 Trifork. All rights reserved.
+//
+
+#import <MapKit/MapKit.h>
+
+@interface MKMapView (Test)
+
+@end

--- a/calabash/Classes/MapKit/MKMapView+Test.m
+++ b/calabash/Classes/MapKit/MKMapView+Test.m
@@ -1,0 +1,110 @@
+//
+//  MKMapView+Test.m
+//  calabash
+//
+//  Created by Nicholas Albion on 3/08/12.
+
+#import "MKMapView+Test.h"
+
+@implementation MKMapView (Test)
+
+- (NSString*) mapBounds {
+    MKCoordinateRegion region = [self region];
+    double dlat = region.span.latitudeDelta / 2;
+    double dlon = region.span.longitudeDelta / 2;
+    double top = region.center.latitude + dlat;
+    double bottom = region.center.latitude - dlat;
+    double left = region.center.longitude - dlon;
+    double right = region.center.longitude + dlon;
+    return [NSString stringWithFormat:@"{\"top\":%F, \"right\":%F, \"bottom\":%F, \"left\":%F}", top, right, bottom, left];
+}
+
+- (void) setCenterToLat:(double)lat lon:(double)lon {
+    CLLocationCoordinate2D coordinate = (CLLocationCoordinate2D){lat, lon};
+    [self setCenterCoordinate:coordinate animated:NO];
+}
+
+- (void) panToLat:(double)lat lon:(double)lon {
+    CLLocationCoordinate2D coordinate = (CLLocationCoordinate2D){lat, lon};
+    [self setCenterCoordinate:coordinate animated:YES];
+}
+
+- (NSString*) currentCenterLocation {
+    CLLocationCoordinate2D center = self.centerCoordinate;	
+    return [NSString stringWithFormat:@"%3.6F,%3.6F", center.latitude, center.longitude];
+}
+
+- (void) showUserLocation:(NSString*)show {
+    BOOL showUser = [@"false" isEqualToString:show] == NO;
+    //    [self showsUserLocation:showUser];
+    self.showsUserLocation = showUser;
+}
+
+/**
+ * selects or deselects the named marker (AKA annotation)
+ */
+- (NSNumber*) tapMarkerByTitle:(NSString*)title {
+    for (NSObject<MKAnnotation> *annotation in [self annotations]) {
+        BOOL matched = [[annotation title] isEqualToString:title];
+        if( !matched ) {
+            // If we can't match by title, perhaps we can match against something in the description
+            // for iPhone 3.2 or better we can check the :description for the title
+            NSString *regEx = [NSString stringWithFormat:@"[\\b_]%@\\b", title];
+            NSRange r = [[annotation description] rangeOfString:regEx options:NSRegularExpressionSearch];
+            if (r.location != NSNotFound) {
+                matched = TRUE;
+            }
+            // for older phones, we could fall back to  [[annotation description] hasSuffix:title] 
+        }
+        
+        if( matched ) {
+            if( [[self selectedAnnotations] containsObject:annotation] ) {
+                [self deselectAnnotation:(id <MKAnnotation>)annotation animated:NO];
+            } else {
+                [self selectAnnotation:(id <MKAnnotation>)annotation animated:NO];
+            }
+            return [NSNumber numberWithBool:YES];
+        }
+    }
+    
+    return [NSNumber numberWithBool:NO];
+}
+
+/**
+ * Provides useful information for a specified marker (MKAnnotation) using the annotation's "debugDescription" method
+ * Your MKAnnotation subclass should implement debugDescription() to return a JSON string.  "focused" will be inserted if the marker has been tapped and focused by the user.
+ *
+ * @return nil or (for example)) {title:"My Marker", "latitude":-33.123456, "longitude":151.123456, "foo":"bar", "focused":true}
+ */
+- (NSString*) getMarkerByTitle:(NSString*)title {
+    for (NSObject<MKAnnotation> *annotation in [self annotations]) {
+        BOOL matched = [[annotation title] isEqualToString:title];
+        if( !matched ) {
+            // If we can't match by title, perhaps we can match against something in the description
+            // for iPhone 3.2 or better we can check the :description for the title
+            NSString *regEx = [NSString stringWithFormat:@"[\\b_]%@\\b", title];
+            NSRange r = [[annotation description] rangeOfString:regEx options:NSRegularExpressionSearch];
+            if (r.location != NSNotFound) {
+                matched = TRUE;
+            }
+            // for older phones, we could fall back to  [[annotation description] hasSuffix:title] 
+        }
+        
+        if( matched ) {
+            NSString* str = [annotation debugDescription];
+            
+            if( [[self selectedAnnotations] containsObject:annotation] ) {
+                //str = [str stringByReplacingOccurrencesOfString:@"}" withString:@", \"focused\":true}"];               
+                str = [str substringToIndex:([str length] - 1)];  // up to but not including index
+                str = [str stringByAppendingString:@", \"focused\":true}"];
+            }
+            
+            return str;
+        }
+    }
+    
+    return nil;
+}
+
+
+@end

--- a/calabash/Classes/MapKit/MKMapView+ZoomLevel.h
+++ b/calabash/Classes/MapKit/MKMapView+ZoomLevel.h
@@ -1,0 +1,16 @@
+//
+//  MKMapView+ZoomLevel.h
+//  http://troybrant.net/blog/2010/01/set-the-zoom-level-of-an-mkmapview/
+//
+
+#import <MapKit/MapKit.h>
+
+@interface MKMapView (ZoomLevel)
+
+- (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                  zoomLevel:(NSUInteger)zoomLevel
+                   animated:(BOOL)animated;
+
+- (NSUInteger) zoomLevel;
+
+@end

--- a/calabash/Classes/MapKit/MKMapView+ZoomLevel.m
+++ b/calabash/Classes/MapKit/MKMapView+ZoomLevel.m
@@ -1,0 +1,133 @@
+//
+//  MKMapView+ZoomLevel.h
+//  http://troybrant.net/blog/2010/01/set-the-zoom-level-of-an-mkmapview/
+
+#import "MKMapView+ZoomLevel.h"
+
+#define MERCATOR_OFFSET 268435456
+#define MERCATOR_RADIUS 85445659.44705395
+
+@implementation MKMapView (ZoomLevel)
+
+#pragma mark -
+#pragma mark Map conversion methods
+
+- (double)longitudeToPixelSpaceX:(double)longitude
+{
+    return round(MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0);
+}
+
+- (double)latitudeToPixelSpaceY:(double)latitude
+{
+    return round(MERCATOR_OFFSET - MERCATOR_RADIUS * logf((1 + sinf(latitude * M_PI / 180.0)) / (1 - sinf(latitude * M_PI / 180.0))) / 2.0);
+}
+
+- (double)pixelSpaceXToLongitude:(double)pixelX
+{
+    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0 / M_PI;
+}
+
+- (double)pixelSpaceYToLatitude:(double)pixelY
+{
+    return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0 / M_PI;
+}
+
+#pragma mark -
+#pragma mark Helper methods
+
+- (MKCoordinateSpan)coordinateSpanWithMapView:(MKMapView *)mapView
+                             centerCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                 andZoomLevel:(NSUInteger)zoomLevel
+{
+    // convert center coordiate to pixel space
+    double centerPixelX = [self longitudeToPixelSpaceX:centerCoordinate.longitude];
+    double centerPixelY = [self latitudeToPixelSpaceY:centerCoordinate.latitude];
+    
+    // determine the scale value from the zoom level
+    NSInteger zoomExponent = 20 - zoomLevel;
+    double zoomScale = pow(2, zoomExponent);
+    
+    // scale the map’s size in pixel space
+    CGSize mapSizeInPixels = mapView.bounds.size;
+    double scaledMapWidth = mapSizeInPixels.width * zoomScale;
+    double scaledMapHeight = mapSizeInPixels.height * zoomScale;
+    
+    // figure out the position of the top-left pixel
+    double topLeftPixelX = centerPixelX - (scaledMapWidth / 2);
+    double topLeftPixelY = centerPixelY - (scaledMapHeight / 2);
+    
+    // find delta between left and right longitudes
+    CLLocationDegrees minLng = [self pixelSpaceXToLongitude:topLeftPixelX];
+    CLLocationDegrees maxLng = [self pixelSpaceXToLongitude:topLeftPixelX + scaledMapWidth];
+    CLLocationDegrees longitudeDelta = maxLng - minLng;
+    
+    // find delta between top and bottom latitudes
+    CLLocationDegrees minLat = [self pixelSpaceYToLatitude:topLeftPixelY];
+    CLLocationDegrees maxLat = [self pixelSpaceYToLatitude:topLeftPixelY + scaledMapHeight];
+    CLLocationDegrees latitudeDelta = -1 * (maxLat - minLat);
+    
+    // create and return the lat/lng span
+    MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
+    return span;
+}
+
+- (NSUInteger) zoomLevelWithMapView: (MKMapView*) mapView {
+    MKCoordinateRegion region = self.region;
+    
+    double centerPixelX = [self longitudeToPixelSpaceX: region.center.longitude];
+    double topLeftPixelX = [self longitudeToPixelSpaceX: region.center.longitude - region.span.longitudeDelta / 2];
+    
+    double scaledMapWidth = (centerPixelX - topLeftPixelX) * 2;
+    CGSize mapSizeInPixels = mapView.bounds.size;
+    double zoomScale = scaledMapWidth / mapSizeInPixels.width;
+    double zoomExponent = log(zoomScale) / log(2);
+    double zoomLevel = 20 - zoomExponent;
+    
+    return zoomLevel;
+}
+
+#pragma mark -
+#pragma mark Public methods
+
+- (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                  zoomLevel:(NSUInteger)zoomLevel
+                   animated:(BOOL)animated
+{
+    // clamp large numbers to 28
+    zoomLevel = MIN(zoomLevel, 28);
+    
+    // use the zoom level to compute the region
+    MKCoordinateSpan span = [self coordinateSpanWithMapView:self centerCoordinate:centerCoordinate andZoomLevel:zoomLevel];
+    MKCoordinateRegion region = MKCoordinateRegionMake(centerCoordinate, span);
+    
+    // set the region like normal
+    [self setRegion:region animated:animated];
+}
+
+- (NSNumber*) setZoomLevel:(int)zoomLevel {
+    CLLocationCoordinate2D center = self.centerCoordinate;	
+    [self setCenterCoordinate:center zoomLevel:zoomLevel animated:NO];
+    
+    NSUInteger newZoomLevel = [self zoomLevel];
+    BOOL success = (newZoomLevel == zoomLevel);
+    return [NSNumber numberWithBool:success];
+}
+
+- (NSNumber*) zoomIn {
+    NSUInteger prevZoomLevel = [self zoomLevel];
+    NSUInteger reqZoomLevel = prevZoomLevel + 1;
+    return [self setZoomLevel:reqZoomLevel];
+}
+
+- (NSNumber*) zoomOut {
+    NSUInteger prevZoomLevel = [self zoomLevel];
+    NSUInteger reqZoomLevel = prevZoomLevel - 1;
+    return [self setZoomLevel:reqZoomLevel];
+}
+
+- (NSUInteger) zoomLevel {
+    NSUInteger zoom = [self zoomLevelWithMapView:self];
+    return zoom;
+}
+
+@end

--- a/calabash/Classes/MapKit/MKPolylineView+Test.h
+++ b/calabash/Classes/MapKit/MKPolylineView+Test.h
@@ -1,0 +1,10 @@
+//
+//  MKPolylineView+Test.h
+//
+//  Created by Nicholas Albion on 27/07/12.
+
+#import <MapKit/MapKit.h>
+
+@interface MKPolylineView (Test)
+
+@end

--- a/calabash/Classes/MapKit/MKPolylineView+Test.m
+++ b/calabash/Classes/MapKit/MKPolylineView+Test.m
@@ -1,0 +1,40 @@
+//
+//  MKPolylineView+Test.m
+//
+//  Created by Nicholas Albion on 27/07/12.
+
+#import "MKPolylineView+Test.h"
+
+@implementation MKPolylineView (Test)
+
+
+/**
+ * @return {"width: 1, "color":[r,g,b], "points":[[lat,lon], ...]}
+ */
+- (NSString*) debugDescription {
+    int count = self.polyline.pointCount;
+    CLLocationCoordinate2D* coords = malloc(sizeof(CLLocationCoordinate2D) * count);
+    NSRange range = NSMakeRange(0, count);
+    [[self polyline] getCoordinates:coords range:range];
+    
+    CGFloat lineWidth = self.lineWidth;
+    
+    CGFloat red, green, blue, alpha;
+    [[self strokeColor] getRed:&red green:&green blue:&blue alpha:&alpha];
+    
+    NSString *str = [NSString stringWithFormat:@"{\"width\":%F, \"color\":[%d, %d, %d], \"points\":[", lineWidth, 
+                                                (int)(red * 255), (int)(green * 255), (int)(blue * 255) ];
+
+    for( int i = 0; i < count; i++ ) {
+        if( i != 0 ) {
+            str = [str stringByAppendingString:@","];
+        }
+        str = [str stringByAppendingFormat:@"[%F,%F]", coords[i].latitude, coords[i].longitude];
+    }
+    str = [str stringByAppendingFormat:@"]}"];
+    
+    free(coords);
+    return str;
+}
+
+@end


### PR DESCRIPTION
I've implemented some "Test" Categories on MKMapView and MKPolylineView that allow calabash-ios to:
- Zoom in, out and to a specified zoom level
- Query the map zoom level
- Centre the map (animated or not)
- Query the map bounds and centre
- Turn the user location marker on/off
- Tap on a map marker by title or description
- Tap away from any map markers
- Query the debugDescription (eg a JSON string) for a marker (via its annotation) by title or description
- Query the debugDescription of a map polyline: {"width: 1, "color":[r,g,b], "points":[[lat,lon], ...]}
