### PR TITLE
added operation for manipulating UIDatePickers

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		B1EBF08916EE63A000AE4D40 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		B1EBF08A16EE63A000AE4D40 /* LPQueryLogRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EBF08616EE63A000AE4D40 /* LPQueryLogRoute.h */; };
 		B1EBF08B16EE63A000AE4D40 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; };
+		F55A351117CF8F8F0001E8B4 /* LPDatePickerOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F55A350F17CF8F8F0001E8B4 /* LPDatePickerOperation.h */; };
+		F55A351217CF8F8F0001E8B4 /* LPDatePickerOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F55A351017CF8F8F0001E8B4 /* LPDatePickerOperation.m */; };
 		F591380417C39128007B2BE4 /* LPOrientationOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F591380217C39128007B2BE4 /* LPOrientationOperation.h */; };
 		F591380517C39128007B2BE4 /* LPOrientationOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F591380317C39128007B2BE4 /* LPOrientationOperation.m */; };
 		F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */; };
@@ -275,6 +277,8 @@
 		B1FF22B515CF002500F3A17B /* MKMapView+ZoomLevel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKMapView+ZoomLevel.m"; sourceTree = "<group>"; };
 		B1FF22B615CF002500F3A17B /* MKPolylineView+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKPolylineView+Test.h"; sourceTree = "<group>"; };
 		B1FF22B715CF002500F3A17B /* MKPolylineView+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKPolylineView+Test.m"; sourceTree = "<group>"; };
+		F55A350F17CF8F8F0001E8B4 /* LPDatePickerOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDatePickerOperation.h; sourceTree = "<group>"; };
+		F55A351017CF8F8F0001E8B4 /* LPDatePickerOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDatePickerOperation.m; sourceTree = "<group>"; };
 		F591380217C39128007B2BE4 /* LPOrientationOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPOrientationOperation.h; sourceTree = "<group>"; };
 		F591380317C39128007B2BE4 /* LPOrientationOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPOrientationOperation.m; sourceTree = "<group>"; };
 		F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToRowWithMarkOperation.h; sourceTree = "<group>"; };
@@ -478,6 +482,8 @@
 		B184FDC114B6DB2B002A744C /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				F55A350F17CF8F8F0001E8B4 /* LPDatePickerOperation.h */,
+				F55A351017CF8F8F0001E8B4 /* LPDatePickerOperation.m */,
 				F591380217C39128007B2BE4 /* LPOrientationOperation.h */,
 				F591380317C39128007B2BE4 /* LPOrientationOperation.m */,
 				F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */,
@@ -659,6 +665,7 @@
 				B19440441725C70A00EE1B25 /* LPFlashOperation.h in Headers */,
 				F5AE0BC6174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h in Headers */,
 				F591380417C39128007B2BE4 /* LPOrientationOperation.h in Headers */,
+				F55A351117CF8F8F0001E8B4 /* LPDatePickerOperation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -812,6 +819,7 @@
 				B19440451725C70A00EE1B25 /* LPFlashOperation.m in Sources */,
 				F5AE0BC7174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m in Sources */,
 				F591380517C39128007B2BE4 /* LPOrientationOperation.m in Sources */,
+				F55A351217CF8F8F0001E8B4 /* LPDatePickerOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.h
@@ -1,0 +1,11 @@
+//
+//  ScrollOperation.h
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPOperation.h"
+
+@interface LPDatePickerOperation : LPOperation
+
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -1,0 +1,104 @@
+//
+//  ScrollOperation.m
+//  Calabash
+//
+//  Created by Karl Krukow on 18/08/11.
+//  Copyright (c) 2011 LessPainful. All rights reserved.
+//
+
+#import "LPDatePickerOperation.h"
+
+
+
+
+@implementation LPDatePickerOperation
+
+- (NSString *) description {
+	return [NSString stringWithFormat:@"DatePicker: %@",_arguments];
+}
+
+/*
+ args << options[:is_timer] || false
+ args << options[:notify_targets] || true
+ args << options[:animate] || true
+ */
+
+
+//                        required =========> |     optional
+// _arguments ==> [target date str, format str, notify targets, animated]
+- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
+  if ([_view isKindOfClass:[UIDatePicker class]] == NO) {
+    NSLog(@"Warning view: %@ should be a date picker",_view);
+    return nil;
+  }
+  
+  UIDatePicker *picker = (UIDatePicker *) _view;
+  
+  NSString *dateStr = _arguments[0];
+  if (dateStr == nil || [dateStr length] == 0) {
+    NSLog(@"Warning: date str: '%@' should be non-nil and non-empty", dateStr);
+    return nil;
+  }
+  
+  NSUInteger argcount = [_arguments count];
+
+  NSString *dateFormat = nil;
+  if (argcount > 1) {
+    dateFormat = _arguments[1];
+  } else {
+    NSLog(@"Warning: date format is required as the second argument");
+    return nil;
+  }
+  
+  
+  BOOL notifyTargets = YES;
+  if (argcount > 2) {
+    notifyTargets = [_arguments[2] boolValue];
+  }
+  
+  BOOL animate = YES;
+  if (argcount > 3) {
+    animate = [_arguments[3] boolValue];
+  }
+  
+  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+  [formatter setDateFormat:dateFormat];
+  NSDate *date = [formatter dateFromString:dateStr];
+  if (date == nil) {
+    NSLog(@"Warning: could not create date from '%@' and format '%@'", dateStr, dateFormat);
+    return nil;
+  }
+  
+  NSDate *minDate = picker.minimumDate;
+  if (minDate != nil && [date compare:minDate] == NSOrderedAscending) {
+    NSLog(@"Warning: could not set the date to '%@' because is earlier than the minimum date '%@'",
+          date, [minDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+    return nil;
+  }
+  
+  NSDate *maxDate = picker.maximumDate;
+  if (maxDate != nil && [date compare:maxDate] == NSOrderedDescending) {
+    NSLog(@"Warning: could not set the date to '%@' because is later than the maximum date '%@'",
+          date, [maxDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+    return nil;
+  }
+  
+  [picker setDate:date animated:animate];
+
+  if (notifyTargets) {
+    NSSet *targets = [picker allTargets];
+    for (id target in targets) {
+      NSArray *actions = [picker actionsForTarget:target forControlEvent:UIControlEventValueChanged];
+      for (NSString *action in actions) {
+        SEL sel = NSSelectorFromString(action);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [target performSelector:sel withObject:picker];
+#pragma clang diagnostic pop
+      }
+    }
+  }
+
+  return _view;
+}
+@end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -13,7 +13,7 @@
 #import "LPSetTextOperation.h"
 #import "LPQueryAllOperation.h"
 #import "LPRecorder.h"
-#import "LPTouchUtils.h"
+#import "LPDatePickerOperation.h"
 #import "LPOrientationOperation.h"
 
 @implementation LPOperation
@@ -24,17 +24,23 @@
     if ([opName isEqualToString:@"scrollToRow"])
     {
         op = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
-    } else if ([opName isEqualToString:@"scrollToRowWithMark"]) {
-        op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
+      
+    } else if ([opName isEqualToString:@"scrollToRowWithMark"])
+    {
+      op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
+    
     }  else if ([opName isEqualToString:@"scroll"])
     {
         op = [[LPScrollOperation alloc] initWithOperation:dictionary];
+    
     } else if ([opName isEqualToString:@"query"])
     {
         op = [[LPQueryOperation alloc] initWithOperation:dictionary];
+    
     } else if ([opName isEqualToString:@"query_all"])
     {
         op = [[LPQueryAllOperation alloc] initWithOperation:dictionary];
+    
     } else if ([opName isEqualToString:@"setText"])
     {
         op = [[LPSetTextOperation alloc] initWithOperation:dictionary];
@@ -46,6 +52,10 @@
     else if ([opName isEqualToString:@"orientation"])
     {
         op = [[LPOrientationOperation alloc] initWithOperation:dictionary];
+    }
+    else if ([opName isEqualToString:@"changeDatePickerDate"])
+    {
+      op = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
     }
     else
     {
@@ -86,80 +96,80 @@
 
 
 - (id) initWithOperation:(NSDictionary *)operation {
-    self = [super init];
-    if (self != nil) {
-        _selector =  NSSelectorFromString( [operation objectForKey:@"method_name"] );
-        _arguments = [[operation objectForKey:@"arguments"] retain];
-    }
-    return self;
+	self = [super init];
+	if (self != nil) {
+		_selector =  NSSelectorFromString( [operation objectForKey:@"method_name"] );
+		_arguments = [[operation objectForKey:@"arguments"] retain];
+	}
+	return self;
 }
 
 - (void) dealloc
 {
-    [_arguments release];_arguments=nil;
-    [super dealloc];
+	[_arguments release];_arguments=nil;
+	[super dealloc];
 }
 
 - (NSString *) description {
-    return [NSString stringWithFormat:@"Operation<SEL=%@,Args=%@>",NSStringFromSelector(_selector),_arguments];
+	return [NSString stringWithFormat:@"Operation<SEL=%@,Args=%@>",NSStringFromSelector(_selector),_arguments];
 }
 
 - (id) performWithTarget:(UIView*)target error:(NSError **)error {
-    NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
-    NSUInteger argc = tSig.numberOfArguments - 2;
-    if( argc != [_arguments count]  && *error != NULL) {
-        *error = [NSError errorWithDomain:@"CalabashServer" code:1
+	NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
+	NSUInteger argc = tSig.numberOfArguments - 2;
+	if( argc != [_arguments count]  && *error != NULL) {
+        *error = [NSError errorWithDomain:@"CalabashServer" code:1 
                                  userInfo:
                   [NSDictionary dictionaryWithObjectsAndKeys:
-                   @"Arity mismatch", @"reason",
-                   [NSString stringWithFormat:@"%@ applied to selector %@ with %i args",self,NSStringFromSelector(_selector),argc],@"details"
+                    @"Arity mismatch", @"reason",
+                    [NSString stringWithFormat:@"%@ applied to selector %@ with %i args",self,NSStringFromSelector(_selector),argc],@"details"
                    ,nil]];
         return nil;
     }
+	
+	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:tSig];
+	[invocation setSelector:_selector];
+	
+	NSInteger index = 2; 
+	for( NSObject* arg in _arguments) {
+		[invocation setArgument:&arg atIndex:index++];
+	}
     
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:tSig];
-    [invocation setSelector:_selector];
+	[invocation invokeWithTarget:target];
     
-    NSInteger index = 2;
-    for( NSObject* arg in _arguments) {
-        [invocation setArgument:&arg atIndex:index++];
-    }
-    
-    [invocation invokeWithTarget:target];
-    
-    
-    const char *returnType = tSig.methodReturnType;
-    
-    id returnValue;
-    if( !strcmp(returnType, @encode(void)) )
-        returnValue =  nil;
-    else if( !strcmp(returnType, @encode(id)) ) // retval is an objective c object
-    {
-        [invocation getReturnValue:&returnValue];
-    }else {
-        // handle primitive c types by wrapping them in an NSValue
-        
-        NSUInteger length = [tSig methodReturnLength];
-        void *buffer = (void *)malloc(length);
-        [invocation getReturnValue:buffer];
-        
-        // for some reason using [NSValue valueWithBytes:returnType] is creating instances of NSConcreteValue rather than NSValue, so
-        //I'm fudging it here with case-by-case logic
-        if( !strcmp(returnType, @encode(BOOL)) )
-        {
-            returnValue = [NSNumber numberWithBool:*((BOOL*)buffer)];
-        }else if( !strcmp(returnType, @encode(NSInteger)) )
-        {
-            returnValue = [NSNumber numberWithInteger:*((NSInteger*)buffer)];
-        }else if( !strcmp(returnType, @encode(float)) )
-        {
-            returnValue = [NSNumber numberWithFloat:*((float*)buffer)];
-        }else {
-            returnValue = [[[NSValue valueWithBytes:buffer objCType:returnType] copy] autorelease];
-        }
-        free(buffer);//memory leak here, but apparently NSValue doesn't copy the passed buffer, it just stores the pointer
-    }
-    return returnValue;	
+	
+	const char *returnType = tSig.methodReturnType;
+	
+	id returnValue;
+	if( !strcmp(returnType, @encode(void)) )
+		returnValue =  nil;
+	else if( !strcmp(returnType, @encode(id)) ) // retval is an objective c object
+	{
+		[invocation getReturnValue:&returnValue];
+	}else {
+		// handle primitive c types by wrapping them in an NSValue
+		
+		NSUInteger length = [tSig methodReturnLength];
+		void *buffer = (void *)malloc(length);
+		[invocation getReturnValue:buffer];
+		
+		// for some reason using [NSValue valueWithBytes:returnType] is creating instances of NSConcreteValue rather than NSValue, so 
+		//I'm fudging it here with case-by-case logic
+		if( !strcmp(returnType, @encode(BOOL)) ) 
+		{
+			returnValue = [NSNumber numberWithBool:*((BOOL*)buffer)];
+		}else if( !strcmp(returnType, @encode(NSInteger)) )
+		{
+			returnValue = [NSNumber numberWithInteger:*((NSInteger*)buffer)];
+		}else if( !strcmp(returnType, @encode(float)) )
+		{
+			returnValue = [NSNumber numberWithFloat:*((float*)buffer)];
+		}else {
+			returnValue = [[[NSValue valueWithBytes:buffer objCType:returnType] copy] autorelease];
+		}
+		free(buffer);//memory leak here, but apparently NSValue doesn't copy the passed buffer, it just stores the pointer
+	}
+	return returnValue;	
 }
 
 @end

--- a/changelog/0.9.152.md
+++ b/changelog/0.9.152.md
@@ -1,0 +1,14 @@
+* (pull 20) Alert View support for iOS 7 (credit to Kra Larivain @
+  OpenTable)
+  https://github.com/calabash/calabash-ios-server/pull/20
+
+* (pull 22) enhance device rotation
+  thanks to Maksym Grebenets @mgrebenets (issue 156)
+  thanks to Mayank Jain @firesofmay (issue 72)
+  https://github.com/calabash/calabash-ios-server/pull/22
+
+* (pull 24) added operation for manipulating UIDatePickers
+  https://github.com/calabash/calabash-ios-server/pull/24
+
+
+

--- a/changelog/0.9.152.txt
+++ b/changelog/0.9.152.txt
@@ -1,7 +1,0 @@
-* (pull 20) Alert View support for iOS 7 (credit to Kra Larivain @
-  OpenTable)
-  https://github.com/calabash/calabash-ios-server/pull/20
-* (issue 156) enhance device rotation
-  https://github.com/calabash/calabash-ios/issues/156
-
-


### PR DESCRIPTION
@krukow apologies for the formatting changes in LPOperations.m - still working on my git foo.  hopefully this will be the last time this happens.
### Motivation

Manipulating UIDatePickers using calabash-ios is difficult.  

The forum is littered with questions about and problems with interacting with date pickers.

Dealing with dates is inherently complex.  
- time zones
- regional date formats
- 12h/24 clocks
- timers vs clocks
- alarm time vs clock time
- minimum/maximum allow dates

Application features involving dates are often buggy making testing particularly important.
- Can my app display 12h/24h times correctly in a label when the picker is changed?
- Do my Reminders work across time zones?
- When I change the time on view X, does the change show up in view Y?
### Previous Solutions
#### Make a Recording - Do what the user would do.

This does work, but getting it to work well is difficult and time consuming.  Consider an app with date pickers, time pickers, date and time pickers, alarms, and support for 12h/24h formats.  Recordings need to be made and managed to handle all these modes; some will be the same, but some will not and identifying those edge cases is tedious.  From experience, I know that using the `scroll` functions and recordings provided by calabash do not work. 
#### Set the Date with `query`

e.g. `query("datePicker", {setDate:<date>})`

This also works, but no UIEvents are generated.  The UIDatePicker targets will not receive action messages.  The date will change, but the rest of the UI/app will not be aware of the change.  This is not ideal.
#### Use a Category on UIDatePicker

```
@interface UIDatePicker (CALABASH_ADDITIONS)
- (NSString *) hasCalabashAdditions:(NSString *) aSuccessIndicator;
- (BOOL) setDateWithString:(NSString *)aString
                    format:(NSString *) aFormat
                  animated:(BOOL) aAnimated;
@end
```

This also works, but it requires access to the source code.  We want manipulating the UIDatePicker to work out-of-the-box.
#### Use `query` to Manipulate the UIPickerView subviews

I tried this approach in briar.  It works, but it takes a lot of code to dig through the view hierarchy and you face the same issues as you do with recordings - there are so many modes and so many edge cases that it difficult to support (and test) all use cases.
### Proposed Solution:  `LPDatePickerOperation`

I have been using the operation extensively in my own apps.

It boils down to this: 
- send a target date as a string
- send a format string that objc can use to convert the date to an NSDate
- set the date with `UIDatePicker setDate:animated`
- optionally call the picker target/action pairs

It is very simple and very flexible.

`map(query_str, :changeDatePickerDate, target_str, fmt_str, *args)`

I realize this breaks with the 'do what the user would do' maxim, but the reality is that all other solutions are suboptimal.
