### PR TITLE
adds :changeDatePickerDate operation to the server to allow testers to easily interact with date pickers

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; };
 		F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */; };
 		F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; };
+		F5FDE7901755D56B002A3749 /* LPDatePickerOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5FDE78E1755D56B002A3749 /* LPDatePickerOperation.h */; };
+		F5FDE7911755D56B002A3749 /* LPDatePickerOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5FDE78F1755D56B002A3749 /* LPDatePickerOperation.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -275,6 +277,8 @@
 		B1FF22B715CF002500F3A17B /* MKPolylineView+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKPolylineView+Test.m"; sourceTree = "<group>"; };
 		F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToRowWithMarkOperation.h; sourceTree = "<group>"; };
 		F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPScrollToRowWithMarkOperation.m; sourceTree = "<group>"; };
+		F5FDE78E1755D56B002A3749 /* LPDatePickerOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDatePickerOperation.h; sourceTree = "<group>"; };
+		F5FDE78F1755D56B002A3749 /* LPDatePickerOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDatePickerOperation.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -472,6 +476,8 @@
 		B184FDC114B6DB2B002A744C /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				F5FDE78E1755D56B002A3749 /* LPDatePickerOperation.h */,
+				F5FDE78F1755D56B002A3749 /* LPDatePickerOperation.m */,
 				F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */,
 				F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */,
 				B19440421725C70A00EE1B25 /* LPFlashOperation.h */,
@@ -650,6 +656,7 @@
 				B1EBF08A16EE63A000AE4D40 /* LPQueryLogRoute.h in Headers */,
 				B19440441725C70A00EE1B25 /* LPFlashOperation.h in Headers */,
 				F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */,
+				F5FDE7901755D56B002A3749 /* LPDatePickerOperation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -802,6 +809,7 @@
 				B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */,
 				B19440451725C70A00EE1B25 /* LPFlashOperation.m in Sources */,
 				F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */,
+				F5FDE7911755D56B002A3749 /* LPDatePickerOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.h
@@ -1,0 +1,11 @@
+//
+//  ScrollOperation.h
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPOperation.h"
+
+@interface LPDatePickerOperation : LPOperation
+
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -1,0 +1,104 @@
+//
+//  ScrollOperation.m
+//  Calabash
+//
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPDatePickerOperation.h"
+
+
+
+
+@implementation LPDatePickerOperation
+
+- (NSString *) description {
+	return [NSString stringWithFormat:@"DatePicker: %@",_arguments];
+}
+
+/*
+ args << options[:is_timer] || false
+ args << options[:notify_targets] || true
+ args << options[:animate] || true
+ */
+
+
+//                        required =========> |     optional
+// _arguments ==> [target date str, format str, notify targets, animated]
+- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
+  if ([_view isKindOfClass:[UIDatePicker class]] == NO) {
+    NSLog(@"Warning view: %@ should be a date picker",_view);
+    return nil;
+  }
+  
+  UIDatePicker *picker = (UIDatePicker *) _view;
+  
+  NSString *dateStr = _arguments[0];
+  if (dateStr == nil || [dateStr length] == 0) {
+    NSLog(@"Warning: date str: '%@' should be non-nil and non-empty", dateStr);
+    return nil;
+  }
+  
+  NSUInteger argcount = [_arguments count];
+
+  NSString *dateFormat = nil;
+  if (argcount > 1) {
+    dateFormat = _arguments[1];
+  } else {
+    NSLog(@"Warning: date format is required as the second argument");
+    return nil;
+  }
+  
+  
+  BOOL notifyTargets = YES;
+  if (argcount > 2) {
+    notifyTargets = [_arguments[2] boolValue];
+  }
+  
+  BOOL animate = YES;
+  if (argcount > 3) {
+    animate = [_arguments[3] boolValue];
+  }
+  
+  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+  [formatter setDateFormat:dateFormat];
+  NSDate *date = [formatter dateFromString:dateStr];
+  if (date == nil) {
+    NSLog(@"Warning: could not create date from '%@' and format '%@'", dateStr, dateFormat);
+    return nil;
+  }
+  
+  NSDate *minDate = picker.minimumDate;
+  if (minDate != nil && [date compare:minDate] == NSOrderedAscending) {
+    NSLog(@"Warning: could not set the date to '%@' because is earlier than the minimum date '%@'",
+          date, [minDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+    return nil;
+  }
+  
+  NSDate *maxDate = picker.maximumDate;
+  if (maxDate != nil && [date compare:maxDate] == NSOrderedDescending) {
+    NSLog(@"Warning: could not set the date to '%@' because is later than the maximum date '%@'",
+          date, [maxDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+    return nil;
+  }
+  
+  [picker setDate:date animated:animate];
+
+  if (notifyTargets) {
+    NSSet *targets = [picker allTargets];
+    for (id target in targets) {
+      NSArray *actions = [picker actionsForTarget:target forControlEvent:UIControlEventValueChanged];
+      for (NSString *action in actions) {
+        SEL sel = NSSelectorFromString(action);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [target performSelector:sel withObject:picker];
+#pragma clang diagnostic pop
+      }
+    }
+  }
+
+  return _view;
+}
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -12,6 +12,7 @@
 #import "LPFlashOperation.h"
 #import "LPSetTextOperation.h"
 #import "LPQueryAllOperation.h"
+#import "LPDatePickerOperation.h"
 #import "LPRecorder.h"
 
 @implementation LPOperation
@@ -40,8 +41,10 @@
     else if ([opName isEqualToString:@"flash"])
     {
         op = [[LPFlashOperation alloc] initWithOperation:dictionary];
-    }
-    else
+    } else if ([opName isEqualToString:@"changeDatePickerDate"])
+    {
+        op = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
+    } else
     {
         op = [[LPOperation alloc] initWithOperation:dictionary];
     }


### PR DESCRIPTION
hey karl,

i don't expect you to merge this branch (yet).  it is more of a proof of concept that i want to run by you before i move on to the next phase of tests.

so, date pickers.  what a drag!  i have been fighting with them for over a year now.  briar addresses most of my needs, but others are finding briar hard to use.

a search for 'date picker' on the forum reveals that no one has found a great solution for interacting with them and that newcomers find it difficult to make any progress.

the biggest problem is that, while it is possible  to set the date using `query`, the targets of the date picker do not get have their actions called.  for example, a common UI pattern is to have a label update when the picker changes (see attached screenshot).  in briar, i have to _toggle_ one of the columns to get the associated label to update and this causes no end of problems because of min/max dates and AM/PM devices.
# 

here is how i call the target/actions in the new operation:

```
  if (notifyTargets) {
    NSSet *targets = [picker allTargets];
    for (id target in targets) {
      NSArray *actions = [picker actionsForTarget:target forControlEvent:UIControlEventValueChanged];
      for (NSString *action in actions) {
        SEL sel = NSSelectorFromString(action);
        [target performSelector:sel withObject:picker];
      }
    }
  }
```

i have this working and tested on the ruby side for times:

```
  Then I change the time on the picker to "1:45 PM"
  Then I change the time on the picker to "13:45"
```

before i move on to testing dates and dates + times, i want to make sure that you think this is a good addition.  

what do you think?

PS: i have been using this approach (ie. passing the date string and the format string) in briar for about 8 months with a UIDatePicker category. 

![2013-05-29_20-04-01](https://f.cloud.github.com/assets/466104/580561/0fb610b0-c88b-11e2-8c0d-2b57b10d3a49.png)
