### PR TITLE
version route reports if the app is an iphone app emulated on an ipad

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -45,25 +45,38 @@ static NSString *const kLPGitBranch = LP_GIT_BRANCH;
 static NSString *const kLPGitBranch = @"Unknown";
 #endif
 
+@interface LPVersionRoute ()
+
+- (BOOL) isIPhoneAppEmulatedOnIPad;
+
+@end
+
 @implementation LPVersionRoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path 
+- (BOOL) isIPhoneAppEmulatedOnIPad {
+    UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
+    NSString *model = [[UIDevice currentDevice] model];
+    return idiom == UIUserInterfaceIdiomPhone && [model hasPrefix:@"iPad"];
+}
+
+
+- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path
 {
     return [method isEqualToString:@"GET"];
 }
 
 - (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {    
-    NSString *versionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];//
+    NSString *versionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     if (!versionString)
     {
         versionString = @"Unknown";
     }
-    NSString *idString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];//
+    NSString *idString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
     if (!idString)
     {
         idString = @"Unknown";
     }
-    NSString *nameString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];//
+    NSString *nameString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     if (!nameString)
     {
         nameString = @"Unknown";
@@ -88,6 +101,8 @@ static NSString *const kLPGitBranch = @"Unknown";
         sim = @"";
     }
     
+    BOOL isIphoneAppEmulated = [self isIPhoneAppEmulatedOnIPad];
+    
     NSDictionary* res = [NSDictionary dictionaryWithObjectsAndKeys:
                          kLPCALABASHVERSION , @"version",
                          idString,@"app_id",
@@ -99,6 +114,7 @@ static NSString *const kLPGitBranch = @"Unknown";
                          sim, @"simulator",
                          versionString,@"app_version",
                          @"SUCCESS",@"outcome",
+                         [NSNumber numberWithBool:isIphoneAppEmulated], @"iphone_app_emulated_on_ipad",
                          kLPGitShortRevision, @"git revision",
                          kLPGitBranch, @"git branch",
                          nil];


### PR DESCRIPTION
### motivation

sometimes it is important to know that you are dealing with an iPhone app that is emulated on an iPad.  

```
iphone_app_emulated_on_ipad => true | false
```

```
> server_version
{
                        "outcome" => "SUCCESS",
                         "app_id" => "com.lesspainful.example.LPSimpleExample-cal",
               "simulator_device" => "iPad",
                        "version" => "0.9.163.pre7",
                     "git branch" => "0.9.x-detect-iphone-emulation-on-ipad",
                       "app_name" => "LPSimpleExample-cal",
    "iphone_app_emulated_on_ipad" => true,
                          "4inch" => false,
                   "git revision" => "12519e1",
                    "app_version" => "1.0",
                    "iOS_version" => "6.1",
                         "system" => "x86_64",
                      "simulator" => "iPhone Simulator 463.9.4.2, iPhone OS 6.1 (iPad Retina/10B141)"
}
```
