### PR TITLE
adds git revision and branch information to output of server_output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 calabash.xcodeproj/project.xcworkspace/xcuserdata
 calabash.xcodeproj/xcuserdata/
+*.xccheckout
 Markdown.pl
 build
 calabash.framework

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		B1FF22B715CF002500F3A17B /* MKPolylineView+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKPolylineView+Test.m"; sourceTree = "<group>"; };
 		F55A350F17CF8F8F0001E8B4 /* LPDatePickerOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDatePickerOperation.h; sourceTree = "<group>"; };
 		F55A351017CF8F8F0001E8B4 /* LPDatePickerOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDatePickerOperation.m; sourceTree = "<group>"; };
+		F500459D17D249D000B72386 /* LPGitVersionDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPGitVersionDefines.h; sourceTree = "<group>"; };
 		F591380217C39128007B2BE4 /* LPOrientationOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPOrientationOperation.h; sourceTree = "<group>"; };
 		F591380317C39128007B2BE4 /* LPOrientationOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPOrientationOperation.m; sourceTree = "<group>"; };
 		F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToRowWithMarkOperation.h; sourceTree = "<group>"; };
@@ -344,6 +345,7 @@
 		B121E79914B6D9FB0034C6A9 /* calabash */ = {
 			isa = PBXGroup;
 			children = (
+				F500459D17D249D000B72386 /* LPGitVersionDefines.h */,
 				B184FD8514B6DACA002A744C /* Classes */,
 				B121E79A14B6D9FB0034C6A9 /* Supporting Files */,
 			);
@@ -676,7 +678,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B17E757615D433A40066550B /* Build configuration list for PBXNativeTarget "calabash" */;
 			buildPhases = (
+				F500459C17D2498F00B72386 /* Run Script - git versioning 1 of 2 */,
 				B17E756915D433A40066550B /* Sources */,
+				F500459F17D32C0400B72386 /* Run Script - git versioning 2 of 2 */,
 				B17E75B315D435F20066550B /* Headers */,
 				B17E756A15D433A40066550B /* Frameworks */,
 				B17E756B15D433A40066550B /* CopyFiles */,
@@ -732,6 +736,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nmkdir -p \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/${FRAMEWORK_VERSION}/Headers\"\n\n# Link the \"Current\" version to \"${FRAMEWORK_VERSION}\"\nln -sfh ${FRAMEWORK_VERSION} \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/Current\"\nln -sfh Versions/Current/Headers \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Headers\"\nln -sfh \"Versions/Current/${PRODUCT_NAME}\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/${PRODUCT_NAME}\"\n\n# The -a ensures that the headers maintain the source modification date so that we don't constantly\n# cause propagating rebuilds of files that import these headers.\ncp -a \"${BUILT_PRODUCTS_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}/\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/${FRAMEWORK_VERSION}/Headers\"";
+			showEnvVarsInLog = 0;
 		};
 		B17E75BD15D436A50066550B /* Framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -746,6 +751,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\nset +u\n# Avoid recursively calling this script.\nif [[ $SF_MASTER_SCRIPT_RUNNING ]]\nthen\nexit 0\nfi\nset -u\nexport SF_MASTER_SCRIPT_RUNNING=1\n\nSF_TARGET_NAME=${PROJECT_NAME}\nSF_EXECUTABLE_PATH=\"lib${SF_TARGET_NAME}.a\"\nSF_WRAPPER_NAME=\"${SF_TARGET_NAME}.framework\"\n\n# The following conditionals come from\n# https://github.com/kstenerud/iOS-Universal-Framework\n\nif [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]\nthen\nSF_SDK_PLATFORM=${BASH_REMATCH[1]}\nelse\necho \"Could not find platform name from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\nif [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]\nthen\nSF_SDK_VERSION=${BASH_REMATCH[1]}\nelse\necho \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\nif [[ \"$SF_SDK_PLATFORM\" = \"iphoneos\" ]]\nthen\nSF_OTHER_PLATFORM=iphonesimulator\nelse\nSF_OTHER_PLATFORM=iphoneos\nfi\n\nif [[ \"$BUILT_PRODUCTS_DIR\" =~ (.*)$SF_SDK_PLATFORM$ ]]\nthen\nSF_OTHER_BUILT_PRODUCTS_DIR=\"${BASH_REMATCH[1]}${SF_OTHER_PLATFORM}\"\nelse\necho \"Could not find platform name from build products directory: $BUILT_PRODUCTS_DIR\"\nexit 1\nfi\n\n# Build the other platform.\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# Smash the two static libraries into one fat binary and store it in the .framework\nlipo -create \"${BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" -output \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/${FRAMEWORK_VERSION}/${SF_TARGET_NAME}\"\n\n# Copy the binary to the other architecture folder to have a complete framework in both.\ncp -a \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/${FRAMEWORK_VERSION}/${SF_TARGET_NAME}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/${FRAMEWORK_VERSION}/${SF_TARGET_NAME}\"\n\n# Copy the binary as a libcalabashuni.a file\ncp -a \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/${FRAMEWORK_VERSION}/${SF_TARGET_NAME}\" \"${BUILT_PRODUCTS_DIR}/lib${SF_TARGET_NAME}uni.a\"\n\n# Copy the binary as a libcalabashuni.a file\ncp -a \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}/Versions/${FRAMEWORK_VERSION}/${SF_TARGET_NAME}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/lib${SF_TARGET_NAME}uni.a\"\n\nrm -fr calabash.framework\ncp -R \"${BUILT_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\" calabash.framework\n";
+		};
+		F500459C17D2498F00B72386 /* Run Script - git versioning 1 of 2 */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script - git versioning 1 of 2";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh calabash/gitversioning-before.sh \"calabash/LPGitVersionDefines.h\"";
+			showEnvVarsInLog = 0;
+		};
+		F500459F17D32C0400B72386 /* Run Script - git versioning 2 of 2 */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script - git versioning 2 of 2";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh calabash/gitversioning-after.sh \"calabash/LPGitVersionDefines.h\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -15,6 +15,7 @@
 #import "LPRecorder.h"
 #import "LPDatePickerOperation.h"
 #import "LPOrientationOperation.h"
+#import "LPTouchUtils.h"
 
 @implementation LPOperation
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -11,6 +11,40 @@
 #import <sys/utsname.h>
 @class UIDevice;
 
+
+/*** UNEXPECTED ***
+ adds git version and branch information to the server_version route
+ 
+ helps developers know exactly which server framework is installed in an ipa
+ 
+ the two defines:
+ 
+ #define LP_GIT_SHORT_REVISION <rev>  // ex. @"4fdb203"
+ #define LP_GIT_BRANCH <branch>       // ex. @"0.9.x"
+ 
+ are generated before compilation and erased after to avoid git conflicts in
+ LPGitVersionDefines.h
+ 
+ to see how LPGitVersionDefines.h is managed see:
+ 
+ 1. Run Script - git versioning 1 of 2
+ 2. Run Script - git versioning 2 of 2
+ 
+ ******************/
+#import "LPGitVersionDefines.h"
+
+#ifdef LP_GIT_SHORT_REVISION
+static NSString *const kLPGitShortRevision = LP_GIT_SHORT_REVISION;
+#else
+static NSString *const kLPGitShortRevision = @"Unknown";
+#endif
+
+#ifdef LP_GIT_BRANCH
+static NSString *const kLPGitBranch = LP_GIT_BRANCH;
+#else
+static NSString *const kLPGitBranch = @"Unknown";
+#endif
+
 @implementation LPVersionRoute
 
 - (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path 
@@ -54,7 +88,6 @@
         sim = @"";
     }
     
-    
     NSDictionary* res = [NSDictionary dictionaryWithObjectsAndKeys:
                          kLPCALABASHVERSION , @"version",
                          idString,@"app_id",
@@ -66,7 +99,8 @@
                          sim, @"simulator",
                          versionString,@"app_version",
                          @"SUCCESS",@"outcome",
-                         //device, os, serial?, other?
+                         kLPGitShortRevision, @"git revision",
+                         kLPGitBranch, @"git branch",
                          nil];
     return res;
     

--- a/calabash/LPGitVersionDefines.h
+++ b/calabash/LPGitVersionDefines.h
@@ -1,0 +1,24 @@
+/************************** README *****************************
+
+ DO NOT MANUALLY CHANGE THE CONTENTS OF THIS FILE
+
+ the contents are updated before compile time with the following defines:
+
+ #define LP_GIT_SHORT_REVISION <rev>  // ex. @"4fdb203"
+ #define LP_GIT_BRANCH <branch>       // ex. @"0.9.x"
+
+ after compilation, the contents are reset using: 
+
+ to see how this file is managed, navigate to the calabash target and look at:
+
+ 1. Run Script - git versioning 1 of 2
+ 2. Run Script - git versioning 2 of 2
+
+ and these scripts:
+
+ 3. gitversioning-before.sh
+ 4. gitversioning-after.sh
+
+****************************************************************/
+#define LP_GIT_SHORT_REVISION @"7192800"
+#define LP_GIT_BRANCH @"0.9.x-add-git-versioning-information"

--- a/calabash/gitversioning-after.sh
+++ b/calabash/gitversioning-after.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -z "${1}" ]; then
+  echo "FATAL:  you must pass the path to LPGitVersionDefines.h"
+  exit 1
+fi
+
+LP_INFO_PLIST="${1}"
+gitpath=`which git`
+
+echo "INFO: resetting content of ${LP_INFO_PLIST}"
+`$gitpath co -- ${LP_INFO_PLIST}`

--- a/calabash/gitversioning-before.sh
+++ b/calabash/gitversioning-before.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+if [ -z "${1}" ]; then
+  echo "FATAL:  you must pass the path to LPGitVersionDefines.h"
+  exit 1
+fi
+
+LP_INFO_PLIST="${1}"
+gitpath=`which git`
+GITREV=`$gitpath rev-parse --short HEAD`
+GITBRANCH=`git rev-parse --abbrev-ref HEAD`
+
+
+echo "/************************** README *****************************" > "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " DO NOT MANUALLY CHANGE THE CONTENTS OF THIS FILE" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " the contents are updated before compile time with the following defines:" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " #define LP_GIT_SHORT_REVISION <rev>  // ex. @\"4fdb203\"" >> "${LP_INFO_PLIST}"
+echo " #define LP_GIT_BRANCH <branch>       // ex. @\"0.9.x\"" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " after compilation, the contents are reset using: " >> "${LP_INFO_PLIST}"
+echo " git co -- calabash/LPGitVersionDefines.h >>" "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " to see how this file is managed, navigate to the calabash target and look at:" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " 1. Run Script - git versioning 1 of 2" >> "${LP_INFO_PLIST}"
+echo " 2. Run Script - git versioning 2 of 2" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " and these scripts:" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo " 3. gitversioning-before.sh" >> "${LP_INFO_PLIST}"
+echo " 4. gitversioning-after.sh" >> "${LP_INFO_PLIST}"
+echo "" >> "${LP_INFO_PLIST}"
+echo "****************************************************************/" >> "${LP_INFO_PLIST}"
+
+
+
+echo "INFO: setting the GIT_SHORT_REVISION = ${GITREV} in ${LP_INFO_PLIST}"
+echo "#define LP_GIT_SHORT_REVISION @\"${GITREV}\"" >> "${LP_INFO_PLIST}"
+echo "INFO: setting the GIT_BRANCH = ${GITBRANCH} in ${LP_INFO_PLIST}"
+echo "#define LP_GIT_BRANCH @\"${GITBRANCH}\"" >> "${LP_INFO_PLIST}"


### PR DESCRIPTION
#### Change

adds git branch and revision information to `server_version` route.

```
> server_version
{
   <snip>      
   "git branch" => "0.9.x-add-git-versioning-information",
   "git revision" => "e1abd85",
   <snip>
}
```
#### Motivation

the `server_version` route does not provide enough information about what version of the server is installed on an .ipa.
- when developing features for the server where you might testing and developing several feature branches at once over several days
- when you are presented with a stand-alone ipa and you what to know exactly what features are available in the installed framework
#### Implementation

adds two Run Script build phases to calabash target:
1. Run Script - git versioning 1 of 2: runs before compile phase
2. Run Script - git versioning 2 of 2: runs after compile phase

these Run Script build phases call (respectively):
- `calabash/gitversioning-before.sh`
- `calabash/gitversioning-before.sh`

the first script writes git branch and revision information to `calabash/LPGitVersionDefines.h` and the second script performs a `git co -- calabash/LPGitVersionDefines.h` to remove the changes.

in `LPVersionRoute.m`, i use preprocessor conditionals:

```
#ifdef LP_GIT_SHORT_REVISION
static NSString *const kLPGitShortRevision = LP_GIT_SHORT_REVISION;
#else
static NSString *const kLPGitShortRevision = @"Unknown";
#endif
```

to define static constants.

this is important because it guards against script failures.
#### Notes

the second Run Script build phase is necessary because we don't what to track changes in this file:
- it changes for every commit
- if we tracked changes, there would always be conflicts in this file.

in iOS and MacOS projects, i use a versioning target and a preprocessed InfoPlist.h to cache this kind of information in my application Info.plist where it is available in the `NSBundle`.   i tried a similar approach here, but i could get the Info.plist preprocessing step to work.  

i experimented with adding a Bundle to the framework, but that would have required some changes to the `calabash-ios setup` proceedure (an additonal Copy Files build phase).

if a compilation fails, the second Run Script build phase will not be executed, so the `LPGitVersionDefines.h` will have untracked changes.  i guard against this by regenerating the whole `LPGitVersionDefines.h` before compilation.  you probably should not or won't be committing changes when a build does not compile.  for an additional guard, i thought it might make sense to update the file index to `assume-unchanged`:

`git update-index --assume-unchanged calabash/LPGitVersionDefines.h`

but this is a little dangerous and potentially confusing to the uninitiated.
