### PR TITLE
including remote origin in the git information generated by LPVersionRoute

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -290,6 +290,8 @@
 		F500459D17D249D000B72386 /* LPGitVersionDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPGitVersionDefines.h; sourceTree = "<group>"; };
 		F55A350F17CF8F8F0001E8B4 /* LPDatePickerOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDatePickerOperation.h; sourceTree = "<group>"; };
 		F55A351017CF8F8F0001E8B4 /* LPDatePickerOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDatePickerOperation.m; sourceTree = "<group>"; };
+		F58B6DE8186847F70042191C /* gitversioning-after.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "gitversioning-after.sh"; sourceTree = "<group>"; };
+		F58B6DE9186847F70042191C /* gitversioning-before.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "gitversioning-before.sh"; sourceTree = "<group>"; };
 		F591380217C39128007B2BE4 /* LPOrientationOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPOrientationOperation.h; sourceTree = "<group>"; };
 		F591380317C39128007B2BE4 /* LPOrientationOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPOrientationOperation.m; sourceTree = "<group>"; };
 		F5AE0BC4174F58A5006E4050 /* LPScrollToRowWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToRowWithMarkOperation.h; sourceTree = "<group>"; };
@@ -367,6 +369,8 @@
 		B121E79A14B6D9FB0034C6A9 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				F58B6DE8186847F70042191C /* gitversioning-after.sh */,
+				F58B6DE9186847F70042191C /* gitversioning-before.sh */,
 				B121E79B14B6D9FB0034C6A9 /* calabash-Info.plist */,
 				B121E79C14B6D9FB0034C6A9 /* InfoPlist.strings */,
 				B121E79F14B6D9FB0034C6A9 /* calabash-Prefix.pch */,

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -45,6 +45,12 @@ static NSString *const kLPGitBranch = LP_GIT_BRANCH;
 static NSString *const kLPGitBranch = @"Unknown";
 #endif
 
+#ifdef LP_GIT_REMOTE_ORIGIN
+static NSString *const kLPGitRemoteOrigin = LP_GIT_REMOTE_ORIGIN;
+#else
+static NSString *const kLPGitRemoteOrigin = @"Unknown";
+#endif
+
 @interface LPVersionRoute ()
 
 - (BOOL) isIPhoneAppEmulatedOnIPad;
@@ -58,7 +64,6 @@ static NSString *const kLPGitBranch = @"Unknown";
     NSString *model = [[UIDevice currentDevice] model];
     return idiom == UIUserInterfaceIdiomPhone && [model hasPrefix:@"iPad"];
 }
-
 
 - (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path
 {
@@ -77,6 +82,7 @@ static NSString *const kLPGitBranch = @"Unknown";
         idString = @"Unknown";
     }
     NSString *nameString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+
     if (!nameString)
     {
         nameString = @"Unknown";
@@ -102,6 +108,9 @@ static NSString *const kLPGitBranch = @"Unknown";
     }
     
     BOOL isIphoneAppEmulated = [self isIPhoneAppEmulatedOnIPad];
+    NSDictionary *git = @{@"revision" : kLPGitShortRevision,
+                          @"branch" : kLPGitBranch,
+                          @"remote_origin" : kLPGitRemoteOrigin};
     
     NSDictionary* res = [NSDictionary dictionaryWithObjectsAndKeys:
                          kLPCALABASHVERSION , @"version",
@@ -115,8 +124,7 @@ static NSString *const kLPGitBranch = @"Unknown";
                          versionString,@"app_version",
                          @"SUCCESS",@"outcome",
                          [NSNumber numberWithBool:isIphoneAppEmulated], @"iphone_app_emulated_on_ipad",
-                         kLPGitShortRevision, @"git revision",
-                         kLPGitBranch, @"git branch",
+                         git, @"git",
                          nil];
     return res;
     

--- a/calabash/LPGitVersionDefines.h
+++ b/calabash/LPGitVersionDefines.h
@@ -4,8 +4,9 @@
 
  the contents are updated before compile time with the following defines:
 
- #define LP_GIT_SHORT_REVISION <rev>  // ex. @"4fdb203"
- #define LP_GIT_BRANCH <branch>       // ex. @"0.9.x"
+ #define LP_GIT_SHORT_REVISION <rev>    // ex. @"4fdb203"
+ #define LP_GIT_BRANCH <branch>         // ex. @"0.9.x"
+ #define LP_GIT_REMOTE_ORIGIN <origin>  // ex. @"git@github.com:jmoody/calabash-ios-server.git"
 
  after compilation, the contents are reset using: 
 
@@ -20,5 +21,6 @@
  4. gitversioning-after.sh
 
 ****************************************************************/
-#define LP_GIT_SHORT_REVISION @"7192800"
-#define LP_GIT_BRANCH @"0.9.x-add-git-versioning-information"
+#define LP_GIT_SHORT_REVISION @"6cc289a"
+#define LP_GIT_BRANCH @"0.9.x-include-git-remote-origin"
+#define LP_GIT_REMOTE_ORIGIN @"git@github.com:jmoody/calabash-ios-server.git"

--- a/calabash/gitversioning-before.sh
+++ b/calabash/gitversioning-before.sh
@@ -9,6 +9,7 @@ LP_INFO_PLIST="${1}"
 gitpath=`which git`
 GITREV=`$gitpath rev-parse --short HEAD`
 GITBRANCH=`git rev-parse --abbrev-ref HEAD`
+GITREMOTEORIGIN=`git config --get remote.origin.url`
 
 
 echo "/************************** README *****************************" > "${LP_INFO_PLIST}"
@@ -17,8 +18,9 @@ echo " DO NOT MANUALLY CHANGE THE CONTENTS OF THIS FILE" >> "${LP_INFO_PLIST}"
 echo "" >> "${LP_INFO_PLIST}"
 echo " the contents are updated before compile time with the following defines:" >> "${LP_INFO_PLIST}"
 echo "" >> "${LP_INFO_PLIST}"
-echo " #define LP_GIT_SHORT_REVISION <rev>  // ex. @\"4fdb203\"" >> "${LP_INFO_PLIST}"
-echo " #define LP_GIT_BRANCH <branch>       // ex. @\"0.9.x\"" >> "${LP_INFO_PLIST}"
+echo " #define LP_GIT_SHORT_REVISION <rev>    // ex. @\"4fdb203\"" >> "${LP_INFO_PLIST}"
+echo " #define LP_GIT_BRANCH <branch>         // ex. @\"0.9.x\"" >> "${LP_INFO_PLIST}"
+echo " #define LP_GIT_REMOTE_ORIGIN <origin>  // ex. @\"git@github.com:jmoody/calabash-ios-server.git\"" >> "${LP_INFO_PLIST}"
 echo "" >> "${LP_INFO_PLIST}"
 echo " after compilation, the contents are reset using: " >> "${LP_INFO_PLIST}"
 echo " git co -- calabash/LPGitVersionDefines.h >>" "${LP_INFO_PLIST}"
@@ -41,3 +43,5 @@ echo "INFO: setting the GIT_SHORT_REVISION = ${GITREV} in ${LP_INFO_PLIST}"
 echo "#define LP_GIT_SHORT_REVISION @\"${GITREV}\"" >> "${LP_INFO_PLIST}"
 echo "INFO: setting the GIT_BRANCH = ${GITBRANCH} in ${LP_INFO_PLIST}"
 echo "#define LP_GIT_BRANCH @\"${GITBRANCH}\"" >> "${LP_INFO_PLIST}"
+echo "INFO: setting the GIT_REMOTE_ORIGIN = ${GITREMOTEORIGIN} in ${LP_INFO_PLIST}"
+echo "#define LP_GIT_REMOTE_ORIGIN @\"${GITREMOTEORIGIN}\"" >> "${LP_INFO_PLIST}"


### PR DESCRIPTION
### motivation

https://github.com/calabash/calabash-ios/issues/243

when testing stand-alone a stand-alone ipa, it is important to know the provenance of the calabash server.  since this is an open sourced project, clients can build and install their own calabash.framework.  we do not want to be in a position where we are debugging a third party's server changes.

refactored the git related information into its own key and add remote origin information.

```
> server_version
{
                        "outcome" => "SUCCESS",
                         "app_id" => "com.lesspainful.example.LPSimpleExample-cal",
               "simulator_device" => "iPad",
                        "version" => "0.9.163.pre7",
                       "app_name" => "LPSimpleExample-cal",
    "iphone_app_emulated_on_ipad" => true,
                          "4inch" => false,
                            "git" => {
        "remote_origin" => "git@github.com:jmoody/calabash-ios-server.git",
               "branch" => "0.9.x-include-git-remote-origin",
             "revision" => "c68d723"
    },
                    "app_version" => "1.0",
                    "iOS_version" => "6.1",
                         "system" => "x86_64",
                      "simulator" => "iPhone Simulator 463.9.4.2, iPhone OS 6.1 (iPad Retina/10B141)"
}
```
