### PR TITLE
adds support for scroll to rows in table view by mark (access id, access label, and text)

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		B1EBF08916EE63A000AE4D40 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		B1EBF08A16EE63A000AE4D40 /* LPQueryLogRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EBF08616EE63A000AE4D40 /* LPQueryLogRoute.h */; };
 		B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; };
+		F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */; };
+		F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -271,6 +273,8 @@
 		B1FF22B515CF002500F3A17B /* MKMapView+ZoomLevel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKMapView+ZoomLevel.m"; sourceTree = "<group>"; };
 		B1FF22B615CF002500F3A17B /* MKPolylineView+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKPolylineView+Test.h"; sourceTree = "<group>"; };
 		B1FF22B715CF002500F3A17B /* MKPolylineView+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKPolylineView+Test.m"; sourceTree = "<group>"; };
+		F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToRowWithMarkOperation.h; sourceTree = "<group>"; };
+		F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPScrollToRowWithMarkOperation.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -468,6 +472,8 @@
 		B184FDC114B6DB2B002A744C /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */,
+				F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */,
 				B19440421725C70A00EE1B25 /* LPFlashOperation.h */,
 				B19440431725C70A00EE1B25 /* LPFlashOperation.m */,
 				B15DA5E315C5D80A009E6CFE /* LPQueryAllOperation.h */,
@@ -643,6 +649,7 @@
 				B1EBF08816EE63A000AE4D40 /* LPAppPropertyRoute.h in Headers */,
 				B1EBF08A16EE63A000AE4D40 /* LPQueryLogRoute.h in Headers */,
 				B19440441725C70A00EE1B25 /* LPFlashOperation.h in Headers */,
+				F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -794,6 +801,7 @@
 				B1EBF08916EE63A000AE4D40 /* LPAppPropertyRoute.m in Sources */,
 				B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */,
 				B19440451725C70A00EE1B25 /* LPFlashOperation.m in Sources */,
+				F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -6,6 +6,7 @@
 
 #import "LPOperation.h"
 #import "LPScrollToRowOperation.h"
+#import "LPScrollToRowWithMarkOperation.h"
 #import "LPScrollOperation.h"
 #import "LPQueryOperation.h"
 #import "LPFlashOperation.h"
@@ -21,7 +22,9 @@
     if ([opName isEqualToString:@"scrollToRow"])
     {
         op = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
-    } else if ([opName isEqualToString:@"scroll"])
+    } else if ([opName isEqualToString:@"scrollToRowWithMark"]) {
+      op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
+    }  else if ([opName isEqualToString:@"scroll"])
     {
         op = [[LPScrollOperation alloc] initWithOperation:dictionary];
     } else if ([opName isEqualToString:@"query"])

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.h
@@ -1,0 +1,11 @@
+//
+//  ScrollOperation.h
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPOperation.h"
+
+@interface LPScrollToRowWithMarkOperation : LPOperation
+
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -1,0 +1,126 @@
+//
+//  ScrollOperation.m
+//  Calabash
+//
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPScrollToRowWithMarkOperation.h"
+
+@implementation LPScrollToRowWithMarkOperation
+
+- (NSString *) description {
+	return [NSString stringWithFormat:@"ScrollToRow: %@",_arguments];
+}
+
+
+- (BOOL) view:(UIView *) aView hasMark:(NSString *) aMark {
+  // iOS 5+
+  NSString *idenififer = nil;
+  if ([aView respondsToSelector:@selector(accessibilityIdentifier)]) {
+    idenififer = aView.accessibilityIdentifier;
+  }
+  
+  if (idenififer != nil && [idenififer isEqualToString:aMark]) {
+    return YES;
+  }
+  
+  if ([aView.accessibilityLabel isEqualToString:aMark]) {
+    return YES;
+  }
+  
+  if ([aView isKindOfClass:[UILabel class]]) {
+    UILabel *label = (UILabel *) aView;
+    if ([label.text isEqualToString:aMark]) { return YES; }
+  }
+  
+  if ([aView isKindOfClass:[UITextView class]]) {
+    UITextView *textView = (UITextView *) aView;
+    if ([textView.text isEqualToString:aMark]) { return YES; }
+  }
+  
+  return NO;
+}
+
+- (BOOL) cell:(UITableViewCell *) aCell hasSubviewMarked:(NSString *) aMark {
+  // check the textLabel first
+  if ([self view:aCell.textLabel hasMark:aMark]) { return YES; }
+  
+  // skip the details text label
+  // if ([self view:aCell.detailTextLabel hasMark:aMark]) { return YES; }
+  UIView *contentView = aCell.contentView;
+  for (UIView *subview in [contentView subviews]) {
+    if ([self view:subview hasMark:aMark]) { return YES; }
+  }
+  
+  return NO;
+}
+
+- (NSIndexPath *) indexPathForRowWithMark:(NSString *) aMark inTable:(UITableView*) aTable {
+	NSUInteger numberOfSections = [aTable numberOfSections];
+  for (NSUInteger section = 0; section < numberOfSections; section++) {
+    NSUInteger numberOfRows = [aTable numberOfRowsInSection:section];
+    for (NSUInteger row = 0; row < numberOfRows; row++) {
+      NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:section];
+      // only returns visible cells
+      UITableViewCell *cell = [aTable cellForRowAtIndexPath:path];
+      if (cell == nil) {
+        // ask the dataSource for the cell
+        cell = [aTable.dataSource tableView:aTable cellForRowAtIndexPath:path];
+      }
+
+      // is the cell itself marked?
+      if ([self view:cell hasMark:aMark]) { return path; }
+      // are any of it's subviews marked?
+      if ([self cell:cell hasSubviewMarked:aMark]) { return path; }
+    }
+  }
+  return nil;
+}
+
+//                 required      optional     optional
+// _arguments ==> [row mark, scroll position, animated]
+- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
+  if ([_view isKindOfClass:[UITableView class]] == NO) {
+    NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",_view);
+    return nil;
+  }
+  
+  UITableView* table = (UITableView*) _view;
+  NSString *rowId = [_arguments objectAtIndex:0];
+  if (rowId == nil || [rowId length] == 0) {
+    NSLog(@"Warning: row id: '%@' should be non-nil and non-empty", rowId);
+    return nil;
+  }
+  
+  NSIndexPath *path = [self indexPathForRowWithMark:rowId inTable:table];
+  if (path == nil) {
+    NSLog(@"Warning: table doesn't contain row with id '%@'", rowId);
+    return nil;
+  }
+  
+  UITableViewScrollPosition sp = UITableViewScrollPositionTop;
+  BOOL animate = YES;
+  
+  
+  if ([_arguments count] > 1) {
+    NSString *scrollPositionArg = [_arguments objectAtIndex:1];
+    if ([@"middle" isEqualToString:scrollPositionArg]) {
+      sp = UITableViewScrollPositionMiddle;
+    } else if ([@"bottom" isEqualToString:scrollPositionArg]) {
+      sp = UITableViewScrollPositionBottom;
+    } else if ([@"none" isEqualToString:scrollPositionArg]) {
+      sp = UITableViewScrollPositionNone;
+    }
+  }
+  
+  if ([_arguments count] > 2) {
+    NSNumber *ani = [_arguments objectAtIndex:2];
+    animate = [ani boolValue];
+  }
+  
+  [table scrollToRowAtIndexPath:path atScrollPosition:sp animated:animate];
+  return _view;
+}
+@end


### PR DESCRIPTION
adds LPScrollToRowWithMarkOperation which allows calabash-cucumber to send queries using `:scrollToRowWithMark`.  this allows testers to scroll to a row using a mark instead of using an index (path).

supports searching for cells by:
- accessibilityIdentifier (iOS 5+)
- accessibilityLabel
- subviews in the cell's contentView that match:
  - accessibilityIdentifier (iOS 5+)
  - accessibilityLabel
  - text (UILabel and UITextView)

for more details see:
- calabash/calabash-ios#128 for more details
- pull request: https://github.com/calabash/calabash-ios-server/pull/17

**WARNING:** not tested on iOS 4, but calls to `accessibilityIdentifier` are guarded by calls to `respondsToSelector:@selector(accessibilityIdentifier)`

here is an example of how to use the `:scrollToRowWithMark` on the calabash-cucumber side:

```
    def scroll_to_row_with_mark(row_id, options={:query => 'tableView',
                                                 :scroll_position => :middle,
                                                 :animate => true})
      uiquery = options[:query] || 'tableView'

      args = []
      if options.has_key?(:scroll_position)
        args << options[:scroll_position]
      else
        args << 'middle'
      end
      if options.has_key?(:animate)
        args << options[:animate]
      end

      views_touched=map(uiquery, :scrollToRowWithMark, row_id, *args)

      if views_touched.empty? or views_touched.member? '<VOID>'
        screenshot_and_raise "Unable to scroll: '#{uiquery}' to: #{options}"
      end
      views_touched
    end
```
