### PR TITLE
Handle NSDate argument

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPSetTextOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSetTextOperation.m
@@ -31,7 +31,13 @@
     }
     else if ([_view respondsToSelector:@selector(setText:)]) 
     {
-        NSString *txt = [_arguments objectAtIndex:0];        
+        NSString *txt = nil;
+        id argument = [_arguments objectAtIndex:0];
+        if ( [ argument isKindOfClass: [ NSString class ] ] ) {
+            txt = argument;
+        } else {
+            txt = [argument description];
+        }
         [_view performSelector:@selector(setText:) withObject:txt];
         return _view;
     }


### PR DESCRIPTION
Resolves an issue that otherwise can cause a crash when the argument is an instance of NSDate

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSDate _isNaturallyRTL]: unrecognized selector sent to instance 0x92a6ef0'
*** First throw call stack:
(0x1b01052 0x17d6d0a 0x1b02ced 0x1a67f00 0x1a67ce2 0x7bd941 0x1b02e72 0x32651 0x3990a 0x39f13 0x2e667 0x1e720 0x23448 0x15786 0x19be3ec 0x19c0515 0x1a38833 0x1a37db4 0x1a37ccb 0x2461879 0x246193e 0x70aa9b 0x53f4d 0x53e7d)


Thread 0 Crashed:
0   libsystem_kernel.dylib          0x9c0dc9c6 __pthread_kill + 10
1   libsystem_c.dylib               0x9ad45f78 pthread_kill + 106
2   libsystem_c.dylib               0x9ad36bdd abort + 167
3   libc++abi.dylib                 0x018f0e78 abort_message + 50
4   libc++abi.dylib                 0x018ee89e _ZL17default_terminatev + 34
5   libobjc.A.dylib                 0x017d6f4b _objc_terminate + 94
6   libc++abi.dylib                 0x018ee8de _ZL19safe_handler_callerPFvvE + 13
7   libc++abi.dylib                 0x018ee946 std::terminate() + 23
8   libc++abi.dylib                 0x018efab2 __cxa_throw + 110
9   libobjc.A.dylib                 0x017d6e15 objc_exception_throw + 311
10  CoreFoundation                  0x01b02ced -[NSObject doesNotRecognizeSelector:] + 253
11  CoreFoundation                  0x01a67f00 ___forwarding___ + 432
12  CoreFoundation                  0x01a67ce2 _CF_forwarding_prep_0 + 50
13  UIKit                           0x007bd941 -[UITextField setText:] + 36
14  CoreFoundation                  0x01b02e72 -[NSObject performSelector:withObject:] + 66
15  HyprMX-FunctionalTesting        0x00032651 -[LPSetTextOperation performWithTarget:error:] + 689 (LPSetTextOperation.m:36)
```
