### PR TITLE
adds a change date operation for manipulating date pickers

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		B1EBF08916EE63A000AE4D40 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		B1EBF08A16EE63A000AE4D40 /* LPQueryLogRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EBF08616EE63A000AE4D40 /* LPQueryLogRoute.h */; };
 		B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; };
+		F533172817CF319C005A286C /* LPDatePickerOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F533172617CF319C005A286C /* LPDatePickerOperation.h */; };
+		F533172917CF319C005A286C /* LPDatePickerOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F533172717CF319C005A286C /* LPDatePickerOperation.m */; };
 		F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */; };
 		F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; };
 /* End PBXBuildFile section */
@@ -273,6 +275,8 @@
 		B1FF22B515CF002500F3A17B /* MKMapView+ZoomLevel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKMapView+ZoomLevel.m"; sourceTree = "<group>"; };
 		B1FF22B615CF002500F3A17B /* MKPolylineView+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKPolylineView+Test.h"; sourceTree = "<group>"; };
 		B1FF22B715CF002500F3A17B /* MKPolylineView+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKPolylineView+Test.m"; sourceTree = "<group>"; };
+		F533172617CF319C005A286C /* LPDatePickerOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDatePickerOperation.h; sourceTree = "<group>"; };
+		F533172717CF319C005A286C /* LPDatePickerOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDatePickerOperation.m; sourceTree = "<group>"; };
 		F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToRowWithMarkOperation.h; sourceTree = "<group>"; };
 		F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPScrollToRowWithMarkOperation.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -472,6 +476,8 @@
 		B184FDC114B6DB2B002A744C /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				F533172617CF319C005A286C /* LPDatePickerOperation.h */,
+				F533172717CF319C005A286C /* LPDatePickerOperation.m */,
 				F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */,
 				F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */,
 				B19440421725C70A00EE1B25 /* LPFlashOperation.h */,
@@ -650,6 +656,7 @@
 				B1EBF08A16EE63A000AE4D40 /* LPQueryLogRoute.h in Headers */,
 				B19440441725C70A00EE1B25 /* LPFlashOperation.h in Headers */,
 				F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */,
+				F533172817CF319C005A286C /* LPDatePickerOperation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -802,6 +809,7 @@
 				B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */,
 				B19440451725C70A00EE1B25 /* LPFlashOperation.m in Sources */,
 				F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */,
+				F533172917CF319C005A286C /* LPDatePickerOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.h
@@ -1,0 +1,11 @@
+//
+//  ScrollOperation.h
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPOperation.h"
+
+@interface LPDatePickerOperation : LPOperation
+
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -1,0 +1,104 @@
+//
+//  ScrollOperation.m
+//  Calabash
+//
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPDatePickerOperation.h"
+
+
+
+
+@implementation LPDatePickerOperation
+
+- (NSString *) description {
+	return [NSString stringWithFormat:@"DatePicker: %@",_arguments];
+}
+
+/*
+ args << options[:is_timer] || false
+ args << options[:notify_targets] || true
+ args << options[:animate] || true
+ */
+
+
+//                        required =========> |     optional
+// _arguments ==> [target date str, format str, notify targets, animated]
+- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
+  if ([_view isKindOfClass:[UIDatePicker class]] == NO) {
+    NSLog(@"Warning view: %@ should be a date picker",_view);
+    return nil;
+  }
+  
+  UIDatePicker *picker = (UIDatePicker *) _view;
+  
+  NSString *dateStr = _arguments[0];
+  if (dateStr == nil || [dateStr length] == 0) {
+    NSLog(@"Warning: date str: '%@' should be non-nil and non-empty", dateStr);
+    return nil;
+  }
+  
+  NSUInteger argcount = [_arguments count];
+
+  NSString *dateFormat = nil;
+  if (argcount > 1) {
+    dateFormat = _arguments[1];
+  } else {
+    NSLog(@"Warning: date format is required as the second argument");
+    return nil;
+  }
+  
+  
+  BOOL notifyTargets = YES;
+  if (argcount > 2) {
+    notifyTargets = [_arguments[2] boolValue];
+  }
+  
+  BOOL animate = YES;
+  if (argcount > 3) {
+    animate = [_arguments[3] boolValue];
+  }
+  
+  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+  [formatter setDateFormat:dateFormat];
+  NSDate *date = [formatter dateFromString:dateStr];
+  if (date == nil) {
+    NSLog(@"Warning: could not create date from '%@' and format '%@'", dateStr, dateFormat);
+    return nil;
+  }
+  
+  NSDate *minDate = picker.minimumDate;
+  if (minDate != nil && [date compare:minDate] == NSOrderedAscending) {
+    NSLog(@"Warning: could not set the date to '%@' because is earlier than the minimum date '%@'",
+          date, [minDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+    return nil;
+  }
+  
+  NSDate *maxDate = picker.maximumDate;
+  if (maxDate != nil && [date compare:maxDate] == NSOrderedDescending) {
+    NSLog(@"Warning: could not set the date to '%@' because is later than the maximum date '%@'",
+          date, [maxDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+    return nil;
+  }
+  
+  [picker setDate:date animated:animate];
+
+  if (notifyTargets) {
+    NSSet *targets = [picker allTargets];
+    for (id target in targets) {
+      NSArray *actions = [picker actionsForTarget:target forControlEvent:UIControlEventValueChanged];
+      for (NSString *action in actions) {
+        SEL sel = NSSelectorFromString(action);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [target performSelector:sel withObject:picker];
+#pragma clang diagnostic pop
+      }
+    }
+  }
+
+  return _view;
+}
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -13,6 +13,7 @@
 #import "LPSetTextOperation.h"
 #import "LPQueryAllOperation.h"
 #import "LPRecorder.h"
+#import "LPDatePickerOperation.h"
 
 @implementation LPOperation
 
@@ -22,17 +23,23 @@
     if ([opName isEqualToString:@"scrollToRow"])
     {
         op = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
-    } else if ([opName isEqualToString:@"scrollToRowWithMark"]) {
+      
+    } else if ([opName isEqualToString:@"scrollToRowWithMark"])
+    {
       op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
+    
     }  else if ([opName isEqualToString:@"scroll"])
     {
         op = [[LPScrollOperation alloc] initWithOperation:dictionary];
+    
     } else if ([opName isEqualToString:@"query"])
     {
         op = [[LPQueryOperation alloc] initWithOperation:dictionary];
+    
     } else if ([opName isEqualToString:@"query_all"])
     {
         op = [[LPQueryAllOperation alloc] initWithOperation:dictionary];
+    
     } else if ([opName isEqualToString:@"setText"])
     {
         op = [[LPSetTextOperation alloc] initWithOperation:dictionary];
@@ -40,6 +47,10 @@
     else if ([opName isEqualToString:@"flash"])
     {
         op = [[LPFlashOperation alloc] initWithOperation:dictionary];
+    }
+    else if ([opName isEqualToString:@"changeDatePickerDate"])
+    {
+      op = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
     }
     else
     {


### PR DESCRIPTION
### Motivation

Manipulating UIDatePickers using calabash-ios is difficult.  

The forum is littered with questions about and problems with interacting with date pickers.

Dealing with dates is inherently complex.  
- time zones
- regional date formats
- 12h/24 clocks
- timers vs clocks
- alarm time vs clock time
- minimum/maximum allow dates

Application features involving dates are often buggy making testing particularly important.
- Can my app display 12h/24h times correctly in a label when the picker is changed?
- Do my Reminders work across time zones?
- When I change the time on view X, does the change show up in view Y?
### Previous Solutions
#### Make a Recording - Do what the user would do.

This does work, but getting it to work well is difficult and time consuming.  Consider an app with date pickers, time pickers, date and time pickers, alarms, and support for 12h/24h formats.  Recordings need to be made and managed to handle all these modes; some will be the same, but some will not and identifying those edge cases is tedious.  From experience, I know that using the `scroll` functions and recordings provided by calabash do not work. 
#### Set the Date with `query`

e.g. `query("datePicker", {setDate:<date>})`

This also works, but no UIEvents are generated.  The UIDatePicker targets will not receive action messages.  The date will change, but the rest of the UI/app will not be aware of the change.  This is not ideal.
#### Use a Category on UIDatePicker

```
@interface UIDatePicker (CALABASH_ADDITIONS)
- (NSString *) hasCalabashAdditions:(NSString *) aSuccessIndicator;
- (BOOL) setDateWithString:(NSString *)aString
                    format:(NSString *) aFormat
                  animated:(BOOL) aAnimated;
@end
```

This also works, but it requires access to the source code.  We want manipulating the UIDatePicker to work out-of-the-box.
#### Use `query` to Manipulate the UIPickerView subviews

I tried this approach in briar.  It works, but it takes a lot of code to dig through the view hierarchy and you face the same issues as you do with recordings - there are so many modes and so many edge cases that it difficult to support (and test) all use cases.
### Proposed Solution:  `LPDatePickerOperation`

I have been using the operation extensively in my own apps.

It boils down to this: 
- send a target date as a string
- send a format string that objc can use to convert the date to an NSDate
- set the date with `UIDatePicker setDate:animated`
- optionally call the picker target/action pairs

It is very simple and very flexible.

`map(query_str, :changeDatePickerDate, target_str, fmt_str, *args)`

I realize this breaks with the 'do what the user would do' maxim, but the reality is that all other solutions are suboptimal.

On the ruby side, I propose that we provide a simple function and a simple predefined step that demonstrate the capabilities - nothing fancy. 
