### PR TITLE
applies a uniform formatting across source files, removes tab characters, whitespaces, and removed unused imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ calabash.xcodeproj/xcuserdata/
 Markdown.pl
 build
 calabash.framework
+
+# AppCode
+.idea

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				B121E79614B6D9FB0034C6A9 /* Frameworks */,
 				B121E79514B6D9FB0034C6A9 /* Products */,
 			);
-			indentWidth = 4;
+			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
 		};
@@ -754,8 +754,9 @@
 		B121E78814B6D9FB0034C6A9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				CLASSPREFIX = LP;
 				LastUpgradeCheck = 0500;
-				ORGANIZATIONNAME = LessPainful;
+				ORGANIZATIONNAME = Xamarin;
 			};
 			buildConfigurationList = B121E78B14B6D9FB0034C6A9 /* Build configuration list for PBXProject "calabash" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/calabash/Classes/CalabashServer.h
+++ b/calabash/Classes/CalabashServer.h
@@ -1,12 +1,12 @@
 //  Created by Karl Krukow on 11/08/11.
 //  Copyright 2011 LessPainful. All rights reserved.
 
-
 #import "LPHTTPServer.h"
+
 @class LPHTTPServer;
 
 @interface CalabashServer : NSObject {
-	LPHTTPServer *_httpServer;
+  LPHTTPServer *_httpServer;
 }
 
 + (void) start;

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -6,7 +6,6 @@
 //
 
 #import "CalabashServer.h"
-#import "LPHTTPServer.h"
 #import "LPRouter.h"
 #import "LPScreenshotRoute.h"
 #import "LPScreenshotRoute2.h"
@@ -27,204 +26,201 @@
 #import "LPDebugRoute.h"
 #import <dlfcn.h>
 
-@interface CalabashServer()
+@interface CalabashServer ()
 - (void) start;
 @end
+
 @implementation CalabashServer
 
 
 + (void) start {
-    CalabashServer* server = [[CalabashServer alloc] init];
-    [server start];
-    
-    dlopen([@"/Developer/Library/PrivateFrameworks/UIAutomation.framework/UIAutomation" fileSystemRepresentation], RTLD_LOCAL);
-    
+  CalabashServer *server = [[CalabashServer alloc] init];
+  [server start];
+
+  dlopen([@"/Developer/Library/PrivateFrameworks/UIAutomation.framework/UIAutomation" fileSystemRepresentation], RTLD_LOCAL);
 }
 
-- (id) init
-{
-    self = [super init];
-    if (self != nil) {
-        
-        LPMapRoute* mr = [LPMapRoute new];
-        [LPRouter addRoute:mr forPath:@"map"];
-        [mr release];
-        LPScreenshotRoute *sr =[LPScreenshotRoute new];
-        [LPRouter addRoute:sr forPath:@"screenshot"];
-        [sr release];
-        
-        LPScreenshotRoute2 *sr2 =[LPScreenshotRoute2 new];
-        [LPRouter addRoute:sr2 forPath:@"screenshot2"];
-        [sr2 release];
-        
-        LPRecordRoute *rr =[LPRecordRoute new];
-        [LPRouter addRoute:rr forPath:@"record"];
-        [rr release];
-        
-        //        LPPlaybackRoute *pr =[LPPlaybackRoute new];
-        //        [LPRouter addRoute:pr forPath:@"/play"];
-        //        [pr release];
-        //
-        LPAsyncPlaybackRoute *apr =[LPAsyncPlaybackRoute new];
-        [LPRouter addRoute:apr forPath:@"play"];
-        [apr release];
-        
-        LPUserPrefRoute *bgr =[LPUserPrefRoute new];
-        [LPRouter addRoute:bgr forPath:@"userprefs"];
-        [bgr release];
-        
-        LPAppPropertyRoute *appr =[LPAppPropertyRoute new];
-        [LPRouter addRoute:appr forPath:@"appproperty"];
-        [appr release];
-        
-        LPQueryLogRoute *qlr =[LPQueryLogRoute new];
-        [LPRouter addRoute:qlr forPath:@"querylog"];
-        [qlr release];
-        
-        LPInterpolateRoute *panr =[LPInterpolateRoute new];
-        [LPRouter addRoute:panr forPath:@"interpolate"];
-        [panr release];
-        
-        LPBackdoorRoute* backdr = [LPBackdoorRoute new];
-        [LPRouter addRoute:backdr forPath:@"backdoor"];
-        [backdr release];
-        
-        LPExitRoute* exit_route = [LPExitRoute new];
-        [LPRouter addRoute:exit_route forPath:@"exit"];
-        [exit_route release];
-        
-        LPVersionRoute* verr = [LPVersionRoute new];
-        [LPRouter addRoute:verr forPath:@"version"];
-        [verr release];
-        
-        LPConditionRoute* cond = [LPConditionRoute new];
-        [LPRouter addRoute:cond forPath:@"condition"];
-        [cond release];
-        
-        LPKeyboardRoute* keyboard = [LPKeyboardRoute new];
-        [LPRouter addRoute:keyboard forPath:@"keyboard"];
-        [keyboard release];
-        
-        LPUIARoute* uia = [LPUIARoute new];
-        [LPRouter addRoute:uia forPath:@"uia"];
-        [uia release];
 
-        LPLocationRoute* location = [LPLocationRoute new];
-        [LPRouter addRoute:location forPath:@"location"];
-        [location release];
+- (id) init {
+  self = [super init];
+  if (self != nil) {
 
-        LPDebugRoute* debugRoute = [LPDebugRoute new];
-        [LPRouter addRoute:debugRoute forPath:@"debug"];
-        [debugRoute release];
+    LPMapRoute *mr = [LPMapRoute new];
+    [LPRouter addRoute:mr forPath:@"map"];
+    [mr release];
+    LPScreenshotRoute *sr = [LPScreenshotRoute new];
+    [LPRouter addRoute:sr forPath:@"screenshot"];
+    [sr release];
 
-        
-        
-        
-        //
-        //        LPScreencastRoute *scr = [LPScreencastRoute new];
-        //        [LPRouter addRoute:scr forPath:@"/screencast"];
-        //        [scr release];
-        //
-        
-        _httpServer = [[[LPHTTPServer alloc]init] retain];
-        
-        [_httpServer setName:@"Calabash Server"];
-        [_httpServer setType:@"_http._tcp."];
-        
-        // Advertise this device's capabilities to our listeners inside of the TXT record
-        NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
-        NSMutableDictionary *capabilities = [[NSMutableDictionary alloc]
-                                             initWithObjectsAndKeys:
-                                             [[UIDevice currentDevice] name], @"name",
-                                             [[UIDevice currentDevice] model], @"model",
-                                             [[UIDevice currentDevice] systemVersion], @"os_version",
-                                             [info objectForKey:@"CFBundleDisplayName"], @"app",
-                                             [info objectForKey:@"CFBundleIdentifier"], @"app_id",
-                                             [info objectForKey:@"CFBundleVersion"], @"app_version",
-                                             nil];
+    LPScreenshotRoute2 *sr2 = [LPScreenshotRoute2 new];
+    [LPRouter addRoute:sr2 forPath:@"screenshot2"];
+    [sr2 release];
+
+    LPRecordRoute *rr = [LPRecordRoute new];
+    [LPRouter addRoute:rr forPath:@"record"];
+    [rr release];
+
+    //        LPPlaybackRoute *pr =[LPPlaybackRoute new];
+    //        [LPRouter addRoute:pr forPath:@"/play"];
+    //        [pr release];
+    //
+    LPAsyncPlaybackRoute *apr = [LPAsyncPlaybackRoute new];
+    [LPRouter addRoute:apr forPath:@"play"];
+    [apr release];
+
+    LPUserPrefRoute *bgr = [LPUserPrefRoute new];
+    [LPRouter addRoute:bgr forPath:@"userprefs"];
+    [bgr release];
+
+    LPAppPropertyRoute *appr = [LPAppPropertyRoute new];
+    [LPRouter addRoute:appr forPath:@"appproperty"];
+    [appr release];
+
+    LPQueryLogRoute *qlr = [LPQueryLogRoute new];
+    [LPRouter addRoute:qlr forPath:@"querylog"];
+    [qlr release];
+
+    LPInterpolateRoute *panr = [LPInterpolateRoute new];
+    [LPRouter addRoute:panr forPath:@"interpolate"];
+    [panr release];
+
+    LPBackdoorRoute *backdr = [LPBackdoorRoute new];
+    [LPRouter addRoute:backdr forPath:@"backdoor"];
+    [backdr release];
+
+    LPExitRoute *exit_route = [LPExitRoute new];
+    [LPRouter addRoute:exit_route forPath:@"exit"];
+    [exit_route release];
+
+    LPVersionRoute *verr = [LPVersionRoute new];
+    [LPRouter addRoute:verr forPath:@"version"];
+    [verr release];
+
+    LPConditionRoute *cond = [LPConditionRoute new];
+    [LPRouter addRoute:cond forPath:@"condition"];
+    [cond release];
+
+    LPKeyboardRoute *keyboard = [LPKeyboardRoute new];
+    [LPRouter addRoute:keyboard forPath:@"keyboard"];
+    [keyboard release];
+
+    LPUIARoute *uia = [LPUIARoute new];
+    [LPRouter addRoute:uia forPath:@"uia"];
+    [uia release];
+
+    LPLocationRoute *location = [LPLocationRoute new];
+    [LPRouter addRoute:location forPath:@"location"];
+    [location release];
+
+    LPDebugRoute *debugRoute = [LPDebugRoute new];
+    [LPRouter addRoute:debugRoute forPath:@"debug"];
+    [debugRoute release];
+
+    //
+    //        LPScreencastRoute *scr = [LPScreencastRoute new];
+    //        [LPRouter addRoute:scr forPath:@"/screencast"];
+    //        [scr release];
+    //
+
+    _httpServer = [[[LPHTTPServer alloc] init] retain];
+
+    [_httpServer setName:@"Calabash Server"];
+    [_httpServer setType:@"_http._tcp."];
+
+    // Advertise this device's capabilities to our listeners inside of the TXT record
+    NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+    NSMutableDictionary *capabilities = [[NSMutableDictionary alloc]
+            initWithObjectsAndKeys:[[UIDevice currentDevice] name], @"name",
+                                   [[UIDevice currentDevice] model], @"model",
+                                   [[UIDevice currentDevice]
+                                           systemVersion], @"os_version",
+                                   [info objectForKey:@"CFBundleDisplayName"], @"app",
+                                   [info objectForKey:@"CFBundleIdentifier"], @"app_id",
+                                   [info objectForKey:@"CFBundleVersion"], @"app_version",
+                                   nil];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-        if ([[UIDevice currentDevice] respondsToSelector:@selector(uniqueIdentifier)]) {
-            id uuid = [[UIDevice currentDevice] performSelector:@selector(uniqueIdentifier) withObject:nil];
-            [capabilities setObject: uuid forKey:@"uuid"];
-        }
-#pragma clang diagnostic pop
-        [_httpServer setTXTRecordDictionary:capabilities];
-        [_httpServer setConnectionClass:[LPRouter class]];
-        [_httpServer setPort:37265];
-        [capabilities release];
-        // Serve files from our embedded Web folder
-        //        NSString *webPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Web"];
-        //        [_httpServer setDocumentRoot:webPath];
-        NSLog( @"Creating the server: %@", _httpServer );
-        NSLog( @"Calabash iOS server version: %@", kLPCALABASHVERSION );
+    if ([[UIDevice currentDevice]
+            respondsToSelector:@selector(uniqueIdentifier)]) {
+      id uuid = [[UIDevice currentDevice]
+              performSelector:@selector(uniqueIdentifier) withObject:nil];
+      [capabilities setObject:uuid forKey:@"uuid"];
     }
-    return self;
+#pragma clang diagnostic pop
+    [_httpServer setTXTRecordDictionary:capabilities];
+    [_httpServer setConnectionClass:[LPRouter class]];
+    [_httpServer setPort:37265];
+    [capabilities release];
+    // Serve files from our embedded Web folder
+    //        NSString *webPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Web"];
+    //        [_httpServer setDocumentRoot:webPath];
+    NSLog(@"Creating the server: %@", _httpServer);
+    NSLog(@"Calabash iOS server version: %@", kLPCALABASHVERSION);
+  }
+  return self;
 }
+
 
 - (void) start {
-    
-    [self enableAccessibility];
 
-    NSError *error=nil;
-    if( ![_httpServer start:&error] ) {
-        NSLog(@"Error starting LPHTTP Server: %@",error);// %@", error);
-    }
+  [self enableAccessibility];
+
+  NSError *error = nil;
+  if (![_httpServer start:&error]) {
+    NSLog(@"Error starting LPHTTP Server: %@", error);// %@", error);
+  }
 }
 
-- (void) enableAccessibility
-{
-    // Approach described at:
-    // http://sgleadow.github.com/blog/2011/11/16/enabling-accessibility-programatically-on-ios-devices/
-    NSAutoreleasePool *autoreleasePool = [[NSAutoreleasePool alloc] init];
-    
-    
-    NSString *appSupportPath = @"/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport";
-    
-    // If we're on the simulator, make sure we're using the sim's copy of AppSupport
-    NSDictionary *environment = [[NSProcessInfo processInfo] environment];
-    NSString *simulatorRoot = [environment objectForKey:@"IPHONE_SIMULATOR_ROOT"];
-    NSLog(@"simroot: %@",simulatorRoot);
-    if (simulatorRoot) {
-        appSupportPath = [simulatorRoot stringByAppendingString:appSupportPath];
-    }
-    
-    void *appSupport = dlopen([appSupportPath fileSystemRepresentation], RTLD_LAZY);
-    if (!appSupport) {
-        NSLog(@"ERROR: Unable to dlopen AppSupport. Cannot automatically enable accessibility.");
-        return;
-    }
-    
-    CFStringRef (*copySharedResourcesPreferencesDomainForDomain)(CFStringRef domain) = dlsym(appSupport, "CPCopySharedResourcesPreferencesDomainForDomain");
-    if (!copySharedResourcesPreferencesDomainForDomain) {
-        NSLog(@"ERROR: Unable to dlsym CPCopySharedResourcesPreferencesDomainForDomain. "
-              "Cannot automatically enable accessibility.");
-        return;
-    }
-    
-    CFStringRef accessibilityDomain
-    = copySharedResourcesPreferencesDomainForDomain(CFSTR("com.apple.Accessibility"));
-    if (!accessibilityDomain) {
-        NSLog(@"ERROR: Unable to cop accessibility preferences. Cannot automatically enable accessibility.");
-        return;
-    }
-    
-    CFPreferencesSetValue(CFSTR("ApplicationAccessibilityEnabled"),
-                          kCFBooleanTrue,
-                          accessibilityDomain,
-                          kCFPreferencesAnyUser,
-                          kCFPreferencesAnyHost);
-    CFRelease(accessibilityDomain);
-    
-    [autoreleasePool drain];
-    
+
+- (void) enableAccessibility {
+  // Approach described at:
+  // http://sgleadow.github.com/blog/2011/11/16/enabling-accessibility-programatically-on-ios-devices/
+  NSAutoreleasePool *autoreleasePool = [[NSAutoreleasePool alloc] init];
+
+  NSString *appSupportPath = @"/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport";
+
+  // If we're on the simulator, make sure we're using the sim's copy of AppSupport
+  NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+  NSString *simulatorRoot = [environment objectForKey:@"IPHONE_SIMULATOR_ROOT"];
+  NSLog(@"simroot: %@", simulatorRoot);
+  if (simulatorRoot) {
+    appSupportPath = [simulatorRoot stringByAppendingString:appSupportPath];
+  }
+
+  void *appSupport = dlopen(
+          [appSupportPath fileSystemRepresentation], RTLD_LAZY);
+  if (!appSupport) {
+    NSLog(@"ERROR: Unable to dlopen AppSupport. Cannot automatically enable accessibility.");
+    return;
+  }
+
+  CFStringRef (*copySharedResourcesPreferencesDomainForDomain)(
+          CFStringRef domain) = dlsym(appSupport,
+          "CPCopySharedResourcesPreferencesDomainForDomain");
+  if (!copySharedResourcesPreferencesDomainForDomain) {
+    NSLog(@"ERROR: Unable to dlsym CPCopySharedResourcesPreferencesDomainForDomain. "
+            "Cannot automatically enable accessibility.");
+    return;
+  }
+
+  CFStringRef accessibilityDomain = copySharedResourcesPreferencesDomainForDomain(CFSTR("com.apple.Accessibility"));
+  if (!accessibilityDomain) {
+    NSLog(@"ERROR: Unable to cop accessibility preferences. Cannot automatically enable accessibility.");
+    return;
+  }
+
+  CFPreferencesSetValue(CFSTR("ApplicationAccessibilityEnabled"),
+          kCFBooleanTrue, accessibilityDomain, kCFPreferencesAnyUser,
+          kCFPreferencesAnyHost);
+  CFRelease(accessibilityDomain);
+
+  [autoreleasePool drain];
 }
 
-- (void) dealloc
-{
-    
-    [_httpServer release];
-    [super dealloc];
+
+- (void) dealloc {
+  [_httpServer release];
+  [super dealloc];
 }
 
 

--- a/calabash/Classes/FranklyServer/LPI.mm
+++ b/calabash/Classes/FranklyServer/LPI.mm
@@ -8,13 +8,15 @@
 
 #import "CalabashServer.h"
 
+
 int ___calabashserverinit();
 
 int ___lesspainfulserver = ___calabashserverinit();
 
+
 int ___calabashserverinit() {
-    NSAutoreleasePool *ap = [[NSAutoreleasePool alloc] init];
-    [CalabashServer start];
-    [ap release];
-    return 42;
+  NSAutoreleasePool *ap = [[NSAutoreleasePool alloc] init];
+  [CalabashServer start];
+  [ap release];
+  return 42;
 }

--- a/calabash/Classes/FranklyServer/LPRecorder.h
+++ b/calabash/Classes/FranklyServer/LPRecorder.h
@@ -1,19 +1,27 @@
 #import <Foundation/Foundation.h>
 
 @interface LPRecorder : NSObject {
-	NSMutableArray* eventList;
-	id playbackDelegate;
-	SEL playbackDoneSelector;
-    BOOL _isRecording;
+  NSMutableArray *eventList;
+  id playbackDelegate;
+  SEL playbackDoneSelector;
+  BOOL _isRecording;
 }
-@property (nonatomic, readonly) BOOL isRecording;
-+(LPRecorder *)sharedRecorder;
--(void)record;
--(void)saveToFile:(NSString*)path;
--(NSArray*)events;
--(void)load:(NSArray*)events;
--(void)loadFromFile:(NSString*)path;
--(void)playbackWithDelegate:(id)delegate doneSelector:(SEL)selector;
--(void)stop;
+@property(nonatomic, readonly) BOOL isRecording;
+
++ (LPRecorder *) sharedRecorder;
+
+- (void) record;
+
+- (void) saveToFile:(NSString *) path;
+
+- (NSArray *) events;
+
+- (void) load:(NSArray *) events;
+
+- (void) loadFromFile:(NSString *) path;
+
+- (void) playbackWithDelegate:(id) delegate doneSelector:(SEL) selector;
+
+- (void) stop;
 
 @end

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -1,94 +1,106 @@
-#import <UIKit/UIKit.h>
-
 #import "LPRecorder.h"
 
 
 @interface UIApplication (Recording)
 
--(void)_addRecorder:(id)recorder;
--(void)_removeRecorder:(id)recorder;
--(void)_playbackEvents:(NSArray*)events atPlaybackRate:(float)playbackRate messageWhenDone:(id)target withSelector:(SEL)selector;
+- (void) _addRecorder:(id) recorder;
+
+- (void) _removeRecorder:(id) recorder;
+
+- (void) _playbackEvents:(NSArray *) events atPlaybackRate:(float) playbackRate messageWhenDone:(id) target withSelector:(SEL) selector;
 
 @end
 
 static LPRecorder *sharedRecorder = nil;
 
 @implementation LPRecorder
-@synthesize isRecording=_isRecording;
-+(LPRecorder *)sharedRecorder {
-	if (sharedRecorder == nil) {
-		sharedRecorder = [[super allocWithZone:NULL] init];
-	}
-	return sharedRecorder;
+@synthesize isRecording = _isRecording;
+
+
++ (LPRecorder *) sharedRecorder {
+  if (sharedRecorder == nil) {
+    sharedRecorder = [[super allocWithZone:NULL] init];
+  }
+  return sharedRecorder;
 }
 
--(id)init {
-	self = [super init];
 
-	eventList = [[NSMutableArray alloc] init];
+- (id) init {
+  self = [super init];
 
-	return self;
+  eventList = [[NSMutableArray alloc] init];
+
+  return self;
 }
 
--(void)dealloc {
-	[eventList release];
-	[super dealloc];
+
+// todo dealloc does not playbackDelegate but it retains it
+- (void) dealloc {
+  [eventList release];
+  [super dealloc];
 }
 
--(void)record {
-	[eventList removeAllObjects];
 
-	NSLog(@"Starting recording");
-    _isRecording = YES;
-	[[UIApplication sharedApplication] _addRecorder: self];
-}
--(NSArray*)events {
-    return eventList;
-}
--(void)saveToFile:(NSString*)path {
-	NSLog(@"Saving events to file: %@", path);
-    
-	if ([eventList writeToFile: path atomically: YES]) {
-        NSLog(@"succeeded");
-    }
+- (void) record {
+  [eventList removeAllObjects];
+
+  NSLog(@"Starting recording");
+  _isRecording = YES;
+  [[UIApplication sharedApplication] _addRecorder:self];
 }
 
--(void)stop {
-	NSLog(@"Stopping recording");
-    _isRecording = NO;
-	[[UIApplication sharedApplication] _removeRecorder: self];
+
+- (NSArray *) events {
+  return eventList;
 }
 
--(void)recordApplicationEvent:(NSDictionary*)event {
-	NSLog(@"Recorded event: %@", event);
 
-	[eventList addObject:event];
+- (void) saveToFile:(NSString *) path {
+  NSLog(@"Saving events to file: %@", path);
+
+  if ([eventList writeToFile:path atomically:YES]) {
+    NSLog(@"succeeded");
+  }
 }
 
--(void)load:(NSArray*)events {
 
-	[eventList setArray: events];
+- (void) stop {
+  NSLog(@"Stopping recording");
+  _isRecording = NO;
+  [[UIApplication sharedApplication] _removeRecorder:self];
 }
 
--(void)loadFromFile:(NSString*)path {
 
-	[eventList setArray: [NSMutableArray arrayWithContentsOfFile: path]];
+- (void) recordApplicationEvent:(NSDictionary *) event {
+  NSLog(@"Recorded event: %@", event);
+  [eventList addObject:event];
 }
 
--(void)playbackWithDelegate: (id)delegate doneSelector:(SEL)doneSelector {
 
-	playbackDelegate = [delegate retain];
-    
-	playbackDoneSelector = doneSelector;
-
-	[[UIApplication sharedApplication] _playbackEvents: eventList atPlaybackRate: 1.0f messageWhenDone: self withSelector: @selector(playbackDone:)];
+- (void) load:(NSArray *) events {
+  [eventList setArray:events];
 }
 
--(void)playbackDone:(NSDictionary *)details {
 
-	[playbackDelegate performSelector: playbackDoneSelector];
-    [playbackDelegate release];
-    playbackDelegate=nil;
+- (void) loadFromFile:(NSString *) path {
+  [eventList setArray:[NSMutableArray arrayWithContentsOfFile:path]];
+}
+
+
+- (void) playbackWithDelegate:(id) delegate doneSelector:(SEL) doneSelector {
+  playbackDelegate = [delegate retain];
+  playbackDoneSelector = doneSelector;
+
+  [[UIApplication sharedApplication]
+          _playbackEvents:eventList atPlaybackRate:1.0f messageWhenDone:self
+             withSelector:@selector(playbackDone:)];
+}
+
+
+- (void) playbackDone:(NSDictionary *) details {
+  [playbackDelegate performSelector:playbackDoneSelector];
+  [playbackDelegate release];
+  playbackDelegate = nil;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/LPRoute.h
+++ b/calabash/Classes/FranklyServer/LPRoute.h
@@ -6,13 +6,18 @@
 //
 
 #import <Foundation/Foundation.h>
+
 @class LPHTTPConnection;
+
 @protocol LPRoute <NSObject>
 
 @optional
-- (void) setParameters:(NSDictionary*) parameters;
-- (void) setConnection:(LPHTTPConnection*) connection;
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path;
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data;
+- (void) setParameters:(NSDictionary *) parameters;
+
+- (void) setConnection:(LPHTTPConnection *) connection;
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path;
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data;
 
 @end

--- a/calabash/Classes/FranklyServer/LPRouter.h
+++ b/calabash/Classes/FranklyServer/LPRouter.h
@@ -5,10 +5,12 @@
 
 #import "LPHTTPConnection.h"
 #import "LPRoute.h"
-@interface LPRouter : LPHTTPConnection {
-    NSMutableData *_postData;
-}
-@property (nonatomic, retain, readonly) NSData *postData;
 
-+ (void) addRoute:(id<LPRoute>) route forPath:(NSString*) path;
+@interface LPRouter : LPHTTPConnection {
+  NSMutableData *_postData;
+}
+@property(nonatomic, retain, readonly) NSData *postData;
+
++ (void) addRoute:(id <LPRoute>) route forPath:(NSString *) path;
+
 @end

--- a/calabash/Classes/FranklyServer/LPRouter.m
+++ b/calabash/Classes/FranklyServer/LPRouter.m
@@ -9,104 +9,109 @@
 #import "LPHTTPDataResponse.h"
 
 @implementation LPRouter
-@synthesize postData=_postData;
+@synthesize postData = _postData;
 
-static NSMutableDictionary* routes = nil;
+static NSMutableDictionary *routes = nil;
 
-+ (void)initialize
-{
-	static BOOL initialized = NO;
-	if(!initialized)
-	{
-		// Initialize class variables
-		routes = [[NSMutableDictionary alloc] initWithCapacity:16];
-		initialized = YES;
-	}
+
++ (void) initialize {
+  static BOOL initialized = NO;
+  if (!initialized) {
+    // Initialize class variables
+    routes = [[NSMutableDictionary alloc] initWithCapacity:16];
+    initialized = YES;
+  }
 }
 
-+ (void) addRoute:(id<LPRoute>) route forPath:(NSString*) path {
-    [routes setObject:route forKey:path];
+
++ (void) addRoute:(id <LPRoute>) route forPath:(NSString *) path {
+  [routes setObject:route forKey:path];
 }
 
-- (void)processBodyData:(NSData *)postDataChunk {
-    if (_postData == nil) {
-        _postData = [[NSMutableData alloc] initWithData:postDataChunk];
-    } else {
-        [_postData appendData:postDataChunk];
-    }
-	
+
+- (void) processBodyData:(NSData *) postDataChunk {
+  if (_postData == nil) {
+    _postData = [[NSMutableData alloc] initWithData:postDataChunk];
+  } else {
+    [_postData appendData:postDataChunk];
+  }
 }
+
 
 - (void) dealloc {
-    [_postData release];_postData=nil;
-    [super dealloc];
+  [_postData release];
+  _postData = nil;
+  [super dealloc];
 }
 
-- (NSObject<LPHTTPResponse> *) responseForJSON:(NSDictionary*) json {
-    if (json == nil) {
-        json=[NSDictionary dictionaryWithObjectsAndKeys:
-              [NSArray array], @"results",
-              @"SUCCESS",@"outcome",nil];
+
+- (NSObject <LPHTTPResponse> *) responseForJSON:(NSDictionary *) json {
+  if (json == nil) {
+    json = [NSDictionary dictionaryWithObjectsAndKeys:[NSArray array], @"results",
+                                                      @"SUCCESS", @"outcome",
+                                                      nil];
+  }
+  NSString *serialized = [LPJSONUtils serializeDictionary:json];
+  NSData *data = [serialized dataUsingEncoding:NSUTF8StringEncoding];
+  LPHTTPDataResponse *rsp = [[LPHTTPDataResponse alloc] initWithData:data];
+  return [rsp autorelease];
+}
+
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  NSArray *components = [path componentsSeparatedByString:@"?"];
+  NSArray *pathComponents = [[components objectAtIndex:0]
+          componentsSeparatedByString:@"/"];
+  NSString *lastSegment = [pathComponents lastObject];
+
+  id <LPRoute> route = [routes objectForKey:lastSegment];
+  BOOL supported = [route supportsMethod:method atPath:lastSegment];
+
+  return supported;
+}
+
+
+- (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
+  NSArray *components = [path componentsSeparatedByString:@"?"];
+  NSArray *pathComponents = [[components objectAtIndex:0]
+          componentsSeparatedByString:@"/"];
+  NSString *lastSegment = [pathComponents lastObject];
+
+  id <LPRoute> route = [routes objectForKey:lastSegment];
+
+  if ([route supportsMethod:method atPath:path]) {
+    NSDictionary *params = nil;
+    if ([method isEqualToString:@"GET"]) {
+      params = [super parseGetParams];
     }
-    NSString* serialized = [LPJSONUtils serializeDictionary:json];
-    NSData *data = [serialized dataUsingEncoding:NSUTF8StringEncoding];
-    LPHTTPDataResponse *rsp = [[LPHTTPDataResponse alloc] initWithData:data];
-    return [rsp autorelease];
-}
-
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path
-{
-    NSArray *components = [path componentsSeparatedByString:@"?"];
-    NSArray *pathComponents = [[components objectAtIndex:0] componentsSeparatedByString:@"/"];
-    NSString *lastSegment = [pathComponents lastObject];
-    
-
-    id<LPRoute> route = [routes objectForKey:lastSegment];
-    BOOL supported = [route supportsMethod:method atPath:lastSegment];
-    
-    return supported;
-}
-
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path {
-    NSArray *components = [path componentsSeparatedByString:@"?"];
-    NSArray *pathComponents = [[components objectAtIndex:0] componentsSeparatedByString:@"/"];
-    NSString *lastSegment = [pathComponents lastObject];
-    
-    
-    id<LPRoute> route = [routes objectForKey:lastSegment];
-
-    if ([route supportsMethod:method atPath:path]) {
-        NSDictionary* params = nil;
-        if ([method isEqualToString:@"GET"]) {
-            params=[super parseGetParams];
-        }
-        if ([method isEqualToString:@"POST"]) {
-            if (_postData != nil && [_postData length]>0) {
-                NSString* postDataAsString = [[NSString alloc] initWithBytes:[_postData bytes] length:[_postData length] encoding:NSUTF8StringEncoding];
-                params=[LPJSONUtils deserializeDictionary:postDataAsString];
-                [postDataAsString release];
-                [_postData release];
-                _postData = nil;
-            } 
-        }
-        if ([route respondsToSelector:@selector(setConnection:)]) {
-            [route setConnection:self];
-        }
-        if ([route respondsToSelector:@selector(setParameters:)]) {
-            [route setParameters:params];
-        }
-        
-        SEL raw = @selector(httpResponseForMethod:URI:);
-        if ([route respondsToSelector:raw]) {
-            return [route performSelector:raw withObject:method withObject:path];
-        }
-        
-        NSDictionary* json = [route JSONResponseForMethod:method URI:path data:params];
-        return [self responseForJSON:json];
+    if ([method isEqualToString:@"POST"]) {
+      if (_postData != nil && [_postData length] > 0) {
+        NSString *postDataAsString = [[NSString alloc]
+                initWithBytes:[_postData bytes] length:[_postData length]
+                     encoding:NSUTF8StringEncoding];
+        params = [LPJSONUtils deserializeDictionary:postDataAsString];
+        [postDataAsString release];
+        [_postData release];
+        _postData = nil;
+      }
     }
-    return nil;
-    
+    if ([route respondsToSelector:@selector(setConnection:)]) {
+      [route setConnection:self];
+    }
+    if ([route respondsToSelector:@selector(setParameters:)]) {
+      [route setParameters:params];
+    }
 
+    SEL raw = @selector(httpResponseForMethod:URI:);
+    if ([route respondsToSelector:raw]) {
+      return [route performSelector:raw withObject:method withObject:path];
+    }
+
+    NSDictionary *json = [route JSONResponseForMethod:method URI:path
+                                                 data:params];
+    return [self responseForJSON:json];
+  }
+  return nil;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
@@ -4,84 +4,78 @@
 @implementation LPCollectionViewScrollToItemOperation
 
 - (NSString *) description {
-	return [NSString stringWithFormat:@"CollectionViewScrollToRow: %@",_arguments];
+  return [NSString stringWithFormat:@"CollectionViewScrollToRow: %@",
+                                    _arguments];
 }
 
 
 //                 <===               required                ===>
 // _arguments ==> [item_num, section_num, scroll postion, animated]
-- (id) performWithTarget:(UIView*) aView error:(NSError **) aError {
-    
-    // UICollectionView appears in iOS 6
-    Class clz = NSClassFromString(@"UICollectionView");
-    if (clz == nil) {
-        NSLog(@"Warning UICollectionView is not supported on this version of iOS:  '%@'",
-              [[UIDevice currentDevice] systemVersion]);
-        return nil;
-    }
-    
-    
-    if ([aView isKindOfClass:[UICollectionView class]] == NO) {
-        NSLog(@"Warning view: %@ should be an instance of UICollectionView but found '%@'",
-              aView, aView == nil ? nil : [aView class]);
-        return nil;
-    }
-    
-    UICollectionView *collection = (UICollectionView *) aView;
-    
-    if ([_arguments count] != 4) {
-        NSLog(@"Warning:  required 4 args but found only '%d' - %@",
-              [_arguments count], _arguments);
-        return nil;
-    }
-    
-    NSInteger itemIndex = [[_arguments objectAtIndex:0] integerValue];
-    NSInteger section = [[_arguments objectAtIndex:1] integerValue];
-    
-    NSInteger numSections = [collection numberOfSections];
-    if (section >= numSections) {
-        NSLog(@"Warning:  requested to scroll to section '%d' but view only has '%d' sections",
-              section, numSections);
-        return nil;
-    }
-    
-    NSInteger numItemInSection = [collection numberOfItemsInSection:section];
-    if (itemIndex >= numItemInSection) {
-        NSLog(@"Warning:  requested to scroll to item '%d' in section '%d' but that section on has '%d' items",
-              itemIndex, section, numItemInSection);
-        return nil;
-    }
+- (id) performWithTarget:(UIView *) aView error:(NSError **) aError {
 
-    // avoid a nasty if/else if conditional
-    NSDictionary *opts = @{@"top" : @(UICollectionViewScrollPositionTop),
-                           @"center_vertical" : @(UICollectionViewScrollPositionCenteredVertically),
-                           @"bottom" : @(UICollectionViewScrollPositionBottom),
-                           @"left" : @(UICollectionViewScrollPositionLeft),
-                           @"center_horizontal" : @(UICollectionViewScrollPositionCenteredHorizontally),
-                           @"right" : @(UICollectionViewScrollPositionRight)};
+  // UICollectionView appears in iOS 6
+  Class clz = NSClassFromString(@"UICollectionView");
+  if (clz == nil) {
+    NSLog(@"Warning UICollectionView is not supported on this version of iOS:  '%@'",
+            [[UIDevice currentDevice] systemVersion]);
+    return nil;
+  }
 
-    NSString *position = [_arguments objectAtIndex:2];
-    
-    NSNumber *posNum = [opts objectForKey:position];
-    if (posNum == nil) {
-        NSLog(@"Warning:  requesting to scroll to position '%@' but that is not one of these valid positions: '%@'",
-              position, [opts allKeys]);
-        return nil;
-    }
-    
-    
-    UICollectionViewScrollPosition scrollPosition = [posNum unsignedIntegerValue];
-    
-    NSNumber *animateNum = [_arguments objectAtIndex:3];
-    BOOL animate = [animateNum boolValue];
-    
-    NSIndexPath *ip = [NSIndexPath indexPathForItem:itemIndex inSection:section];
-    
-    [collection scrollToItemAtIndexPath:ip
-                       atScrollPosition:scrollPosition
-                               animated:animate];
-    
-    return collection;
+  if ([aView isKindOfClass:[UICollectionView class]] == NO) {
+    NSLog(@"Warning view: %@ should be an instance of UICollectionView but found '%@'",
+            aView, aView == nil ? nil : [aView class]);
+    return nil;
+  }
+
+  UICollectionView *collection = (UICollectionView *) aView;
+
+  if ([_arguments count] != 4) {
+    NSLog(@"Warning:  required 4 args but found only '%d' - %@",
+            [_arguments count], _arguments);
+    return nil;
+  }
+
+  NSInteger itemIndex = [[_arguments objectAtIndex:0] integerValue];
+  NSInteger section = [[_arguments objectAtIndex:1] integerValue];
+
+  NSInteger numSections = [collection numberOfSections];
+  if (section >= numSections) {
+    NSLog(@"Warning:  requested to scroll to section '%d' but view only has '%d' sections",
+            section, numSections);
+    return nil;
+  }
+
+  NSInteger numItemInSection = [collection numberOfItemsInSection:section];
+  if (itemIndex >= numItemInSection) {
+    NSLog(@"Warning:  requested to scroll to item '%d' in section '%d' but that section on has '%d' items",
+            itemIndex, section, numItemInSection);
+    return nil;
+  }
+
+  // avoid a nasty if/else if conditional
+  NSDictionary *opts = @{@"top" : @(UICollectionViewScrollPositionTop), @"center_vertical" : @(UICollectionViewScrollPositionCenteredVertically), @"bottom" : @(UICollectionViewScrollPositionBottom), @"left" : @(UICollectionViewScrollPositionLeft), @"center_horizontal" : @(UICollectionViewScrollPositionCenteredHorizontally), @"right" : @(UICollectionViewScrollPositionRight)};
+
+  NSString *position = [_arguments objectAtIndex:2];
+
+  NSNumber *posNum = [opts objectForKey:position];
+  if (posNum == nil) {
+    NSLog(@"Warning:  requesting to scroll to position '%@' but that is not one of these valid positions: '%@'",
+            position, [opts allKeys]);
+    return nil;
+  }
+
+
+  UICollectionViewScrollPosition scrollPosition = [posNum unsignedIntegerValue];
+
+  NSNumber *animateNum = [_arguments objectAtIndex:3];
+  BOOL animate = [animateNum boolValue];
+
+  NSIndexPath *ip = [NSIndexPath indexPathForItem:itemIndex inSection:section];
+
+  [collection scrollToItemAtIndexPath:ip atScrollPosition:scrollPosition
+                             animated:animate];
+
+  return collection;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -9,12 +9,10 @@
 #import "LPDatePickerOperation.h"
 
 
-
-
 @implementation LPDatePickerOperation
 
 - (NSString *) description {
-	return [NSString stringWithFormat:@"DatePicker: %@",_arguments];
+  return [NSString stringWithFormat:@"DatePicker: %@", _arguments];
 }
 
 /*
@@ -26,20 +24,20 @@
 
 //                        required =========> |     optional
 // _arguments ==> [target date str, format str, notify targets, animated]
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
   if ([_view isKindOfClass:[UIDatePicker class]] == NO) {
-    NSLog(@"Warning view: %@ should be a date picker",_view);
+    NSLog(@"Warning view: %@ should be a date picker", _view);
     return nil;
   }
-  
+
   UIDatePicker *picker = (UIDatePicker *) _view;
-  
+
   NSString *dateStr = _arguments[0];
   if (dateStr == nil || [dateStr length] == 0) {
     NSLog(@"Warning: date str: '%@' should be non-nil and non-empty", dateStr);
     return nil;
   }
-  
+
   NSUInteger argcount = [_arguments count];
 
   NSString *dateFormat = nil;
@@ -49,46 +47,50 @@
     NSLog(@"Warning: date format is required as the second argument");
     return nil;
   }
-  
-  
+
+
   BOOL notifyTargets = YES;
   if (argcount > 2) {
     notifyTargets = [_arguments[2] boolValue];
   }
-  
+
   BOOL animate = YES;
   if (argcount > 3) {
     animate = [_arguments[3] boolValue];
   }
-  
+
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
   [formatter setDateFormat:dateFormat];
   NSDate *date = [formatter dateFromString:dateStr];
   if (date == nil) {
-    NSLog(@"Warning: could not create date from '%@' and format '%@'", dateStr, dateFormat);
+    NSLog(@"Warning: could not create date from '%@' and format '%@'", dateStr,
+            dateFormat);
     return nil;
   }
-  
+
   NSDate *minDate = picker.minimumDate;
   if (minDate != nil && [date compare:minDate] == NSOrderedAscending) {
     NSLog(@"Warning: could not set the date to '%@' because is earlier than the minimum date '%@'",
-          date, [minDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+            date,
+            [minDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
     return nil;
   }
-  
+
   NSDate *maxDate = picker.maximumDate;
   if (maxDate != nil && [date compare:maxDate] == NSOrderedDescending) {
     NSLog(@"Warning: could not set the date to '%@' because is later than the maximum date '%@'",
-          date, [maxDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
+            date,
+            [maxDate descriptionWithLocale:[NSLocale autoupdatingCurrentLocale]]);
     return nil;
   }
-  
+
   [picker setDate:date animated:animate];
 
   if (notifyTargets) {
     NSSet *targets = [picker allTargets];
     for (id target in targets) {
-      NSArray *actions = [picker actionsForTarget:target forControlEvent:UIControlEventValueChanged];
+      NSArray *actions = [picker actionsForTarget:target
+                                  forControlEvent:UIControlEventValueChanged];
       for (NSString *action in actions) {
         SEL sel = NSSelectorFromString(action);
 #pragma clang diagnostic push

--- a/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
@@ -7,23 +7,19 @@
 #import "LPOperation.h"
 #import "LPFlashOperation.h"
 
-#import "LPFlashOperation.h"
-#import "LPJSONUtils.h"
 #import "LPTouchUtils.h"
 
 
 @implementation LPFlashOperation
 - (NSString *) description {
-	return [NSString stringWithFormat:@"Flash: %@",_arguments];
+  return [NSString stringWithFormat:@"Flash: %@", _arguments];
 }
 
 
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
-    [LPTouchUtils flashView:_view forDuration:2];
-    
-    return _view;
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+  [LPTouchUtils flashView:_view forDuration:2];
+  return _view;
 }
 
-            
-                 
+
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.h
@@ -8,15 +8,16 @@
 #import "UIScriptParser.h"
 
 @interface LPOperation : NSObject {
-    SEL _selector;
-	NSArray *_arguments;
-    BOOL _done;
+  SEL _selector;
+  NSArray *_arguments;
+  BOOL _done;
 }
-+ (id) operationFromDictionary:(NSDictionary*) dictionary;
++ (id) operationFromDictionary:(NSDictionary *) dictionary;
 
-+(NSArray*)performQuery:(id)query;
++ (NSArray *) performQuery:(id) query;
 
-- (id) initWithOperation:(NSDictionary *)operation;
+- (id) initWithOperation:(NSDictionary *) operation;
 
-- (id) performWithTarget:(UIView*) view error:(NSError **)error;
+- (id) performWithTarget:(UIView *) view error:(NSError **) error;
+
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -11,8 +11,6 @@
 #import "LPQueryOperation.h"
 #import "LPFlashOperation.h"
 #import "LPSetTextOperation.h"
-#import "LPQueryAllOperation.h"
-#import "LPRecorder.h"
 #import "LPDatePickerOperation.h"
 #import "LPOrientationOperation.h"
 #import "LPTouchUtils.h"
@@ -21,166 +19,144 @@
 
 @implementation LPOperation
 
-+ (id) operationFromDictionary:(NSDictionary*) dictionary {
-    NSString *opName = [dictionary valueForKey:@"method_name"];
-    LPOperation* op = nil;
-    if ([opName isEqualToString:@"scrollToRow"])
-    {
-        op = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
-      
-    } else if ([opName isEqualToString:@"scrollToRowWithMark"])
-    {
-        op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
-    
-    }  else if ([opName isEqualToString:@"scroll"])
-    {
-        op = [[LPScrollOperation alloc] initWithOperation:dictionary];
-    
-    } else if ([opName isEqualToString:@"query"])
-    {
-        op = [[LPQueryOperation alloc] initWithOperation:dictionary];
-    
-    } else if ([opName isEqualToString:@"query_all"])
-    {
-        op = [[LPQueryAllOperation alloc] initWithOperation:dictionary];
-    
-    } else if ([opName isEqualToString:@"setText"])
-    {
-        op = [[LPSetTextOperation alloc] initWithOperation:dictionary];
-    }
-    else if ([opName isEqualToString:@"flash"])
-    {
-        op = [[LPFlashOperation alloc] initWithOperation:dictionary];
-    }
-    else if ([opName isEqualToString:@"orientation"])
-    {
-        op = [[LPOrientationOperation alloc] initWithOperation:dictionary];
-    }
-    else if ([opName isEqualToString:@"changeDatePickerDate"])
-    {
-        op = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
-    }
-    else if ([opName isEqualToString:@"changeSlider"])
-    {
-        op = [[LPSliderOperation alloc] initWithOperation:dictionary];
-    }
-    else if ([opName isEqualToString:@"collectionViewScroll"])
-    {
-        op = [[LPCollectionViewScrollToItemOperation alloc] initWithOperation:dictionary];
-    }
-    else
-    {
-        op = [[LPOperation alloc] initWithOperation:dictionary];
-    }
-    return [op autorelease];
-}
-
-+(NSArray*)performQuery:(id)query
-{
-    
-    UIScriptParser *parser = nil;
-    if ([query isKindOfClass:[NSString class]])
-    {
-        parser = [[UIScriptParser alloc] initWithUIScript:(NSString*) query];
-    }
-    else if ([query isKindOfClass:[NSArray class]])
-    {
-        parser = [[UIScriptParser alloc] initWithQuery:(NSArray*) query];
-    }
-    else {
-        return nil;
-    }
-    [parser parse];
-    
-    NSMutableArray* views = [NSMutableArray arrayWithCapacity:32];
-	
-    NSArray *allWindows = [LPTouchUtils applicationWindows];
-    for (UIWindow *window in allWindows)
-    {
-        [views addObjectsFromArray:[window subviews]];
-    }
-    NSArray* result = [parser evalWith:views];
-    [parser release];
-    
-    return result;
++ (id) operationFromDictionary:(NSDictionary *) dictionary {
+  NSString *opName = [dictionary valueForKey:@"method_name"];
+  LPOperation *op = nil;
+  if ([opName isEqualToString:@"scrollToRow"]) {
+    op = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"scrollToRowWithMark"]) {
+    op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"scroll"]) {
+    op = [[LPScrollOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"query"]) {
+    op = [[LPQueryOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"query_all"]) {
+    op = [[LPQueryAllOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"setText"]) {
+    op = [[LPSetTextOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"flash"]) {
+    op = [[LPFlashOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"orientation"]) {
+    op = [[LPOrientationOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"changeDatePickerDate"]) {
+    op = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"changeSlider"]) {
+    op = [[LPSliderOperation alloc] initWithOperation:dictionary];
+  } else if ([opName isEqualToString:@"collectionViewScroll"]) {
+    op = [[LPCollectionViewScrollToItemOperation alloc]
+            initWithOperation:dictionary];
+  } else {
+    op = [[LPOperation alloc] initWithOperation:dictionary];
+  }
+  return [op autorelease];
 }
 
 
-- (id) initWithOperation:(NSDictionary *)operation {
-	self = [super init];
-	if (self != nil) {
-		_selector =  NSSelectorFromString( [operation objectForKey:@"method_name"] );
-		_arguments = [[operation objectForKey:@"arguments"] retain];
-	}
-	return self;
++ (NSArray *) performQuery:(id) query {
+  UIScriptParser *parser = nil;
+  if ([query isKindOfClass:[NSString class]]) {
+    parser = [[UIScriptParser alloc] initWithUIScript:(NSString *) query];
+  } else if ([query isKindOfClass:[NSArray class]]) {
+    parser = [[UIScriptParser alloc] initWithQuery:(NSArray *) query];
+  } else {
+    return nil;
+  }
+  [parser parse];
+
+  NSMutableArray *views = [NSMutableArray arrayWithCapacity:32];
+
+  NSArray *allWindows = [LPTouchUtils applicationWindows];
+  for (UIWindow *window in allWindows) {
+    [views addObjectsFromArray:[window subviews]];
+  }
+  NSArray *result = [parser evalWith:views];
+  [parser release];
+
+  return result;
 }
 
-- (void) dealloc
-{
-	[_arguments release];_arguments=nil;
-	[super dealloc];
+
+- (id) initWithOperation:(NSDictionary *) operation {
+  self = [super init];
+  if (self != nil) {
+    _selector = NSSelectorFromString([operation objectForKey:@"method_name"]);
+    _arguments = [[operation objectForKey:@"arguments"] retain];
+  }
+  return self;
 }
+
+
+- (void) dealloc {
+  [_arguments release];
+  _arguments = nil;
+  [super dealloc];
+}
+
 
 - (NSString *) description {
-	return [NSString stringWithFormat:@"Operation<SEL=%@,Args=%@>",NSStringFromSelector(_selector),_arguments];
+  return [NSString stringWithFormat:@"Operation<SEL=%@,Args=%@>",
+                                    NSStringFromSelector(_selector),
+                                    _arguments];
 }
 
-- (id) performWithTarget:(UIView*)target error:(NSError **)error {
-	NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
-	NSUInteger argc = tSig.numberOfArguments - 2;
-	if( argc != [_arguments count]  && *error != NULL) {
-        *error = [NSError errorWithDomain:@"CalabashServer" code:1 
-                                 userInfo:
-                  [NSDictionary dictionaryWithObjectsAndKeys:
-                    @"Arity mismatch", @"reason",
-                    [NSString stringWithFormat:@"%@ applied to selector %@ with %i args",self,NSStringFromSelector(_selector),argc],@"details"
-                   ,nil]];
-        return nil;
+
+- (id) performWithTarget:(UIView *) target error:(NSError **) error {
+  NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
+  NSUInteger argc = tSig.numberOfArguments - 2;
+  if (argc != [_arguments count] && *error != NULL) {
+    *error = [NSError errorWithDomain:@"CalabashServer" code:1
+                             userInfo:[NSDictionary dictionaryWithObjectsAndKeys:@"Arity mismatch", @"reason",
+                                                                                 [NSString stringWithFormat:@"%@ applied to selector %@ with %i args",
+                                                                                                            self,
+                                                                                                            NSStringFromSelector(
+                                                                                                                    _selector),
+                                                                                                            argc], @"details",
+                                                                                 nil]];
+    return nil;
+  }
+
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:tSig];
+  [invocation setSelector:_selector];
+
+  NSInteger index = 2;
+  for (NSObject *arg in _arguments) {
+    [invocation setArgument:&arg atIndex:index++];
+  }
+
+  [invocation invokeWithTarget:target];
+
+
+  const char *returnType = tSig.methodReturnType;
+
+  id returnValue;
+  if (!strcmp(returnType, @encode(void))) {
+    returnValue = nil;
+  } else if (!strcmp(returnType,
+          @encode(id))) // retval is an objective c object
+  {
+    [invocation getReturnValue:&returnValue];
+  } else {
+    // handle primitive c types by wrapping them in an NSValue
+
+    NSUInteger length = [tSig methodReturnLength];
+    void *buffer = (void *) malloc(length);
+    [invocation getReturnValue:buffer];
+
+    // for some reason using [NSValue valueWithBytes:returnType] is creating instances of NSConcreteValue rather than NSValue, so
+    //I'm fudging it here with case-by-case logic
+    if (!strcmp(returnType, @encode(BOOL))) {
+      returnValue = [NSNumber numberWithBool:*((BOOL *) buffer)];
+    } else if (!strcmp(returnType, @encode(NSInteger))) {
+      returnValue = [NSNumber numberWithInteger:*((NSInteger *) buffer)];
+    } else if (!strcmp(returnType, @encode(float))) {
+      returnValue = [NSNumber numberWithFloat:*((float *) buffer)];
+    } else {
+      returnValue = [[[NSValue valueWithBytes:buffer objCType:returnType] copy]
+              autorelease];
     }
-	
-	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:tSig];
-	[invocation setSelector:_selector];
-	
-	NSInteger index = 2; 
-	for( NSObject* arg in _arguments) {
-		[invocation setArgument:&arg atIndex:index++];
-	}
-    
-	[invocation invokeWithTarget:target];
-    
-	
-	const char *returnType = tSig.methodReturnType;
-	
-	id returnValue;
-	if( !strcmp(returnType, @encode(void)) )
-		returnValue =  nil;
-	else if( !strcmp(returnType, @encode(id)) ) // retval is an objective c object
-	{
-		[invocation getReturnValue:&returnValue];
-	}else {
-		// handle primitive c types by wrapping them in an NSValue
-		
-		NSUInteger length = [tSig methodReturnLength];
-		void *buffer = (void *)malloc(length);
-		[invocation getReturnValue:buffer];
-		
-		// for some reason using [NSValue valueWithBytes:returnType] is creating instances of NSConcreteValue rather than NSValue, so 
-		//I'm fudging it here with case-by-case logic
-		if( !strcmp(returnType, @encode(BOOL)) ) 
-		{
-			returnValue = [NSNumber numberWithBool:*((BOOL*)buffer)];
-		}else if( !strcmp(returnType, @encode(NSInteger)) )
-		{
-			returnValue = [NSNumber numberWithInteger:*((NSInteger*)buffer)];
-		}else if( !strcmp(returnType, @encode(float)) )
-		{
-			returnValue = [NSNumber numberWithFloat:*((float*)buffer)];
-		}else {
-			returnValue = [[[NSValue valueWithBytes:buffer objCType:returnType] copy] autorelease];
-		}
-		free(buffer);//memory leak here, but apparently NSValue doesn't copy the passed buffer, it just stores the pointer
-	}
-	return returnValue;	
+    free(buffer);//memory leak here, but apparently NSValue doesn't copy the passed buffer, it just stores the pointer
+  }
+  return returnValue;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.h
@@ -8,6 +8,7 @@
 @interface LPOrientationOperation : LPOperation
 
 + (NSString *) deviceOrientation;
+
 + (NSString *) statusBarOrientation;
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
@@ -18,97 +18,101 @@ static NSString *const kUnknown = @"unknown";
 static NSString *const kFaceDown = @"face down";
 static NSString *const kFaceUp = @"face up";
 
-
 @implementation LPOrientationOperation
 
 - (NSString *) description {
-    return [NSString stringWithFormat:@"Orientation: %@",_arguments];
+  return [NSString stringWithFormat:@"Orientation: %@", _arguments];
 }
+
 
 + (NSString *) deviceOrientation {
-    
-    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-    UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
-    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-    switch (orientation) {
-        case UIDeviceOrientationUnknown: return kUnknown;
-        case UIDeviceOrientationPortrait: return kDown;
-        case UIDeviceOrientationPortraitUpsideDown: return kUp;
-        /*** UNEXPECTED ***/
-        /*
-         confusing semantics
-           
-         the rotation methods in the gem orient by the position of the home button
-         e.g. if the home is on the right we say "the device is in the right orientation"
-         
-         from the apple docs -
-         
-         UIDeviceOrientationLandscapeRight:  The device is in landscape mode, 
-         with the device held upright and the home button on the __left__ side.
-         
-         ===>  so we reverse left and right <===
-         */
-        case UIDeviceOrientationLandscapeLeft: return kRight;
-        case UIDeviceOrientationLandscapeRight: return kLeft;
-        /******************/
-        case UIDeviceOrientationFaceDown: return kFaceDown;
-        case UIDeviceOrientationFaceUp: return kFaceUp;
-        default: return kUnknown;
-    }
+
+  [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+  UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+  [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+  switch (orientation) {
+    case UIDeviceOrientationUnknown: return kUnknown;
+    case UIDeviceOrientationPortrait: return kDown;
+    case UIDeviceOrientationPortraitUpsideDown: return kUp;
+      /*** UNEXPECTED ***/
+      /*
+       confusing semantics
+
+       the rotation methods in the gem orient by the position of the home button
+       e.g. if the home is on the right we say "the device is in the right orientation"
+
+       from the apple docs -
+
+       UIDeviceOrientationLandscapeRight:  The device is in landscape mode,
+       with the device held upright and the home button on the __left__ side.
+
+       ===>  so we reverse left and right <===
+       */
+    case UIDeviceOrientationLandscapeLeft: return kRight;
+    case UIDeviceOrientationLandscapeRight: return kLeft;
+      /******************/
+    case UIDeviceOrientationFaceDown: return kFaceDown;
+    case UIDeviceOrientationFaceUp: return kFaceUp;
+    default: return kUnknown;
+  }
 }
+
 
 + (NSString *) statusBarOrientation {
-    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-    switch (orientation) {
-        case UIInterfaceOrientationPortrait: return kDown;
-        case UIInterfaceOrientationPortraitUpsideDown: return kUp;
-        /*** UNEXPECTED ***/
-        /* 
-         confusing semantics
-         
-         from the app docs -
+  UIInterfaceOrientation orientation = [[UIApplication sharedApplication]
+          statusBarOrientation];
+  switch (orientation) {
+    case UIInterfaceOrientationPortrait: return kDown;
+    case UIInterfaceOrientationPortraitUpsideDown: return kUp;
+      /*** UNEXPECTED ***/
+      /*
+       confusing semantics
 
-         UIInterfaceOrientationLandscapeLeft: The device is in landscape mode,
-         with the device held upright and the home button on the __left__ side.
-         
-         ==> no need to reverse left and right <==
-        */
-        case UIInterfaceOrientationLandscapeLeft: return kLeft;
-        case UIInterfaceOrientationLandscapeRight: return kRight;
-        /******************/
-    }
+       from the app docs -
+
+       UIInterfaceOrientationLandscapeLeft: The device is in landscape mode,
+       with the device held upright and the home button on the __left__ side.
+
+       ==> no need to reverse left and right <==
+      */
+    case UIInterfaceOrientationLandscapeLeft: return kLeft;
+    case UIInterfaceOrientationLandscapeRight: return kRight;
+      /******************/
+  }
 }
+
 
 // _arguments ==> {'device' | 'status_bar'}
-- (id) performWithTarget:(UIView*) _view error:(NSError **)error {
-    
-    NSUInteger argCount = [_arguments count];
-    if (argCount == 0) {
-        NSLog(@"Warning: requires exactly one argument: {'%@' | '%@'} found none",
-              kDevice, kStatusBar);
-        return nil;
-    }
-    
-    if (argCount > 1) {
-        NSLog(@"Warning: argument should be {'%@' | '%@'} - found '[%@']",
-              kDevice, kStatusBar, [_arguments componentsJoinedByString:@", "]);
-        return nil;
-    }
-    
-    NSString *firstArg = [_arguments objectAtIndex:0];
-    if ([@[kDevice, kStatusBar] containsObject:firstArg] == NO) {
-        NSLog(@"Warning: argument should be {'%@' | '%@'} - found '%@'",
-              kDevice, kStatusBar, firstArg);
-    }
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
 
-    if ([kDevice isEqualToString:firstArg]) {
-        return [LPOrientationOperation deviceOrientation];
-    } else if ([kStatusBar isEqualToString:firstArg]) {
-        return [LPOrientationOperation statusBarOrientation];
-    } else {
-        NSLog(@"Warning: feel through conditional for arguments: '[%@]'",
-              [_arguments componentsJoinedByString:@", "]);
-        return nil;
-    }
+  NSUInteger argCount = [_arguments count];
+  if (argCount == 0) {
+    NSLog(@"Warning: requires exactly one argument: {'%@' | '%@'} found none",
+            kDevice, kStatusBar);
+    return nil;
+  }
+
+  if (argCount > 1) {
+    NSLog(@"Warning: argument should be {'%@' | '%@'} - found '[%@']", kDevice,
+            kStatusBar, [_arguments componentsJoinedByString:@", "]);
+    return nil;
+  }
+
+  NSString *firstArg = [_arguments objectAtIndex:0];
+  if ([@[kDevice, kStatusBar] containsObject:firstArg] == NO) {
+    NSLog(@"Warning: argument should be {'%@' | '%@'} - found '%@'", kDevice,
+            kStatusBar, firstArg);
+  }
+
+  if ([kDevice isEqualToString:firstArg]) {
+    return [LPOrientationOperation deviceOrientation];
+  } else if ([kStatusBar isEqualToString:firstArg]) {
+    return [LPOrientationOperation statusBarOrientation];
+  } else {
+    NSLog(@"Warning: feel through conditional for arguments: '[%@]'",
+            [_arguments componentsJoinedByString:@", "]);
+    return nil;
+  }
 }
+
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -6,302 +6,255 @@
 
 #import "LPQueryAllOperation.h"
 #import "LPJSONUtils.h"
-#import "LPTouchUtils.h"
 
 
 @implementation LPQueryAllOperation
 - (NSString *) description {
-	return [NSString stringWithFormat:@"Query All: %@",_arguments];
+  return [NSString stringWithFormat:@"Query All: %@", _arguments];
 }
 
--(SEL)parseValuesFromArray:(NSArray *)arr withArgs:(NSMutableArray *)args
-{
-    NSMutableString *selStr = [NSMutableString stringWithCapacity:32];
-    for (NSDictionary *selPart in arr)
-    {
-        NSString *as = [selPart objectForKey:@"as"];
-        if (as)
-        {
-            NSMutableDictionary *mdict = [[selPart mutableCopy] autorelease];
-            [mdict removeObjectForKey:@"as"];
-            selPart = mdict;
-        }
 
-        NSString *key = [[selPart keyEnumerator] nextObject];
-
-        [selStr appendFormat:@"%@:",key];
-        id tgt = [selPart objectForKey:key];
-        if (as)
-        {
-            Class asClass = NSClassFromString(as);
-            if (asClass)
-            {
-                if ([tgt isKindOfClass: [NSArray class]])
-                {
-                    NSMutableArray * subArgs = [NSMutableArray array];
-                    SEL sel = [self parseValuesFromArray:tgt withArgs:subArgs];
-
-                    NSMethodSignature *sig = [asClass methodSignatureForSelector:sel];
-                    if (!sig || ![asClass respondsToSelector:sel])
-                    {
-                        NSLog(@"*****");
-                        return nil;
-                    }
-                    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
-
-                    [self invoke: invocation withTarget: asClass args: subArgs selector: sel signature: sig];
-
-                    id objValue;
-                    [invocation getReturnValue:(void **)&objValue];
-                    tgt = objValue ? objValue : [NSNull null];
-
-                }
-                else
-                {
-                    tgt = [asClass performSelector:NSSelectorFromString(tgt)];
-                }
-            }
-        }
-        [args addObject:tgt];
+- (SEL) parseValuesFromArray:(NSArray *) arr withArgs:(NSMutableArray *) args {
+  NSMutableString *selStr = [NSMutableString stringWithCapacity:32];
+  for (NSDictionary *selPart in arr) {
+    NSString *as = [selPart objectForKey:@"as"];
+    if (as) {
+      NSMutableDictionary *mdict = [[selPart mutableCopy] autorelease];
+      [mdict removeObjectForKey:@"as"];
+      selPart = mdict;
     }
-    return NSSelectorFromString(selStr);
-}
 
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
-    id target = _view;
+    NSString *key = [[selPart keyEnumerator] nextObject];
 
-    if([_arguments count] <= 0) {
-        return [LPJSONUtils jsonifyObject: _view];
-    }
-    for (NSInteger i=0;i<[_arguments count];i++) {
-        id selObj = [_arguments objectAtIndex:i];
-        id objValue;
-        int intValue;
-        unsigned int uintValue;
-        long longValue;
-        char *charPtrValue; 
-        char charValue;
-        short shortValue;
-        float floatValue;
-        double doubleValue;
-        SEL sel = nil;
-        
-        NSMutableArray *args = [NSMutableArray array];
-        
-        if ([selObj isKindOfClass:[NSString class]])
-        {
-            sel = NSSelectorFromString(selObj);
-        }
-        else if ([selObj isKindOfClass:[NSDictionary class]])
-        {
-            sel = [self parseValuesFromArray:[NSArray arrayWithObject: selObj] withArgs:args];
-        }
-        else if ([selObj isKindOfClass:[NSArray class]])
-        {
-            sel = [self parseValuesFromArray:selObj withArgs:args];
-            
-        }
-        
-        NSMethodSignature *sig = [target methodSignatureForSelector:sel];
-        if (!sig || ![target respondsToSelector:sel]) 
-        {
-            return @"*****";
-        } 
-        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
+    [selStr appendFormat:@"%@:", key];
+    id tgt = [selPart objectForKey:key];
+    if (as) {
+      Class asClass = NSClassFromString(as);
+      if (asClass) {
+        if ([tgt isKindOfClass:[NSArray class]]) {
+          NSMutableArray *subArgs = [NSMutableArray array];
+          SEL sel = [self parseValuesFromArray:tgt withArgs:subArgs];
 
-        if (![self invoke: invocation withTarget: target args: args selector: sel signature: sig])
-        {
+          NSMethodSignature *sig = [asClass methodSignatureForSelector:sel];
+          if (!sig || ![asClass respondsToSelector:sel]) {
+            NSLog(@"*****");
             return nil;
-        }
+          }
+          NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
 
+          [self invoke:invocation withTarget:asClass args:subArgs selector:sel
+             signature:sig];
 
-        const char* type = [[invocation methodSignature] methodReturnType];
-        NSString *returnType = [NSString stringWithFormat:@"%s", type];
-        const char* trimmedType = [[returnType substringToIndex:1] cStringUsingEncoding:NSASCIIStringEncoding];
-        switch(*trimmedType) {
-            case '@':
-                [invocation getReturnValue:(void **)&objValue];
-                if (objValue == nil) {
-                    return nil;
-                } else {
-                    if (i == [_arguments count]-1) {                                                 
-                        return [LPJSONUtils jsonifyObject:objValue];
-                    } else {
-                        target = objValue;
-                        continue;
-                    }
-                    
-                }
-            case 'i':
-                [invocation getReturnValue:(void **)&intValue];
-                return [NSNumber numberWithInt: intValue];
-            case 'I':
-                [invocation getReturnValue:(void **)& uintValue];
-                return [NSNumber numberWithUnsignedInteger: uintValue];
-            case 's':
-                [invocation getReturnValue:(void **)&shortValue];
-                return [NSNumber numberWithShort:shortValue];
-            case 'd':
-                [invocation getReturnValue:(void **)&doubleValue];
-                return [NSNumber numberWithDouble: doubleValue];
-            case 'f':
-                [invocation getReturnValue:(void **)&floatValue];
-                return [NSNumber numberWithFloat:floatValue];
-            case 'l':
-                [invocation getReturnValue:(void **)&longValue];
-                return [NSNumber numberWithLong: longValue];
-            case '*':
-                [invocation getReturnValue:(void **)&charPtrValue];
-                return [NSString stringWithFormat:@"%s", charPtrValue];
-            case 'c':
-                [invocation getReturnValue:(void **)&charValue];
-                return [NSString stringWithFormat:@"%d", charValue];
-            case '{': {
-                unsigned int length = [[invocation methodSignature] methodReturnLength];
-                void *buffer = (void *)malloc(length);
-                [invocation getReturnValue:buffer];
-                NSValue *value = [[[NSValue alloc] initWithBytes:buffer objCType:type] autorelease];
-                
-                if ([returnType rangeOfString:@"{CGRect"].location == 0)
-                {
-                    CGRect *rec = (CGRect*)buffer;
-                    return [NSDictionary dictionaryWithObjectsAndKeys:
-                            [value description], @"description",
-                            [NSNumber numberWithFloat:rec->origin.x],@"X",
-                            [NSNumber numberWithFloat:rec->origin.y],@"Y",
-                            [NSNumber numberWithFloat:rec->size.width],@"Width",
-                            [NSNumber numberWithFloat:rec->size.height],@"Height",
-                            nil];
-                    
-                }
-                else if ([returnType rangeOfString:@"{CGPoint="].location == 0)
-                {
-                    CGPoint *point = (CGPoint*)buffer;
-                    return [NSDictionary dictionaryWithObjectsAndKeys:
-                            [value description], @"description",
-                            [NSNumber numberWithFloat:point->x],@"X",
-                            [NSNumber numberWithFloat:point->y],@"Y",
-                            nil];
-                    
-                }
-                else if ([returnType isEqualToString:@"{?=dd}"])
-                {
-                    double *doubles = (double*)buffer;
-                    double d1 = *doubles;
-                    doubles++;
-                    double d2 = *doubles;
-                    return [NSArray arrayWithObjects:[NSNumber numberWithDouble:d1],
-                            [NSNumber numberWithDouble:d2],
-                            nil];
-                }
-                else
-                {
-                    return [value description];                    
-                }
-            }
+          id objValue;
+          [invocation getReturnValue:(void **) &objValue];
+          tgt = objValue ? objValue : [NSNull null];
+        } else {
+          tgt = [asClass performSelector:NSSelectorFromString(tgt)];
         }
-    
+      }
     }
-    
-	return nil;
+    [args addObject:tgt];
+  }
+  return NSSelectorFromString(selStr);
 }
 
-- (BOOL)invoke:(NSInvocation *)invocation withTarget:(id)target args:(NSMutableArray *)args selector:(SEL)sel signature:(NSMethodSignature *)sig
-{
-    [invocation setSelector:sel];
-    for (NSInteger i =0, N=[args count]; i<N; i++)
-    {
-        id arg = [args objectAtIndex:i];
-        const char *cType = [sig getArgumentTypeAtIndex:i+2];
-        switch(*cType) {
-            case '@':
-            {
-                if ([arg isEqual:@"__self__"])
-                {
-                    arg = target;
-                }
-                [invocation setArgument:&arg atIndex:i+2];
-                break;
-            }
-            case 'i':
-            {
-                NSInteger intVal = [arg integerValue];
-                [invocation setArgument:&intVal atIndex:i+2];
-                break;
-            }
-            case 'I':
-            {
-                NSInteger uIntVal = [arg unsignedIntegerValue];
-                [invocation setArgument:&uIntVal atIndex:i+2];
-                break;
-            }
-            case 's':
-            {
-                short shVal = [arg shortValue];
-                [invocation setArgument:&shVal atIndex:i+2];
-                break;
-            }
-            case 'd':
-            {
-                double dbVal = [arg doubleValue];
-                [invocation setArgument:&dbVal atIndex:i+2];
-                break;
-            }
-            case 'f':
-            {
-                float fltVal = [arg floatValue];
-                [invocation setArgument:&fltVal atIndex:i+2];
-                break;
-            }
-            case 'l':
-            {
-                long lngVal = [arg longValue];
-                [invocation setArgument:&lngVal atIndex:i+2];
-                break;
-            }
-            case '*':
-            {
-                const char *cstringValue = [arg cStringUsingEncoding:NSUTF8StringEncoding];
-                [invocation setArgument:&cstringValue atIndex:i+2];
-                break;
-            }
-            case 'c':
-            {
-                char chVal =[arg charValue];
-                [invocation setArgument:&chVal atIndex:i+2];
-                break;
-            }
-            case '{': {
-                //not supported yet
-                if (strcmp(cType,"{CGPoint=ff}") == 0)
-                {
-                    CGPoint point;
-                    CGPointMakeWithDictionaryRepresentation((CFDictionaryRef)arg, &point);
-                    [invocation setArgument:&point atIndex:i+2];
-                    break;
-                }
-                else if (strcmp(cType,"{CGRect={CGPoint=ff}{CGSize=ff}}") == 0)
-                {
-                    CGRect rect;
-                    CGRectMakeWithDictionaryRepresentation((CFDictionaryRef)arg, &rect);
-                    [invocation setArgument:&rect atIndex:i+2];
-                    break;
-                }
-                @throw [NSString stringWithFormat: @"not yet support struct args: %@",sig];
-            }
+
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+  id target = _view;
+
+  if ([_arguments count] <= 0) {
+    return [LPJSONUtils jsonifyObject:_view];
+  }
+  for (NSInteger i = 0; i < [_arguments count]; i++) {
+    id selObj = [_arguments objectAtIndex:i];
+    id objValue;
+    int intValue;
+    unsigned int uintValue;
+    long longValue;
+    char *charPtrValue;
+    char charValue;
+    short shortValue;
+    float floatValue;
+    double doubleValue;
+    SEL sel = nil;
+
+    NSMutableArray *args = [NSMutableArray array];
+
+    if ([selObj isKindOfClass:[NSString class]]) {
+      sel = NSSelectorFromString(selObj);
+    } else if ([selObj isKindOfClass:[NSDictionary class]]) {
+      sel = [self parseValuesFromArray:[NSArray arrayWithObject:selObj]
+                              withArgs:args];
+    } else if ([selObj isKindOfClass:[NSArray class]]) {
+      sel = [self parseValuesFromArray:selObj withArgs:args];
+    }
+
+    NSMethodSignature *sig = [target methodSignatureForSelector:sel];
+    if (!sig || ![target respondsToSelector:sel]) {
+      return @"*****";
+    }
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
+
+    if (![self invoke:invocation withTarget:target args:args selector:sel
+            signature:sig]) {
+      return nil;
+    }
+
+
+    const char *type = [[invocation methodSignature] methodReturnType];
+    NSString *returnType = [NSString stringWithFormat:@"%s", type];
+    const char *trimmedType = [[returnType substringToIndex:1]
+            cStringUsingEncoding:NSASCIIStringEncoding];
+    switch (*trimmedType) {
+      case '@':[invocation getReturnValue:(void **) &objValue];
+        if (objValue == nil) {
+          return nil;
+        } else {
+          if (i == [_arguments count] - 1) {
+            return [LPJSONUtils jsonifyObject:objValue];
+          } else {
+            target = objValue;
+            continue;
+          }
         }
+      case 'i':[invocation getReturnValue:(void **) &intValue];
+        return [NSNumber numberWithInt:intValue];
+      case 'I':[invocation getReturnValue:(void **) &uintValue];
+        return [NSNumber numberWithUnsignedInteger:uintValue];
+      case 's':[invocation getReturnValue:(void **) &shortValue];
+        return [NSNumber numberWithShort:shortValue];
+      case 'd':[invocation getReturnValue:(void **) &doubleValue];
+        return [NSNumber numberWithDouble:doubleValue];
+      case 'f':[invocation getReturnValue:(void **) &floatValue];
+        return [NSNumber numberWithFloat:floatValue];
+      case 'l':[invocation getReturnValue:(void **) &longValue];
+        return [NSNumber numberWithLong:longValue];
+      case '*':[invocation getReturnValue:(void **) &charPtrValue];
+        return [NSString stringWithFormat:@"%s", charPtrValue];
+      case 'c':[invocation getReturnValue:(void **) &charValue];
+        return [NSString stringWithFormat:@"%d", charValue];
+      case '{': {
+        unsigned int length = [[invocation methodSignature] methodReturnLength];
+        void *buffer = (void *) malloc(length);
+        [invocation getReturnValue:buffer];
+        NSValue *value = [[[NSValue alloc] initWithBytes:buffer objCType:type]
+                autorelease];
+
+        if ([returnType rangeOfString:@"{CGRect"].location == 0) {
+          CGRect *rec = (CGRect *) buffer;
+          return [NSDictionary dictionaryWithObjectsAndKeys:[value description], @"description",
+                                                            [NSNumber numberWithFloat:rec->origin.x], @"X",
+                                                            [NSNumber numberWithFloat:rec->origin.y], @"Y",
+                                                            [NSNumber numberWithFloat:rec->size.width], @"Width",
+                                                            [NSNumber numberWithFloat:rec->size.height], @"Height",
+                                                            nil];
+        } else if ([returnType rangeOfString:@"{CGPoint="].location == 0) {
+          CGPoint *point = (CGPoint *) buffer;
+          return [NSDictionary dictionaryWithObjectsAndKeys:[value description], @"description",
+                                                            [NSNumber numberWithFloat:point->x], @"X",
+                                                            [NSNumber numberWithFloat:point->y], @"Y",
+                                                            nil];
+        } else if ([returnType isEqualToString:@"{?=dd}"]) {
+          double *doubles = (double *) buffer;
+          double d1 = *doubles;
+          doubles++;
+          double d2 = *doubles;
+          return [NSArray arrayWithObjects:[NSNumber numberWithDouble:d1],
+                                           [NSNumber numberWithDouble:d2], nil];
+        } else {
+          return [value description];
+        }
+      }
     }
-    [invocation setTarget:target];
-    @try {
-        [invocation invoke];
-    }
-    @catch (NSException *exception) {
-        NSLog(@"Perform %@ with target %@ caught %@: %@", NSStringFromSelector(sel), target, [exception name], [exception reason]);
-        return NO;
-    }
-    return YES;
+  }
+
+  return nil;
 }
 
+
+- (BOOL) invoke:(NSInvocation *) invocation withTarget:(id) target args:(NSMutableArray *) args selector:(SEL) sel signature:(NSMethodSignature *) sig {
+  [invocation setSelector:sel];
+  for (NSInteger i = 0, N = [args count]; i < N; i++) {
+    id arg = [args objectAtIndex:i];
+    const char *cType = [sig getArgumentTypeAtIndex:i + 2];
+    switch (*cType) {
+      case '@': {
+        if ([arg isEqual:@"__self__"]) {
+          arg = target;
+        }
+        [invocation setArgument:&arg atIndex:i + 2];
+        break;
+      }
+      case 'i': {
+        NSInteger intVal = [arg integerValue];
+        [invocation setArgument:&intVal atIndex:i + 2];
+        break;
+      }
+      case 'I': {
+        NSInteger uIntVal = [arg unsignedIntegerValue];
+        [invocation setArgument:&uIntVal atIndex:i + 2];
+        break;
+      }
+      case 's': {
+        short shVal = [arg shortValue];
+        [invocation setArgument:&shVal atIndex:i + 2];
+        break;
+      }
+      case 'd': {
+        double dbVal = [arg doubleValue];
+        [invocation setArgument:&dbVal atIndex:i + 2];
+        break;
+      }
+      case 'f': {
+        float fltVal = [arg floatValue];
+        [invocation setArgument:&fltVal atIndex:i + 2];
+        break;
+      }
+      case 'l': {
+        long lngVal = [arg longValue];
+        [invocation setArgument:&lngVal atIndex:i + 2];
+        break;
+      }
+      case '*': {
+        const char *cstringValue = [arg cStringUsingEncoding:NSUTF8StringEncoding];
+        [invocation setArgument:&cstringValue atIndex:i + 2];
+        break;
+      }
+      case 'c': {
+        char chVal = [arg charValue];
+        [invocation setArgument:&chVal atIndex:i + 2];
+        break;
+      }
+      case '{': {
+        //not supported yet
+        if (strcmp(cType, "{CGPoint=ff}") == 0) {
+          CGPoint point;
+          CGPointMakeWithDictionaryRepresentation((CFDictionaryRef) arg,
+                  &point);
+          [invocation setArgument:&point atIndex:i + 2];
+          break;
+        } else if (strcmp(cType, "{CGRect={CGPoint=ff}{CGSize=ff}}") == 0) {
+          CGRect rect;
+          CGRectMakeWithDictionaryRepresentation((CFDictionaryRef) arg, &rect);
+          [invocation setArgument:&rect atIndex:i + 2];
+          break;
+        }
+        @throw [NSString stringWithFormat:@"not yet support struct args: %@",
+                                          sig];
+      }
+    }
+  }
+  [invocation setTarget:target];
+  @try {
+    [invocation invoke];
+  }
+  @catch (NSException *exception) {
+    NSLog(@"Perform %@ with target %@ caught %@: %@", NSStringFromSelector(sel),
+            target, [exception name], [exception reason]);
+    return NO;
+  }
+  return YES;
+}
 
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
@@ -5,20 +5,17 @@
 //
 
 #import "LPQueryOperation.h"
-#import "LPJSONUtils.h"
-#import "LPTouchUtils.h"
 
 
 @implementation LPQueryOperation
 - (NSString *) description {
-	return [NSString stringWithFormat:@"Query: %@",_arguments];
+  return [NSString stringWithFormat:@"Query: %@", _arguments];
 }
 
 
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
-    return [super performWithTarget:_view error:error];    
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+  return [super performWithTarget:_view error:error];
 }
 
-            
-                 
+
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -8,50 +8,54 @@
 
 @implementation LPScrollOperation
 - (NSString *) description {
-	return [NSString stringWithFormat:@"Scroll: %@",_arguments];
+  return [NSString stringWithFormat:@"Scroll: %@", _arguments];
 }
 
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
-    NSString *dir = [_arguments objectAtIndex:0];
-    
-    if ([_view isKindOfClass:[UIScrollView class]]) {
-        UIScrollView* sv = (UIScrollView*) _view;
-        CGSize size = sv.frame.size;
-        CGPoint offset = sv.contentOffset;
-        CGFloat fraction = 2.0;
-        if ([sv isPagingEnabled]) {
-            fraction = 1.0;
-        }
-        
-        if ([@"up" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x, offset.y - size.height/fraction) animated:YES];
-        } else if ([@"down" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x, offset.y + size.height/fraction) animated:YES];            
-        } else if ([@"left" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x - size.width/fraction, offset.y) animated:YES];
-        } else if ([@"right" isEqualToString:dir]) {
-            [sv setContentOffset:CGPointMake(offset.x + size.width/fraction, offset.y) animated:YES];            
-        }
-        
-        return _view;
-        
-    } else if ([_view isKindOfClass:[UIWebView class]]) {
-        UIWebView* wv = (UIWebView*) _view;
-        NSString* scrollJS = @"window.scrollBy(%@,%@);";
-        if ([@"up" isEqualToString:dir]) {
-            scrollJS = [NSString stringWithFormat:scrollJS,@"0",@"-100"];
-        } else if ([@"down" isEqualToString:dir]) {
-            scrollJS = [NSString stringWithFormat:scrollJS,@"0",@"100"];
-        } else if ([@"left" isEqualToString:dir]) {
-            scrollJS = [NSString stringWithFormat:scrollJS,@"-100",@"0"];
-        } else if ([@"right" isEqualToString:dir]) {
-            scrollJS = [NSString stringWithFormat:scrollJS,@"100",@"0"];
-        }
-        NSString *res = [wv stringByEvaluatingJavaScriptFromString:scrollJS];
-        NSLog(@"RES:%@",res);
-        return _view;        
+
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+  NSString *dir = [_arguments objectAtIndex:0];
+
+  if ([_view isKindOfClass:[UIScrollView class]]) {
+    UIScrollView *sv = (UIScrollView *) _view;
+    CGSize size = sv.frame.size;
+    CGPoint offset = sv.contentOffset;
+    CGFloat fraction = 2.0;
+    if ([sv isPagingEnabled]) {
+      fraction = 1.0;
     }
-	return nil;
+
+    if ([@"up" isEqualToString:dir]) {
+      [sv                                setContentOffset:CGPointMake(offset.x,
+              offset.y - size.height / fraction) animated:YES];
+    } else if ([@"down" isEqualToString:dir]) {
+      [sv                                setContentOffset:CGPointMake(offset.x,
+              offset.y + size.height / fraction) animated:YES];
+    } else if ([@"left" isEqualToString:dir]) {
+      [sv       setContentOffset:CGPointMake(offset.x - size.width / fraction,
+              offset.y) animated:YES];
+    } else if ([@"right" isEqualToString:dir]) {
+      [sv       setContentOffset:CGPointMake(offset.x + size.width / fraction,
+              offset.y) animated:YES];
+    }
+
+    return _view;
+  } else if ([_view isKindOfClass:[UIWebView class]]) {
+    UIWebView *wv = (UIWebView *) _view;
+    NSString *scrollJS = @"window.scrollBy(%@,%@);";
+    if ([@"up" isEqualToString:dir]) {
+      scrollJS = [NSString stringWithFormat:scrollJS, @"0", @"-100"];
+    } else if ([@"down" isEqualToString:dir]) {
+      scrollJS = [NSString stringWithFormat:scrollJS, @"0", @"100"];
+    } else if ([@"left" isEqualToString:dir]) {
+      scrollJS = [NSString stringWithFormat:scrollJS, @"-100", @"0"];
+    } else if ([@"right" isEqualToString:dir]) {
+      scrollJS = [NSString stringWithFormat:scrollJS, @"100", @"0"];
+    }
+    NSString *res = [wv stringByEvaluatingJavaScriptFromString:scrollJS];
+    NSLog(@"RES:%@", res);
+    return _view;
+  }
+  return nil;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
@@ -11,80 +11,72 @@
 @implementation LPScrollToRowOperation
 
 - (NSString *) description {
-	return [NSString stringWithFormat:@"ScrollToRow: %@",_arguments];
+  return [NSString stringWithFormat:@"ScrollToRow: %@", _arguments];
 }
 
--(NSIndexPath *)indexPathForRow:(NSUInteger) row inTable:(UITableView*) table {
-	int numberOfSections = [table numberOfSections];
-    int i=0;
-	for(; i< numberOfSections; i++) {
-		NSInteger numberOfRowsInSection = [table numberOfRowsInSection:i];
-		if (row<numberOfRowsInSection) {
-            return [NSIndexPath indexPathForRow:row inSection:i];
-        } else {
-            row -= numberOfSections;
-        }
-	}
-	return nil;
-}
 
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
-    if ([_view isKindOfClass:[UITableView class]]) {
-        UITableView* table = (UITableView*) _view;
-        NSNumber *rowNum = [_arguments objectAtIndex:0];
-        if ([_arguments count] >= 2)
-        {
-            NSInteger row = [rowNum integerValue];
-            NSInteger sec = [[_arguments objectAtIndex:1] integerValue];
-            NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:sec];
-            
-            if ((sec >= 0 && sec < [table numberOfSections]) &&
-                (row >= 0 && row < [table numberOfRowsInSection:sec]))
-            {
-                UITableViewScrollPosition sp = UITableViewScrollPositionTop;
-                BOOL animate = YES;
-                if ([_arguments count] >= 3)
-                {
-                    NSString *pos = [_arguments objectAtIndex:2];
-                    if ([@"middle" isEqualToString:pos])
-                    {
-                        sp = UITableViewScrollPositionMiddle;
-                    }
-                    else if ([@"bottom" isEqualToString:pos])
-                    {
-                        sp = UITableViewScrollPositionBottom;
-                    }
-                    else if ([@"none" isEqualToString:pos])
-                    {
-                        sp = UITableViewScrollPositionNone;
-                    }
-                }
-                if ([_arguments count] >= 4)
-                {
-                    NSNumber *ani = [_arguments objectAtIndex:3];
-                    animate = [ani boolValue];
-                }
-                
-                [table scrollToRowAtIndexPath:path atScrollPosition: sp animated:animate];
-                return _view;
-            }
-            else {
-                NSLog(@"Warning: table doesn't contain indexPath: %@",path);
-                return nil;
-            }
-        
-        }
-        else {
-            NSIndexPath* indexPathForRow = [self indexPathForRow:[rowNum unsignedIntegerValue] inTable:table];
-            if (!indexPathForRow)
-            {
-                return nil;
-            }
-            [table scrollToRowAtIndexPath:indexPathForRow atScrollPosition:UITableViewScrollPositionTop animated:YES];
-            return _view;
-        }
+- (NSIndexPath *) indexPathForRow:(NSUInteger) row inTable:(UITableView *) table {
+  int numberOfSections = [table numberOfSections];
+  int i = 0;
+  for (; i < numberOfSections; i++) {
+    NSInteger numberOfRowsInSection = [table numberOfRowsInSection:i];
+    if (row < numberOfRowsInSection) {
+      return [NSIndexPath indexPathForRow:row inSection:i];
+    } else {
+      row -= numberOfSections;
     }
-    NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",_view);
-	return nil;
+  }
+  return nil;
+}
+
+
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+  if ([_view isKindOfClass:[UITableView class]]) {
+    UITableView *table = (UITableView *) _view;
+    NSNumber *rowNum = [_arguments objectAtIndex:0];
+    if ([_arguments count] >= 2) {
+      NSInteger row = [rowNum integerValue];
+      NSInteger sec = [[_arguments objectAtIndex:1] integerValue];
+      NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:sec];
+
+      if ((sec >= 0 && sec < [table numberOfSections]) && (row >= 0 && row < [table numberOfRowsInSection:sec])) {
+        UITableViewScrollPosition sp = UITableViewScrollPositionTop;
+        BOOL animate = YES;
+        if ([_arguments count] >= 3) {
+          NSString *pos = [_arguments objectAtIndex:2];
+          if ([@"middle" isEqualToString:pos]) {
+            sp = UITableViewScrollPositionMiddle;
+          } else if ([@"bottom" isEqualToString:pos]) {
+            sp = UITableViewScrollPositionBottom;
+          } else if ([@"none" isEqualToString:pos]) {
+            sp = UITableViewScrollPositionNone;
+          }
+        }
+        if ([_arguments count] >= 4) {
+          NSNumber *ani = [_arguments objectAtIndex:3];
+          animate = [ani boolValue];
+        }
+
+        [table scrollToRowAtIndexPath:path atScrollPosition:sp
+                             animated:animate];
+        return _view;
+      } else {
+        NSLog(@"Warning: table doesn't contain indexPath: %@", path);
+        return nil;
+      }
+    } else {
+      NSIndexPath *indexPathForRow = [self indexPathForRow:[rowNum unsignedIntegerValue]
+                                                   inTable:table];
+      if (!indexPathForRow) {
+        return nil;
+      }
+      [table scrollToRowAtIndexPath:indexPathForRow
+                   atScrollPosition:UITableViewScrollPositionTop animated:YES];
+      return _view;
+    }
+  }
+  NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",
+          _view);
+  return nil;
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -11,7 +11,7 @@
 @implementation LPScrollToRowWithMarkOperation
 
 - (NSString *) description {
-	return [NSString stringWithFormat:@"ScrollToRow: %@",_arguments];
+  return [NSString stringWithFormat:@"ScrollToRow: %@", _arguments];
 }
 
 
@@ -21,44 +21,46 @@
   if ([aView respondsToSelector:@selector(accessibilityIdentifier)]) {
     idenififer = aView.accessibilityIdentifier;
   }
-  
+
   if (idenififer != nil && [idenififer isEqualToString:aMark]) {
     return YES;
   }
-  
+
   if ([aView.accessibilityLabel isEqualToString:aMark]) {
     return YES;
   }
-  
+
   if ([aView isKindOfClass:[UILabel class]]) {
     UILabel *label = (UILabel *) aView;
-    if ([label.text isEqualToString:aMark]) { return YES; }
+    if ([label.text isEqualToString:aMark]) {return YES;}
   }
-  
+
   if ([aView isKindOfClass:[UITextView class]]) {
     UITextView *textView = (UITextView *) aView;
-    if ([textView.text isEqualToString:aMark]) { return YES; }
+    if ([textView.text isEqualToString:aMark]) {return YES;}
   }
-  
+
   return NO;
 }
 
+
 - (BOOL) cell:(UITableViewCell *) aCell hasSubviewMarked:(NSString *) aMark {
   // check the textLabel first
-  if ([self view:aCell.textLabel hasMark:aMark]) { return YES; }
-  
+  if ([self view:aCell.textLabel hasMark:aMark]) {return YES;}
+
   // skip the details text label
   // if ([self view:aCell.detailTextLabel hasMark:aMark]) { return YES; }
   UIView *contentView = aCell.contentView;
   for (UIView *subview in [contentView subviews]) {
-    if ([self view:subview hasMark:aMark]) { return YES; }
+    if ([self view:subview hasMark:aMark]) {return YES;}
   }
-  
+
   return NO;
 }
 
-- (NSIndexPath *) indexPathForRowWithMark:(NSString *) aMark inTable:(UITableView*) aTable {
-	NSUInteger numberOfSections = [aTable numberOfSections];
+
+- (NSIndexPath *) indexPathForRowWithMark:(NSString *) aMark inTable:(UITableView *) aTable {
+  NSUInteger numberOfSections = [aTable numberOfSections];
   for (NSUInteger section = 0; section < numberOfSections; section++) {
     NSUInteger numberOfRows = [aTable numberOfRowsInSection:section];
     for (NSUInteger row = 0; row < numberOfRows; row++) {
@@ -71,39 +73,41 @@
       }
 
       // is the cell itself marked?
-      if ([self view:cell hasMark:aMark]) { return path; }
+      if ([self view:cell hasMark:aMark]) {return path;}
       // are any of it's subviews marked?
-      if ([self cell:cell hasSubviewMarked:aMark]) { return path; }
+      if ([self cell:cell hasSubviewMarked:aMark]) {return path;}
     }
   }
   return nil;
 }
 
+
 //                 required      optional     optional
 // _arguments ==> [row mark, scroll position, animated]
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
   if ([_view isKindOfClass:[UITableView class]] == NO) {
-    NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",_view);
+    NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",
+            _view);
     return nil;
   }
-  
-  UITableView* table = (UITableView*) _view;
+
+  UITableView *table = (UITableView *) _view;
   NSString *rowId = [_arguments objectAtIndex:0];
   if (rowId == nil || [rowId length] == 0) {
     NSLog(@"Warning: row id: '%@' should be non-nil and non-empty", rowId);
     return nil;
   }
-  
+
   NSIndexPath *path = [self indexPathForRowWithMark:rowId inTable:table];
   if (path == nil) {
     NSLog(@"Warning: table doesn't contain row with id '%@'", rowId);
     return nil;
   }
-  
+
   UITableViewScrollPosition sp = UITableViewScrollPositionTop;
   BOOL animate = YES;
-  
-  
+
+
   if ([_arguments count] > 1) {
     NSString *scrollPositionArg = [_arguments objectAtIndex:1];
     if ([@"middle" isEqualToString:scrollPositionArg]) {
@@ -114,12 +118,12 @@
       sp = UITableViewScrollPositionNone;
     }
   }
-  
+
   if ([_arguments count] > 2) {
     NSNumber *ani = [_arguments objectAtIndex:2];
     animate = [ani boolValue];
   }
-  
+
   [table scrollToRowAtIndexPath:path atScrollPosition:sp animated:animate];
   return _view;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPSetTextOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSetTextOperation.m
@@ -11,38 +11,34 @@
 
 @implementation LPSetTextOperation
 - (NSString *) description {
-	return [NSString stringWithFormat:@"Text: %@",_arguments];
+  return [NSString stringWithFormat:@"Text: %@", _arguments];
 }
 
-- (id) performWithTarget:(id)_view error:(NSError **)error {
-    if ([_view isKindOfClass:[NSDictionary class]])
-    {
-            NSMutableDictionary *mdict = [NSMutableDictionary dictionaryWithDictionary:_view];
-            [mdict removeObjectForKey:@"html"];
-        
-            UIWebView *webView = [mdict valueForKey:@"webView"];
-            NSString* json = [LPJSONUtils serializeDictionary:mdict];
-            NSLog(@"script: %@",[NSString stringWithFormat:LP_SET_TEXT_JS, json,[_arguments objectAtIndex:0]]);
-            NSString* res = [webView stringByEvaluatingJavaScriptFromString:
-             [NSString stringWithFormat:LP_SET_TEXT_JS, json]
-             ];
-            NSLog(@"RESULT: %@", res);
-        
+
+- (id) performWithTarget:(id) _view error:(NSError **) error {
+  if ([_view isKindOfClass:[NSDictionary class]]) {
+    NSMutableDictionary *mdict = [NSMutableDictionary dictionaryWithDictionary:_view];
+    [mdict removeObjectForKey:@"html"];
+
+    UIWebView *webView = [mdict valueForKey:@"webView"];
+    NSString *json = [LPJSONUtils serializeDictionary:mdict];
+    NSLog(@"script: %@", [NSString stringWithFormat:LP_SET_TEXT_JS, json,
+                                                    [_arguments objectAtIndex:0]]);
+    NSString *res = [webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:LP_SET_TEXT_JS,
+                                                                                               json]];
+    NSLog(@"RESULT: %@", res);
+  } else if ([_view respondsToSelector:@selector(setText:)]) {
+    NSString *txt = nil;
+    id argument = [_arguments objectAtIndex:0];
+    if ([argument isKindOfClass:[NSString class]]) {
+      txt = argument;
+    } else {
+      txt = [argument description];
     }
-    else if ([_view respondsToSelector:@selector(setText:)]) 
-    {
-        NSString *txt = nil;
-        id argument = [_arguments objectAtIndex:0];
-        if ( [ argument isKindOfClass: [ NSString class ] ] ) {
-            txt = argument;
-        } else {
-            txt = [argument description];
-        }
-        [_view performSelector:@selector(setText:) withObject:txt];
-        return _view;
-    }
-    
-	return nil;
+    [_view performSelector:@selector(setText:) withObject:txt];
+    return _view;
+  }
+  return nil;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -9,12 +9,10 @@
 #import "LPSliderOperation.h"
 
 
-
-
 @implementation LPSliderOperation
 
 - (NSString *) description {
-    return [NSString stringWithFormat:@"Slider: %@",_arguments];
+  return [NSString stringWithFormat:@"Slider: %@", _arguments];
 }
 
 /*
@@ -25,61 +23,62 @@
 
 //    required =========> |     optional
 // _arguments ==> [value_st,  notify targets, animate]
-- (id) performWithTarget:(UIView*)_view error:(NSError **)error {
-    if ([_view isKindOfClass:[UISlider class]] == NO) {
-        NSLog(@"Warning view: %@ should be a UISlier", _view);
-        return nil;
-    }
-    
-    UISlider *slider = (UISlider *) _view;
-    
-    NSString *valueStr = _arguments[0];
-    if (valueStr == nil || [valueStr length] == 0) {
-        NSLog(@"Warning: value str: '%@' should be non-nil and non-empty", valueStr);
-        return nil;
-    }
-    
-    CGFloat targetValue = [valueStr floatValue];
-    
-    NSUInteger argcount = [_arguments count];
-    
-    
-    BOOL notifyTargets = YES;
-    if (argcount > 1) {
-        notifyTargets = [_arguments[1] boolValue];
-    }
-    
-    BOOL animate = YES;
-    if (argcount > 2) {
-        animate = [_arguments[2] boolValue];
-    }
-    
-    if (targetValue > [slider maximumValue]) {
-        NSLog(@"Warning: target value '%.2f' is greater than slider max value '%.2f' - will slide to max value",
-              targetValue, [slider maximumValue]);
-    }
-    
-    if (targetValue < [slider minimumValue]) {
-        NSLog(@"Warning: target value '%.2f' is less than slider min value '%.2f' - will slide to min value",
-              targetValue, [slider minimumValue]);
-    }
-    
-    [slider setValue:targetValue animated:animate];
-        
-    if (notifyTargets) {
-        NSSet *targets = [slider allTargets];
-        for (id target in targets) {
-            NSArray *actions = [slider actionsForTarget:target forControlEvent:UIControlEventValueChanged];
-            for (NSString *action in actions) {
-                SEL sel = NSSelectorFromString(action);
+- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+  if ([_view isKindOfClass:[UISlider class]] == NO) {
+    NSLog(@"Warning view: %@ should be a UISlier", _view);
+    return nil;
+  }
+
+  UISlider *slider = (UISlider *) _view;
+
+  NSString *valueStr = _arguments[0];
+  if (valueStr == nil || [valueStr length] == 0) {
+    NSLog(@"Warning: value str: '%@' should be non-nil and non-empty",
+            valueStr);
+    return nil;
+  }
+
+  CGFloat targetValue = [valueStr floatValue];
+
+  NSUInteger argcount = [_arguments count];
+
+  BOOL notifyTargets = YES;
+  if (argcount > 1) {
+    notifyTargets = [_arguments[1] boolValue];
+  }
+
+  BOOL animate = YES;
+  if (argcount > 2) {
+    animate = [_arguments[2] boolValue];
+  }
+
+  if (targetValue > [slider maximumValue]) {
+    NSLog(@"Warning: target value '%.2f' is greater than slider max value '%.2f' - will slide to max value",
+            targetValue, [slider maximumValue]);
+  }
+
+  if (targetValue < [slider minimumValue]) {
+    NSLog(@"Warning: target value '%.2f' is less than slider min value '%.2f' - will slide to min value",
+            targetValue, [slider minimumValue]);
+  }
+
+  [slider setValue:targetValue animated:animate];
+
+  if (notifyTargets) {
+    NSSet *targets = [slider allTargets];
+    for (id target in targets) {
+      NSArray *actions = [slider actionsForTarget:target
+                                  forControlEvent:UIControlEventValueChanged];
+      for (NSString *action in actions) {
+        SEL sel = NSSelectorFromString(action);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-                [target performSelector:sel withObject:slider];
+        [target performSelector:sel withObject:slider];
 #pragma clang diagnostic pop
-            }
-        }
+      }
     }
-    
-    return _view;
+  }
+
+  return _view;
 }
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPAppPropertyRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPAppPropertyRoute.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPAppPropertyRoute : NSObject<LPRoute>
+@interface LPAppPropertyRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPAppPropertyRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPAppPropertyRoute.m
@@ -7,60 +7,52 @@
 //
 
 #import "LPAppPropertyRoute.h"
-#import "LPJSONUtils.h"
 
 @implementation LPAppPropertyRoute
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"] ||[method isEqualToString:@"GET"];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"] || [method isEqualToString:@"GET"];
 }
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {
-    NSObject <UIApplicationDelegate> *delegate = [UIApplication sharedApplication].delegate;
 
-    NSString *key = [data valueForKey:@"key"];
 
-	@try {
-		id curVal = [delegate valueForKeyPath:key];
-		if ([method isEqualToString:@"POST"])
-		{
-			id val = [data valueForKey:@"value"];
-			id kval = val;
-			if ([val isKindOfClass:[NSNull class]])
-			{
-				kval = nil;
-			}
-			NSError *kerror;
-			if (!([delegate validateValue:&kval forKeyPath:key error:&kerror]))
-			{
-				return [NSDictionary dictionaryWithObjectsAndKeys:
-						@"FAILURE",@"outcome",
-						@"value is invalid", @"reason",
-						[kerror description], @"description",
-						nil];
-			}
-			[delegate setValue:kval forKeyPath:key];
-			
-			return [NSDictionary dictionaryWithObjectsAndKeys:
-					[NSArray arrayWithObjects:val,curVal, nil], @"results",
-					@"SUCCESS",@"outcome",
-					nil];
-			
-		}
-		else
-		{
-			return [NSDictionary dictionaryWithObjectsAndKeys:
-					[NSArray arrayWithObjects:curVal, nil], @"results",
-					@"SUCCESS",@"outcome",
-					nil];
-		}
-	}
-	@catch (NSException *exception) {
-		return [NSDictionary dictionaryWithObjectsAndKeys:
-				@"FAILURE",@"outcome",
-				[exception reason], @"reason",
-				@"", @"description",
-				nil];
-		
-	}
-    
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+  NSObject <UIApplicationDelegate> *delegate = [UIApplication sharedApplication].delegate;
+
+  NSString *key = [data valueForKey:@"key"];
+
+  @try {
+    id curVal = [delegate valueForKeyPath:key];
+    if ([method isEqualToString:@"POST"]) {
+      id val = [data valueForKey:@"value"];
+      id kval = val;
+      if ([val isKindOfClass:[NSNull class]]) {
+        kval = nil;
+      }
+      NSError *kerror;
+      if (!([delegate validateValue:&kval forKeyPath:key error:&kerror])) {
+        return [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                          @"value is invalid", @"reason",
+                                                          [kerror description], @"description",
+                                                          nil];
+      }
+      [delegate setValue:kval forKeyPath:key];
+
+      return [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObjects:val,
+                                                                                  curVal,
+                                                                                  nil], @"results",
+                                                        @"SUCCESS", @"outcome",
+                                                        nil];
+    } else {
+      return [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObjects:curVal,
+                                                                                  nil], @"results",
+                                                        @"SUCCESS", @"outcome",
+                                                        nil];
+    }
+  }
+  @catch (NSException *exception) {
+    return [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                      [exception reason], @"reason",
+                                                      @"", @"description", nil];
+  }
 }
+
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPAsyncPlaybackRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPAsyncPlaybackRoute.h
@@ -10,11 +10,10 @@
 #import "LPHTTPResponse.h"
 #import "LPGenericAsyncRoute.h"
 
-@interface LPAsyncPlaybackRoute : LPGenericAsyncRoute
-{    
-    NSArray *_events;    
+@interface LPAsyncPlaybackRoute : LPGenericAsyncRoute {
+  NSArray *_events;
 }
 
-@property (nonatomic, retain) NSArray *events;
+@property(nonatomic, retain) NSArray *events;
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPAsyncPlaybackRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPAsyncPlaybackRoute.m
@@ -7,198 +7,171 @@
 //
 
 #import "LPAsyncPlaybackRoute.h"
-#import "LPHTTPResponse.h"
 #import "LPHTTPConnection.h"
 #import "LPResources.h"
 #import "LPRecorder.h"
 #import "LPTouchUtils.h"
-#import "LPJSONUtils.h"
 #import "LPOperation.h"
 #import "UIAutomation.h"
 
 @class UIDevice;
 
-
 @implementation LPAsyncPlaybackRoute
-@synthesize events=_events;
+@synthesize events = _events;
 
 
-- (BOOL)isDone 
-{
-    return !self.events && [super isDone];
+- (BOOL) isDone {
+  return !self.events && [super isDone];
 }
 
 
+- (void) beginOperation {
+  self.done = NO;
+  NSString *base64Events = [self.data objectForKey:@"events"];
+  id query = [self.data objectForKey:@"query"];
+  UIView *targetView = nil;
+  if (query != nil) {
+    NSArray *result = [LPOperation performQuery:query];
 
--(void) beginOperation 
-{
-    self.done = NO;
-    NSString *base64Events = [self.data objectForKey:@"events"];
-    id query = [self.data objectForKey:@"query"];
-    UIView *targetView = nil;
-    if (query != nil) {
-        NSArray* result = [LPOperation performQuery:query];
-                           
-        
-        if ([result count] >0) {
-            id v = [result objectAtIndex:0];//autopick first?
-            
-            NSDictionary *offset = [self.data valueForKey:@"offset"];
-            NSNumber *x = [offset valueForKey:@"x"];
-            NSNumber *y = [offset valueForKey:@"y"];
-            
-        
-            
-            CGPoint offsetPoint = CGPointMake([x floatValue], [y floatValue]);
-            
-            CGPoint center;
-            if ([v isKindOfClass:[UIView class]]) 
-            {
-                center = [LPTouchUtils centerOfView:v];                
-            }
-            else                
-            {
-                
-                CGPointMakeWithDictionaryRepresentation((CFDictionaryRef)[v valueForKey:@"center"], &center);
-            }
-            
-            targetView = v;        
-            
-            NSArray* baseEvents = [LPResources eventsFromEncoding:base64Events];
-            
-            
-            self.events = [LPResources transformEvents:baseEvents 
-                                               toPoint:CGPointMake(center.x+offsetPoint.x, center.y+offsetPoint.y)];
-            
-            
-            
-            
-            
-        } else {
-            NSLog(@"query %@ found no views. NO-OP.",query);
-            self.done = YES;
-            self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                    [NSString stringWithFormat: @"query %@ found no views. Is accessibility enabled?",query],@"reason",
-                    @"",@"details",
-                    @"FAILURE",@"outcome",
-                    nil];
-            self.events = nil;
-            [self.conn responseHasAvailableData:self];
-            return;
-        }
-    
-        
+
+    if ([result count] > 0) {
+      id v = [result objectAtIndex:0];//autopick first?
+
+      NSDictionary *offset = [self.data valueForKey:@"offset"];
+      NSNumber *x = [offset valueForKey:@"x"];
+      NSNumber *y = [offset valueForKey:@"y"];
+
+      CGPoint offsetPoint = CGPointMake([x floatValue], [y floatValue]);
+
+      CGPoint center;
+      if ([v isKindOfClass:[UIView class]]) {
+        center = [LPTouchUtils centerOfView:v];
+      } else {
+
+        CGPointMakeWithDictionaryRepresentation(
+                (CFDictionaryRef) [v valueForKey:@"center"], &center);
+      }
+
+      targetView = v;
+
+      NSArray *baseEvents = [LPResources eventsFromEncoding:base64Events];
+
+
+      self.events = [LPResources transformEvents:baseEvents toPoint:CGPointMake(
+              center.x + offsetPoint.x, center.y + offsetPoint.y)];
     } else {
-        NSDictionary *offset = [self.data valueForKey:@"offset"];
-        NSNumber *x = [offset valueForKey:@"x"];
-        NSNumber *y = [offset valueForKey:@"y"];
-        
-        CGPoint offsetPoint = CGPointMake([x floatValue], [y floatValue]);
-        self.events = [LPResources eventsFromEncoding:base64Events];
-        if (!self.events || [self.events count] < 1) {
-            NSLog(@"BAD EVENTS: %@", base64Events);
-            self.done = YES;
-            self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                                 [NSString stringWithFormat: @"Bad events %@",base64Events],@"reason",
-                                 @"",@"details",
-                                 @"FAILURE",@"outcome",
-                                 nil];
-            return;
+      NSLog(@"query %@ found no views. NO-OP.", query);
+      self.done = YES;
+      self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"query %@ found no views. Is accessibility enabled?",
+                                                                                                query], @"reason",
+                                                                     @"", @"details",
+                                                                     @"FAILURE", @"outcome",
+                                                                     nil];
+      self.events = nil;
+      [self.conn responseHasAvailableData:self];
+      return;
+    }
+  } else {
+    NSDictionary *offset = [self.data valueForKey:@"offset"];
+    NSNumber *x = [offset valueForKey:@"x"];
+    NSNumber *y = [offset valueForKey:@"y"];
+
+    CGPoint offsetPoint = CGPointMake([x floatValue], [y floatValue]);
+    self.events = [LPResources eventsFromEncoding:base64Events];
+    if (!self.events || [self.events count] < 1) {
+      NSLog(@"BAD EVENTS: %@", base64Events);
+      self.done = YES;
+      self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Bad events %@",
+                                                                                                base64Events], @"reason",
+                                                                     @"", @"details",
+                                                                     @"FAILURE", @"outcome",
+                                                                     nil];
+      return;
+    }
+    if (offset) {
+      NSDictionary *firstEvent = [self.events objectAtIndex:0];
+      NSDictionary *windowLoc = [firstEvent valueForKey:@"WindowLocation"];
+      if (windowLoc == nil || [[firstEvent valueForKey:@"Type"]
+              integerValue] == 50) {
+        NSLog(@"Offset for non window located event: %@", firstEvent);
+        self.done = YES;
+        self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Offset for non window located event: %@",
+                                                                                                  firstEvent], @"reason",
+                                                                       @"", @"details",
+                                                                       @"FAILURE", @"outcome",
+                                                                       nil];
+        return;
+      }
+
+      NSArray *transformed = [LPResources transformEvents:self.events
+                                                  toPoint:CGPointMake(
+                                                          offsetPoint.x,
+                                                          offsetPoint.y)];
+      if ([transformed count] == [self.events count]) {
+        self.events = transformed;
+      }
+    }
+  }
+
+  if ([self.data objectForKey:@"reverse"]) {
+    self.events = [[_events reverseObjectEnumerator] allObjects];
+  }
+  //NSLog(@"PLAY Events:\n%@",self.events);
+  NSDictionary *firstEvent = [self.events objectAtIndex:0];
+  NSDictionary *windowLoc = [firstEvent valueForKey:@"WindowLocation"];
+
+  if (!targetView && windowLoc != nil) {
+    CGPoint touchPoint = CGPointMake([[windowLoc valueForKey:@"X"] floatValue],
+            [[windowLoc valueForKey:@"Y"] floatValue]);
+    for (UIWindow *window in [LPTouchUtils applicationWindows]) {
+      if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen]) {
+        targetView = [window hitTest:touchPoint withEvent:nil];
+        break;
+      }
+    }
+  }
 
 
-        }
-        if (offset)
-        {
-            NSDictionary *firstEvent = [self.events objectAtIndex:0];
-            NSDictionary* windowLoc = [firstEvent valueForKey:@"WindowLocation"];
-            if (windowLoc == nil || [[firstEvent valueForKey:@"Type"] integerValue] == 50) {
-                NSLog(@"Offset for non window located event: %@", firstEvent);
-                self.done = YES;
-                self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                                     [NSString stringWithFormat: @"Offset for non window located event: %@", firstEvent],@"reason",
-                                     @"",@"details",
-                                     @"FAILURE",@"outcome",
-                                     nil];
-                return;
-            }
-            
-            NSArray* transformed = [LPResources transformEvents:self.events 
-                                                        toPoint:CGPointMake(offsetPoint.x, offsetPoint.y)];
-            if ([transformed count] == [self.events count]) {
-                self.events = transformed;
-            }
-        }
-        
-    }
-    
-    if ([self.data objectForKey:@"reverse"]) {
-        self.events = [[_events reverseObjectEnumerator] allObjects];
-    }
-    //NSLog(@"PLAY Events:\n%@",self.events);    
-    NSDictionary *firstEvent = [self.events objectAtIndex:0];
-    NSDictionary* windowLoc = [firstEvent valueForKey:@"WindowLocation"];
-        
-    if (!targetView && windowLoc != nil) {
-        CGPoint touchPoint = CGPointMake([[windowLoc valueForKey:@"X"] floatValue], 
-                                         [[windowLoc valueForKey:@"Y"] floatValue]);
-        for (UIWindow *window in [LPTouchUtils applicationWindows]) {
-           if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen]) {
-                targetView = [window hitTest:touchPoint withEvent:nil];
-                break;
-           }
-        }
-            
-    }        
-    
-    
 //    NSString *base64Prototype = [self.data objectForKey:@"prototype"];
 //    if (base64Prototype) {
 //        NSArray* protoEvents = [LPResources eventsFromEncoding:base64Prototype];
-//        
+//
 //        NSLog(@"Prototype Events\n%@",protoEvents);
-//        
-        
+//
 //    }
-    
-    [self play:self.events];
-    NSArray *resultArray = nil;
-    if (targetView == nil) {
-        resultArray = [NSArray array];
-    } else {
-        resultArray = [NSArray arrayWithObject:targetView];
-    }
-    
-    self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-            resultArray, @"results",
-            @"SUCCESS",@"outcome",
-            nil];
 
+  [self play:self.events];
+  NSArray *resultArray = nil;
+  if (targetView == nil) {
+    resultArray = [NSArray array];
+  } else {
+    resultArray = [NSArray arrayWithObject:targetView];
+  }
 
+  self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:resultArray, @"results",
+                                                                 @"SUCCESS", @"outcome",
+                                                                 nil];
 }
 
 
-
-
-- (void) play:(NSArray *)events 
-{
-    [[LPRecorder sharedRecorder] load: self.events];
-    [[LPRecorder sharedRecorder] playbackWithDelegate: self doneSelector: @selector(playbackDone:)];
-    
+- (void) play:(NSArray *) events {
+  [[LPRecorder sharedRecorder] load:self.events];
+  [[LPRecorder sharedRecorder]
+          playbackWithDelegate:self doneSelector:@selector(playbackDone:)];
 }
+
 
 //When this event occurs, jsonResponse has already been determined.
--(void) playbackDone:(NSDictionary *)details 
-{
-    self.done = YES;
-    self.events = nil;
-    [self.conn responseHasAvailableData:self];
+- (void) playbackDone:(NSDictionary *) details {
+  self.done = YES;
+  self.events = nil;
+  [self.conn responseHasAvailableData:self];
 }
 
 
--(void) dealloc 
-{
-    self.events = nil;    
-    [super dealloc];
+- (void) dealloc {
+  self.events = nil;
+  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPBackdoorRoute : NSObject<LPRoute>
+@interface LPBackdoorRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -10,54 +10,61 @@
 
 @implementation LPBackdoorRoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
 }
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data
-{
-    NSString *originalSelStr = [data objectForKey:@"selector"];
-    NSString *selStr = originalSelStr;
-    if (![originalSelStr hasSuffix:@":"]) {
-        selStr = [selStr stringByAppendingString:@":"];
-    }
 
-    SEL sel = NSSelectorFromString(selStr);
-    
-    if ([[[UIApplication sharedApplication] delegate] respondsToSelector:sel]) {
-        id arg = [data objectForKey:@"arg"];
-        id res = [[[UIApplication sharedApplication] delegate] performSelector:sel withObject:arg];
-        if (!res) { res = [NSNull null]; }
-        return [NSDictionary dictionaryWithObjectsAndKeys:
-                res , @"result",
-                @"SUCCESS",@"outcome",
-                nil];
-    } else {
 
-      NSString *details = [NSString stringWithFormat:@"you must define the selector '%@' in your UIApplicationDelegate.",
-                           selStr];
-      NSString *exDecl0 = @"// declaration";
-      NSString *exDecl1 = [NSString stringWithFormat:@"-(id)%@ (id)arg;", selStr];
-      NSString *exImp0 = @"// implementation";
-      NSString *exImp1 = [NSString stringWithFormat:@"-(id)%@ (id)anArg {", selStr ];
-      NSString *exImp2 = [NSString stringWithFormat:@"  // do custom stuff"];
-      NSString *exImp3 = [NSString stringWithFormat:@"  // return examples"];
-      NSString *exImp4 = [NSString stringWithFormat:@"  return @\"OK\";"];
-      NSString *exImp5 = [NSString stringWithFormat:@"  return [NSArray arrayWithObjects:@\"a\",@\"b\",nil];"];
-      NSString *exImp6 = [NSString stringWithFormat:@"  return nil;"];
-      NSString *exImp7 = [NSString stringWithFormat:@"}"];
-      NSString *usage0 = [NSString stringWithFormat:@"// Ruby usage"];
-      NSString *usage1 = [NSString stringWithFormat:@"backdoor('%@', '<arg>')", selStr];
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+  NSString *originalSelStr = [data objectForKey:@"selector"];
+  NSString *selStr = originalSelStr;
+  if (![originalSelStr hasSuffix:@":"]) {
+    selStr = [selStr stringByAppendingString:@":"];
+  }
 
-      NSArray *exArr = [NSArray arrayWithObjects:details, @"\n", exDecl0, exDecl1, @"\n", exImp0, exImp1, exImp2, exImp3, exImp4, exImp5, exImp6, exImp7, @"\n", usage0, usage1, nil];
-      NSString *detailsStr = [exArr componentsJoinedByString:@"\n"];
+  SEL sel = NSSelectorFromString(selStr);
 
-      NSString *reasonStr = [NSString stringWithFormat:@"application delegate does not respond to selector '%@'",
-                             selStr];
-        return [NSDictionary dictionaryWithObjectsAndKeys:
-                detailsStr, @"details",
-                reasonStr, @"reason",
-                @"FAILURE", @"outcome", nil];
-    }
+  if ([[[UIApplication sharedApplication] delegate] respondsToSelector:sel]) {
+    id arg = [data objectForKey:@"arg"];
+    id res = [[[UIApplication sharedApplication] delegate]
+            performSelector:sel withObject:arg];
+    if (!res) {res = [NSNull null];}
+    return [NSDictionary dictionaryWithObjectsAndKeys:res, @"result",
+                                                      @"SUCCESS", @"outcome",
+                                                      nil];
+  } else {
+
+    NSString *details = [NSString stringWithFormat:@"you must define the selector '%@' in your UIApplicationDelegate.",
+                                                   selStr];
+    NSString *exDecl0 = @"// declaration";
+    NSString *exDecl1 = [NSString stringWithFormat:@"-(id)%@ (id)arg;", selStr];
+    NSString *exImp0 = @"// implementation";
+    NSString *exImp1 = [NSString stringWithFormat:@"-(id)%@ (id)anArg {",
+                                                  selStr];
+    NSString *exImp2 = [NSString stringWithFormat:@"  // do custom stuff"];
+    NSString *exImp3 = [NSString stringWithFormat:@"  // return examples"];
+    NSString *exImp4 = [NSString stringWithFormat:@"  return @\"OK\";"];
+    NSString *exImp5 = [NSString stringWithFormat:@"  return [NSArray arrayWithObjects:@\"a\",@\"b\",nil];"];
+    NSString *exImp6 = [NSString stringWithFormat:@"  return nil;"];
+    NSString *exImp7 = [NSString stringWithFormat:@"}"];
+    NSString *usage0 = [NSString stringWithFormat:@"// Ruby usage"];
+    NSString *usage1 = [NSString stringWithFormat:@"backdoor('%@', '<arg>')",
+                                                  selStr];
+
+    NSArray *exArr = [NSArray arrayWithObjects:details, @"\n", exDecl0, exDecl1,
+                                               @"\n", exImp0, exImp1, exImp2,
+                                               exImp3, exImp4, exImp5, exImp6,
+                                               exImp7, @"\n", usage0, usage1,
+                                               nil];
+    NSString *detailsStr = [exArr componentsJoinedByString:@"\n"];
+
+    NSString *reasonStr = [NSString stringWithFormat:@"application delegate does not respond to selector '%@'",
+                                                     selStr];
+    return [NSDictionary dictionaryWithObjectsAndKeys:detailsStr, @"details",
+                                                      reasonStr, @"reason",
+                                                      @"FAILURE", @"outcome",
+                                                      nil];
+  }
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.h
@@ -9,15 +9,14 @@
 #import "LPRoute.h"
 #import "LPHTTPResponse.h"
 #import "LPGenericAsyncRoute.h"
-@interface LPConditionRoute : LPGenericAsyncRoute
-{    
-    NSTimer *_timer;    
+
+@interface LPConditionRoute : LPGenericAsyncRoute {
+  NSTimer *_timer;
 }
 
-@property (nonatomic, retain) NSTimer *timer;
-@property (nonatomic, assign) NSInteger maxCount;
-@property (nonatomic, assign) NSInteger curCount;
-
+@property(nonatomic, retain) NSTimer *timer;
+@property(nonatomic, assign) NSInteger maxCount;
+@property(nonatomic, assign) NSInteger curCount;
 
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -1,4 +1,3 @@
-
 //
 //  LPConditionRoute.m
 //  calabash
@@ -8,138 +7,111 @@
 //
 
 #import "LPConditionRoute.h"
-#import "LPHTTPResponse.h"
-#import "LPHTTPConnection.h"
-#import "LPResources.h"
-#import "LPRecorder.h"
 #import "LPOperation.h"
-#import "LPTouchUtils.h"
-#import "LPJSONUtils.h"
-#import <QuartzCore/QuartzCore.h>
 
 
 @implementation LPConditionRoute
-@synthesize timer=_timer;
+@synthesize timer = _timer;
 @synthesize maxCount;
 @synthesize curCount;
 
 
-
 // Should only return YES after the LPHTTPConnection has read all available data.
-- (BOOL)isDone
-{
-    return !self.timer && [super isDone];
+- (BOOL) isDone {
+  return !self.timer && [super isDone];
 }
 
--(void) beginOperation {
-    self.done = NO;
-    NSString *condition = [self.data objectForKey:@"condition"];
-    if (!condition)
-    {
-        NSLog(@"condition not specified");
-        [self failWithMessageFormat: @"condition parameter missing" message:nil];
-        return;
-    }
-    NSNumber *count = [self.data objectForKey:@"count"];
-    if (!count)
-    {
-        count = [NSNumber numberWithInt:1];
-    }
-    if ([count integerValue] <= 0)
-    {
-        [self failWithMessageFormat: @"Count should be positive..." message:nil];
-        return;
-    }
-    self.maxCount = [count integerValue];
-    self.curCount = 0;
-    NSNumber *freq = [self.data objectForKey:@"frequency"];
-    if (!freq)
-    {
-        freq = [NSNumber numberWithDouble:0.2];
-    }
-    
-    
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:[freq doubleValue]
-                                                  target:self
-                                                selector:@selector(checkConditionWithTimer:)
-                                                userInfo:nil repeats:YES];
-    [self checkConditionWithTimer:self.timer];
-    
-    
+
+- (void) beginOperation {
+  self.done = NO;
+  NSString *condition = [self.data objectForKey:@"condition"];
+  if (!condition) {
+    NSLog(@"condition not specified");
+    [self failWithMessageFormat:@"condition parameter missing" message:nil];
+    return;
+  }
+  NSNumber *count = [self.data objectForKey:@"count"];
+  if (!count) {
+    count = [NSNumber numberWithInt:1];
+  }
+  if ([count integerValue] <= 0) {
+    [self failWithMessageFormat:@"Count should be positive..." message:nil];
+    return;
+  }
+  self.maxCount = [count integerValue];
+  self.curCount = 0;
+  NSNumber *freq = [self.data objectForKey:@"frequency"];
+  if (!freq) {
+    freq = [NSNumber numberWithDouble:0.2];
+  }
+
+
+  self.timer = [NSTimer scheduledTimerWithTimeInterval:[freq doubleValue]
+                                                target:self
+                                              selector:@selector(checkConditionWithTimer:)
+                                              userInfo:nil repeats:YES];
+  [self checkConditionWithTimer:self.timer];
 }
--(void)checkConditionWithTimer:(NSTimer *)aTimer
-{
-    self.curCount += 1;
-    NSString *condition = [self.data objectForKey:@"condition"];
-    if ([condition isEqualToString:@"NONE_ANIMATING"])
-    {
-        
-        id query = [self.data objectForKey:@"query"];
-        if (query)
-        {
-            NSArray* result = [LPOperation performQuery:query];
-            for (id v in result)
-            {
-                if ([v isKindOfClass:[UIView class]])
-                {
-                    UIView *view = (UIView *)v;
-                    if ([[view.layer animationKeys] count] > 0)
-                    {
-                        [self failWithMessageFormat:@"Found animating view: %@" message:v];
-                        return;
-                    }
-                }
-            }
-            if (self.curCount == self.maxCount)
-            {
-                [self succeedWithResult:[NSArray array]];
-            }
-        }
-        else
-        {
-            [self failWithMessageFormat:@"No query specified." message:nil];
+
+
+- (void) checkConditionWithTimer:(NSTimer *) aTimer {
+  self.curCount += 1;
+  NSString *condition = [self.data objectForKey:@"condition"];
+  if ([condition isEqualToString:@"NONE_ANIMATING"]) {
+
+    id query = [self.data objectForKey:@"query"];
+    if (query) {
+      NSArray *result = [LPOperation performQuery:query];
+      for (id v in result) {
+        if ([v isKindOfClass:[UIView class]]) {
+          UIView *view = (UIView *) v;
+          if ([[view.layer animationKeys] count] > 0) {
+            [self failWithMessageFormat:@"Found animating view: %@" message:v];
             return;
+          }
         }
-        
-        return;
-        
+      }
+      if (self.curCount == self.maxCount) {
+        [self succeedWithResult:[NSArray array]];
+      }
+    } else {
+      [self failWithMessageFormat:@"No query specified." message:nil];
+      return;
     }
-    else if ([condition isEqualToString:@"NO_NETWORK_INDICATOR"])
-    {
-        if ([[UIApplication sharedApplication] isNetworkActivityIndicatorVisible])
-        {
-            [self failWithMessageFormat:@"Network activity indicator visible" message:nil];
-            return;
-        }
-        if (self.curCount == self.maxCount)
-        {
-            [self succeedWithResult:[NSArray array]];
-        }
-        return;
-        
+
+    return;
+  } else if ([condition isEqualToString:@"NO_NETWORK_INDICATOR"]) {
+    if ([[UIApplication sharedApplication] isNetworkActivityIndicatorVisible]) {
+      [self failWithMessageFormat:@"Network activity indicator visible"
+                          message:nil];
+      return;
     }
-    [self failWithMessageFormat:@"Unknown condition %@" message:condition];
-    
+    if (self.curCount == self.maxCount) {
+      [self succeedWithResult:[NSArray array]];
+    }
+    return;
+  }
+  [self failWithMessageFormat:@"Unknown condition %@" message:condition];
 }
 
--(void)failWithMessageFormat:(NSString *)messageFmt message:(NSString *)message
-{
-    [self.timer invalidate];
-    self.timer = nil;
-    [super failWithMessageFormat:messageFmt message:message];
+
+- (void) failWithMessageFormat:(NSString *) messageFmt message:(NSString *) message {
+  [self.timer invalidate];
+  self.timer = nil;
+  [super failWithMessageFormat:messageFmt message:message];
 }
 
--(void)succeedWithResult:(NSArray *)result
-{
-    [self.timer invalidate];
-    self.timer = nil;
-    [super succeedWithResult:result];
+
+- (void) succeedWithResult:(NSArray *) result {
+  [self.timer invalidate];
+  self.timer = nil;
+  [super succeedWithResult:result];
 }
 
--(void) dealloc
-{
-    self.timer = nil;
-    [super dealloc];
+
+- (void) dealloc {
+  self.timer = nil;
+  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPDebugRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPDebugRoute.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPDebugRoute : NSObject<LPRoute>
+@interface LPDebugRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPDebugRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPDebugRoute.m
@@ -11,30 +11,25 @@
 
 @implementation LPDebugRoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
   return [method isEqualToString:@"GET"] || [method isEqualToString:@"POST"];
 }
 
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method
-                                    URI:(NSString *)path
-                                   data:(NSDictionary*)data
-{
-    NSDictionary *resultDict = nil;
-    if ([method isEqualToString:@"POST"])
-    {
-        NSString *requiredLogLevel = [data valueForKey:@"level"];
-        [LPLog setLevelFromString: requiredLogLevel];
-        resultDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                      [NSArray arrayWithObject:[LPLog currentLevelString]] , @"results",
-                      @"SUCCESS",@"outcome",
-                      nil];
-        
-    }
-    
-    return [NSDictionary dictionaryWithObjectsAndKeys:
-             [NSArray arrayWithObject:[LPLog currentLevelString]] , @"results",
-             @"SUCCESS",@"outcome",
-            nil];
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+  NSDictionary *resultDict = nil;
+  if ([method isEqualToString:@"POST"]) {
+    NSString *requiredLogLevel = [data valueForKey:@"level"];
+    [LPLog setLevelFromString:requiredLogLevel];
+    resultDict = [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObject:[LPLog currentLevelString]], @"results",
+                                                            @"SUCCESS", @"outcome",
+                                                            nil];
+    // todo result dictionary is never used in LPDebugRoute
+  }
+
+  return [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObject:[LPLog currentLevelString]], @"results",
+                                                    @"SUCCESS", @"outcome",
+                                                    nil];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPExitRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPExitRoute.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPExitRoute : NSObject<LPRoute>
+@interface LPExitRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPExitRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPExitRoute.m
@@ -10,13 +10,12 @@
 
 @implementation LPExitRoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
   return [method isEqualToString:@"GET"] || [method isEqualToString:@"POST"];
 }
 
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method
-                                    URI:(NSString *)path
-                                   data:(NSDictionary*)data {
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
   // Exiting the app causes the HTTP connection to shutdown immediately.
   // Clients will get an empty response and need to handle the error
   // condition accordingly.

--- a/calabash/Classes/FranklyServer/Routes/LPGenericAsyncRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPGenericAsyncRoute.h
@@ -8,25 +8,27 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 #import "LPHTTPResponse.h"
-@interface LPGenericAsyncRoute : NSObject<LPRoute,LPHTTPResponse> 
-{    
-    BOOL _done;
-    LPHTTPConnection *_conn;
-    NSDictionary *_data;
-    NSDictionary *_jsonResponse;
-    NSData *_bytes;
-    
+
+@interface LPGenericAsyncRoute : NSObject <LPRoute, LPHTTPResponse> {
+  BOOL _done;
+  LPHTTPConnection *_conn;
+  NSDictionary *_data;
+  NSDictionary *_jsonResponse;
+  NSData *_bytes;
 }
 
-@property (nonatomic, assign) BOOL done;
-@property (nonatomic, assign) LPHTTPConnection *conn;
-@property (nonatomic, retain) NSDictionary *data;
-@property (nonatomic, retain) NSDictionary *jsonResponse;
+@property(nonatomic, assign) BOOL done;
+@property(nonatomic, assign) LPHTTPConnection *conn;
+@property(nonatomic, retain) NSDictionary *data;
+@property(nonatomic, retain) NSDictionary *jsonResponse;
 
--(void)beginOperation;
-- (BOOL)isDone;
--(void)failWithMessageFormat:(NSString *)messageFmt message:(NSString *)message;
--(void)succeedWithResult:(NSArray *)result;
+- (void) beginOperation;
+
+- (BOOL) isDone;
+
+- (void) failWithMessageFormat:(NSString *) messageFmt message:(NSString *) message;
+
+- (void) succeedWithResult:(NSArray *) result;
 
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPGenericAsyncRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPGenericAsyncRoute.m
@@ -7,83 +7,79 @@
 //
 
 #import "LPGenericAsyncRoute.h"
-#import "LPHTTPResponse.h"
 #import "LPHTTPConnection.h"
-#import "LPResources.h"
-#import "LPRecorder.h"
-#import "LPTouchUtils.h"
 #import "LPJSONUtils.h"
 
 
 @implementation LPGenericAsyncRoute
-@synthesize done=_done;
-@synthesize conn=_conn;
-@synthesize data=_data;
-@synthesize jsonResponse=_jsonResponse;
+@synthesize done = _done;
+@synthesize conn = _conn;
+@synthesize data = _data;
+@synthesize jsonResponse = _jsonResponse;
 
--(id) init 
-{
-    self = [super init];
-    if (self) 
-    {
-        _bytes = nil;
-    }
-    return self;
+
+- (id) init {
+  self = [super init];
+  if (self) {
+    _bytes = nil;
+  }
+  return self;
 }
 
-- (UInt64)offset {return 0;}
-- (void)setOffset:(UInt64)offset {
-    //this is not handled - we know our client wont use range requests
+
+- (UInt64) offset {return 0;}
+
+
+- (void) setOffset:(UInt64) offset {
+  //this is not handled - we know our client wont use range requests
 }
 
 
 // Returns the length of the data in bytes.
 // If you don't know the length in advance, implement the isChunked method and have it return YES.
-- (UInt64)contentLength {
-    return -1;
+- (UInt64) contentLength {
+  // todo suspicious conversion of UInt64 to -1 in LPGenericAsync
+  return -1;
 }
+
+
 // Important: You should read the discussion at the bottom of this header.
-- (BOOL)isChunked {
-    return YES;
+- (BOOL) isChunked {
+  return YES;
 }
+
 
 // To support asynchronous responses, read the discussion at the bottom of this header.
-- (NSData *)readDataOfLength:(NSUInteger)length {
-    if (!self.done) 
-    {
-        [self beginOperation]; 
-        return nil;//Data generated async.
+- (NSData *) readDataOfLength:(NSUInteger) length {
+  if (!self.done) {
+    [self beginOperation];
+    return nil;//Data generated async.
+  } else {//done is set to YES only after events and jsonResponse is set (playbackDone)
+    if (!_bytes) {
+      NSString *serialized = [LPJSONUtils serializeDictionary:self.jsonResponse];
+      self.jsonResponse = nil;
+      _bytes = [serialized dataUsingEncoding:NSUTF8StringEncoding];
     }
-    else {//done is set to YES only after events and jsonResponse is set (playbackDone)
-        if (!_bytes) 
-        {
-            NSString* serialized = [LPJSONUtils serializeDictionary:self.jsonResponse];
-            self.jsonResponse = nil;
-            _bytes = [serialized dataUsingEncoding:NSUTF8StringEncoding];    
-        }
-        if (length >= [_bytes length]) 
-        {
-            return _bytes;
-        } 
-        else 
-        {//length < [_bytes length]
-            NSData *toReturn = [_bytes subdataWithRange:NSMakeRange(0, length)];
-            _bytes = [_bytes subdataWithRange:NSMakeRange(length, _bytes.length - length)];//the rest
-            return toReturn;
-        }                
+    if (length >= [_bytes length]) {
+      return _bytes;
+    } else {//length < [_bytes length]
+      NSData *toReturn = [_bytes subdataWithRange:NSMakeRange(0, length)];
+      _bytes = [_bytes subdataWithRange:NSMakeRange(length,
+              _bytes.length - length)];//the rest
+      return toReturn;
     }
+  }
 }
+
 
 //Abstract
--(void)beginOperation
-{
-    
+- (void) beginOperation {
 }
 
+
 // Should only return YES after the LPHTTPConnection has read all available data.
-- (BOOL)isDone 
-{
-    return _done && !self.jsonResponse;
+- (BOOL) isDone {
+  return _done && !self.jsonResponse;
 }
 
 
@@ -91,74 +87,72 @@
 // or when the connection is finished with the response.
 // If your response is asynchronous, you should implement this method so you can be sure not to
 // invoke LPHTTPConnection's responseHasAvailableData method after this method is called.
-- (void)connectionDidClose 
-{
-    self.conn = nil;
+- (void) connectionDidClose {
+  self.conn = nil;
 }
 
--(void)failWithMessageFormat:(NSString *)messageFmt message:(NSString *)message
-{
-    self.done = YES;
-    NSString *msg = !message ? messageFmt : [NSString stringWithFormat: messageFmt,message];
-    
-    self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                         msg,@"reason",
-                         @"",@"details",
-                         @"FAILURE",@"outcome",
-                         nil];
-    [self.conn responseHasAvailableData:self];
+
+- (void) failWithMessageFormat:(NSString *) messageFmt message:(NSString *) message {
+  self.done = YES;
+  NSString *msg = !message ? messageFmt : [NSString stringWithFormat:messageFmt,
+                                                                     message];
+
+  self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:msg, @"reason",
+                                                                 @"", @"details",
+                                                                 @"FAILURE", @"outcome",
+                                                                 nil];
+  [self.conn responseHasAvailableData:self];
 }
--(void)succeedWithResult:(NSArray *)result
-{
-    self.done = YES;
-    self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                         result, @"results",
-                         @"SUCCESS",@"outcome",
-                         nil];
-    [self.conn responseHasAvailableData:self];
+
+
+- (void) succeedWithResult:(NSArray *) result {
+  self.done = YES;
+  self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:result, @"results",
+                                                                 @"SUCCESS", @"outcome",
+                                                                 nil];
+  [self.conn responseHasAvailableData:self];
 }
 
 
 // Callbacks from router.
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path 
-{
-    return [method isEqualToString:@"POST"];
-}
-
--(void) setConnection:(LPHTTPConnection *)connection
-{
-    self.conn = connection;
-}
--(void) setParameters:(NSDictionary *) params 
-{
-    self.data = params;
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
 }
 
 
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path 
-{    
-    id route = [[[[self class] alloc] init] autorelease];
-    [route setParameters:self.data];
-    [route setConnection:self.conn];
-    self.data = nil;
-    self.conn = nil;
-    return route;
+- (void) setConnection:(LPHTTPConnection *) connection {
+  self.conn = connection;
 }
 
--(void) dealloc 
-{
-    self.data = nil;
-    self.conn = nil;
-    _bytes = nil;
-    self.jsonResponse = nil;
-    [super dealloc];
+
+- (void) setParameters:(NSDictionary *) params {
+  self.data = params;
+}
+
+
+- (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
+  id route = [[[[self class] alloc] init] autorelease];
+  [route setParameters:self.data];
+  [route setConnection:self.conn];
+  self.data = nil;
+  self.conn = nil;
+  return route;
+}
+
+
+- (void) dealloc {
+  self.data = nil;
+  self.conn = nil;
+  _bytes = nil;
+  self.jsonResponse = nil;
+  [super dealloc];
 }
 
 @end
 
 //From CocoaHTTPServer
 // Important notice to those implementing custom asynchronous and/or chunked responses:
-// 
+//
 // LPHTTPConnection supports asynchronous responses.  All you have to do in your custom response class is
 // asynchronously generate the response, and invoke LPHTTPConnection's responseHasAvailableData method.
 // You don't have to wait until you have all of the response ready to invoke this method.  For example, if you
@@ -166,29 +160,29 @@
 // each chunk.  You MUST invoke the responseHasAvailableData method on the proper thread/runloop.  That is,
 // the thread/runloop that the LPHTTPConnection is operating in.  Please see the LPHTTPAsyncFileResponse class
 // for an example of how to properly do this.
-// 
+//
 // The normal flow of events for an LPHTTPConnection while responding to a request is like this:
 // - Get data from response via readDataOfLength method.
 // - Add data to asyncSocket's write queue.
 // - Wait for asyncSocket to notify it that the data has been sent.
 // - Get more data from response via readDataOfLength method.
 // ... continue this cycle until it has sent the entire response.
-// 
+//
 // With an asynchronous response, the flow is a little different.  When LPHTTPConnection calls your
 // readDataOfLength method, you may or may not have any available data.  If you don't, then simply return nil.
 // You should later invoke LPHTTPConnection's responseHasAvailableData when you have data to send.
-// 
+//
 // You don't have to keep track of when you return nil in the readDataOfLength method, or how many times you've invoked
 // responseHasAvailableData. Just simply call responseHasAvailableData whenever you've generated new data, and
 // return nil in your readDataOfLength whenever you don't have any available data in the requested range.
 // LPHTTPConnection will automatically detect when it should be requesting new data and will act appropriately.
-// 
+//
 // It's important that you also keep in mind that the LPHTTP server supports range requests.
 // The setOffset method is mandatory, and should not be ignored.
 // Make sure you take into account the offset within the readDataOfLength method.
 // You should also be aware that the LPHTTPConnection automatically sorts any range requests.
 // So if your setOffset method is called with a value of 100, then you can safely release bytes 0-98.
-// 
+//
 // LPHTTPConnection can also help you keep your memory footprint small.
 // Imagine you're dynamically generating a 10 MB response.  You probably don't want to load all this data into
 // RAM, and sit around waiting for LPHTTPConnection to slowly send it out over the network.  All you need to do
@@ -196,7 +190,7 @@
 // will never allow asyncSocket's write queue to get much bigger than READ_CHUNKSIZE bytes.  You should
 // consider how you might be able to take advantage of this fact to generate your asynchronous response on demand,
 // while at the same time keeping your memory footprint small, and your application lightning fast.
-// 
+//
 // If you don't know the content-length in advanced, you should also implement the isChunked method.
 // This means the response will not include a Content-Length header, and will instead use "Transfer-Encoding: chunked".
 // There's a good chance that if your response is asynchronous and dynamic, it's also chunked.

--- a/calabash/Classes/FranklyServer/Routes/LPInterpolateRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPInterpolateRoute.h
@@ -11,12 +11,12 @@
 #import "LPHTTPResponse.h"
 #import "LPGenericAsyncRoute.h"
 
-@interface LPInterpolateRoute : LPGenericAsyncRoute
-{    
-    NSArray *_events;
+@interface LPInterpolateRoute : LPGenericAsyncRoute {
+  NSArray *_events;
 }
 
-@property (nonatomic, retain) NSArray *events;
-@property (nonatomic, retain) UIScriptParser *parser1;
-@property (nonatomic, retain) UIScriptParser *parser2;
+@property(nonatomic, retain) NSArray *events;
+@property(nonatomic, retain) UIScriptParser *parser1;
+@property(nonatomic, retain) UIScriptParser *parser2;
+
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPInterpolateRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPInterpolateRoute.m
@@ -7,153 +7,137 @@
 //
 
 #import "LPAsyncPlaybackRoute.h"
-#import "LPHTTPResponse.h"
 #import "LPHTTPConnection.h"
 #import "LPResources.h"
 #import "LPRecorder.h"
 #import "UIScriptParser.h"
 #import "LPTouchUtils.h"
-#import "LPJSONUtils.h"
 #import "LPInterpolateRoute.h"
 
 
 @implementation LPInterpolateRoute
 
-@synthesize events=_events;
+@synthesize events = _events;
 @synthesize parser1;
 @synthesize parser2;
 
 
 // Should only return YES after the LPHTTPConnection has read all available data.
-- (BOOL)isDone {
-    return !self.events && [super isDone];
+- (BOOL) isDone {
+  return !self.events && [super isDone];
 }
 
 
--(void)beginOperation 
-{
-    self.done = NO;
-    NSString *base64Events = [self.data objectForKey:@"events"];
-    id queryStart = [self.data objectForKey:@"start"];
-    id queryEnd = [self.data objectForKey:@"end"];
+- (void) beginOperation {
+  self.done = NO;
+  NSString *base64Events = [self.data objectForKey:@"events"];
+  id queryStart = [self.data objectForKey:@"start"];
+  id queryEnd = [self.data objectForKey:@"end"];
 
-    NSDictionary *offset_start = [self.data valueForKey:@"offset_start"];
-    NSNumber *off_start_x = [offset_start valueForKey:@"x"];
-    NSNumber *off_start_y = [offset_start valueForKey:@"y"];    
-        
-    CGPoint offsetPointStart = CGPointMake([off_start_x floatValue], [off_start_y floatValue]);
+  NSDictionary *offset_start = [self.data valueForKey:@"offset_start"];
+  NSNumber *off_start_x = [offset_start valueForKey:@"x"];
+  NSNumber *off_start_y = [offset_start valueForKey:@"y"];
 
-    NSDictionary *offset_end = [self.data valueForKey:@"offset_end"];
-    NSNumber *off_end_x = [offset_end valueForKey:@"x"];
-    NSNumber *off_end_y = [offset_end valueForKey:@"y"];    
-    
-    CGPoint offsetPointEnd = CGPointMake([off_end_x floatValue], [off_end_y floatValue]);
+  CGPoint offsetPointStart = CGPointMake([off_start_x floatValue],
+          [off_start_y floatValue]);
 
-    UIView *targetView = nil;
-    self.parser1 = [UIScriptParser scriptParserWithObject: queryStart];
-    self.parser2 = [UIScriptParser scriptParserWithObject: queryEnd];
-    [self.parser1 parse];
-    [self.parser2 parse];
-    NSMutableArray* views = [NSMutableArray arrayWithCapacity:32];
-    for (UIWindow *window in [LPTouchUtils applicationWindows])
-    {
-        [views addObjectsFromArray:[window subviews]];
-    }
-    NSArray* resultStart = [self.parser1 evalWith:views];
-    NSArray* resultEnd = [self.parser2 evalWith:views];
+  NSDictionary *offset_end = [self.data valueForKey:@"offset_end"];
+  NSNumber *off_end_x = [offset_end valueForKey:@"x"];
+  NSNumber *off_end_y = [offset_end valueForKey:@"y"];
 
-    CGPoint centerStart;
-    if (resultStart == nil || [resultStart count] == 0)
-    {
-        centerStart = CGPointMake(0,0);
-    }
-    else
-    {
-        id startAt = [resultStart objectAtIndex:0];
-        if ([startAt isKindOfClass:[UIView class]])
-        {
-            centerStart = [LPTouchUtils centerOfView:startAt];
-        }
-        else
-        {
-            CGPointMakeWithDictionaryRepresentation((CFDictionaryRef)[startAt valueForKey:@"center"], &centerStart);
-        }
+  CGPoint offsetPointEnd = CGPointMake([off_end_x floatValue],
+          [off_end_y floatValue]);
 
-    }
-    centerStart = CGPointMake(centerStart.x + offsetPointStart.x, centerStart.y + offsetPointStart.y);
-            
-        
-    CGPoint centerEnd;
-    if (resultEnd == nil || [resultEnd count] == 0)
-    {
-        centerEnd = CGPointMake(0,0);
-    }
-    else {
-        id endAt = [resultEnd objectAtIndex:0];
-        targetView = endAt;
-        if ([endAt isKindOfClass:[UIView class]])
-        {
-            centerEnd = [LPTouchUtils centerOfView:endAt];
-        }
-        else
-        {
-            CGPointMakeWithDictionaryRepresentation((CFDictionaryRef)[endAt valueForKey:@"center"], &centerEnd);
-        }
-    }
+  UIView *targetView = nil;
+  self.parser1 = [UIScriptParser scriptParserWithObject:queryStart];
+  self.parser2 = [UIScriptParser scriptParserWithObject:queryEnd];
+  [self.parser1 parse];
+  [self.parser2 parse];
+  NSMutableArray *views = [NSMutableArray arrayWithCapacity:32];
+  for (UIWindow *window in [LPTouchUtils applicationWindows]) {
+    [views addObjectsFromArray:[window subviews]];
+  }
+  NSArray *resultStart = [self.parser1 evalWith:views];
+  NSArray *resultEnd = [self.parser2 evalWith:views];
 
-    centerEnd = CGPointMake(centerEnd.x + offsetPointEnd.x, centerEnd.y + offsetPointEnd.y);
-
-
-    NSArray* baseEvents = [LPResources eventsFromEncoding:base64Events];
-    
-    
-    self.events = [LPResources interpolateEvents:baseEvents 
-                                       fromPoint:centerStart
-                                         toPoint:centerEnd];
-    
-    //NSLog(@"PLAY Events:\n%@",self.events);    
-    
-    [self play:self.events];
-    NSArray *resultArray = nil;
-    if (targetView == nil) {
-        resultArray = [NSArray array];
+  CGPoint centerStart;
+  if (resultStart == nil || [resultStart count] == 0) {
+    centerStart = CGPointMake(0, 0);
+  } else {
+    id startAt = [resultStart objectAtIndex:0];
+    if ([startAt isKindOfClass:[UIView class]]) {
+      centerStart = [LPTouchUtils centerOfView:startAt];
     } else {
-        resultArray = [NSArray arrayWithObject:targetView];
+      CGPointMakeWithDictionaryRepresentation(
+              (CFDictionaryRef) [startAt valueForKey:@"center"], &centerStart);
     }
-    
-    self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                         resultArray, @"results",
-                         @"SUCCESS",@"outcome",
-                         nil];
-    
-    
+  }
+  centerStart = CGPointMake(centerStart.x + offsetPointStart.x,
+          centerStart.y + offsetPointStart.y);
+
+
+  CGPoint centerEnd;
+  if (resultEnd == nil || [resultEnd count] == 0) {
+    centerEnd = CGPointMake(0, 0);
+  } else {
+    id endAt = [resultEnd objectAtIndex:0];
+    targetView = endAt;
+    if ([endAt isKindOfClass:[UIView class]]) {
+      centerEnd = [LPTouchUtils centerOfView:endAt];
+    } else {
+      CGPointMakeWithDictionaryRepresentation(
+              (CFDictionaryRef) [endAt valueForKey:@"center"], &centerEnd);
+    }
+  }
+
+  centerEnd = CGPointMake(centerEnd.x + offsetPointEnd.x,
+          centerEnd.y + offsetPointEnd.y);
+
+
+  NSArray *baseEvents = [LPResources eventsFromEncoding:base64Events];
+
+
+  self.events = [LPResources interpolateEvents:baseEvents fromPoint:centerStart
+                                       toPoint:centerEnd];
+
+  //NSLog(@"PLAY Events:\n%@",self.events);
+
+  [self play:self.events];
+  NSArray *resultArray = nil;
+  if (targetView == nil) {
+    resultArray = [NSArray array];
+  } else {
+    resultArray = [NSArray arrayWithObject:targetView];
+  }
+
+  self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:resultArray, @"results",
+                                                                 @"SUCCESS", @"outcome",
+                                                                 nil];
 }
 
 
-
-
-- (void) play:(NSArray *)events 
-{
-    [[LPRecorder sharedRecorder] load: self.events];
-    [[LPRecorder sharedRecorder] playbackWithDelegate: self doneSelector: @selector(playbackDone:)];    
+- (void) play:(NSArray *) events {
+  [[LPRecorder sharedRecorder] load:self.events];
+  [[LPRecorder sharedRecorder]
+          playbackWithDelegate:self doneSelector:@selector(playbackDone:)];
 }
+
 
 //When this event occurs, jsonResponse has already been determined.
--(void) playbackDone:(NSDictionary *)details 
-{
-    self.done = YES;
-    self.events = nil;
-    self.parser1 = nil;
-    self.parser2 = nil;
-    [self.conn responseHasAvailableData:self];
+- (void) playbackDone:(NSDictionary *) details {
+  self.done = YES;
+  self.events = nil;
+  self.parser1 = nil;
+  self.parser2 = nil;
+  [self.conn responseHasAvailableData:self];
 }
 
--(void) dealloc 
-{
-    self.parser1 = nil;
-    self.parser2 = nil;
-    self.events = nil;
-    [super dealloc];
+
+- (void) dealloc {
+  self.parser1 = nil;
+  self.parser2 = nil;
+  self.events = nil;
+  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPKeyboardRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPKeyboardRoute.h
@@ -9,9 +9,9 @@
 #import "LPRoute.h"
 #import "LPHTTPResponse.h"
 #import "LPGenericAsyncRoute.h"
-@interface LPKeyboardRoute : LPGenericAsyncRoute
-{    
-    BOOL _playbackDone;
-    NSArray *_events;
+
+@interface LPKeyboardRoute : LPGenericAsyncRoute {
+  BOOL _playbackDone;
+  NSArray *_events;
 }
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPKeyboardRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPKeyboardRoute.m
@@ -7,118 +7,107 @@
 //
 
 #import "LPKeyboardRoute.h"
-#import "LPHTTPResponse.h"
 #import "LPHTTPConnection.h"
 #import "LPResources.h"
 #import "LPRecorder.h"
 #import "UIScriptParser.h"
 #import "LPTouchUtils.h"
-#import "LPJSONUtils.h"
-#import <QuartzCore/QuartzCore.h>
 
+// todo missing dealloc method and _events ivar is not released
 @implementation LPKeyboardRoute
 
--(void)beginOperation
-{
-    _events = nil;
-    _playbackDone = NO;    
-    NSString *characterString = [self.data objectForKey:@"key"];
-    
-    
-    NSArray *events = [LPResources eventsFromEncoding:[self.data objectForKey:@"events"]]; 
-    UIWindow *keyboardWindow = nil;
+- (void) beginOperation {
+  _events = nil;
+  _playbackDone = NO;
+  NSString *characterString = [self.data objectForKey:@"key"];
 
-    for (UIWindow *window in [LPTouchUtils applicationWindows])
-    {
-        if ([NSStringFromClass([window class]) isEqual:@"UITextEffectsWindow"]) 
-        {
-            keyboardWindow = window;
-            break;
-        }
+  NSArray *events = [LPResources eventsFromEncoding:[self.data objectForKey:@"events"]];
+  UIWindow *keyboardWindow = nil;
+
+  for (UIWindow *window in [LPTouchUtils applicationWindows]) {
+    if ([NSStringFromClass([window class]) isEqual:@"UITextEffectsWindow"]) {
+      keyboardWindow = window;
+      break;
     }
-    
-    if (!keyboardWindow) 
-    {
-        _playbackDone = YES;
-        return [self failWithMessageFormat:@"No keyboard displaying..." message:nil];
-    }
+  }
 
-    
+  if (!keyboardWindow) {
+    _playbackDone = YES;
+    return [self failWithMessageFormat:@"No keyboard displaying..."
+                               message:nil];
+  }
 
-    UIView *keyboardView = [UIScriptParser findViewByClass:@"UIKBKeyplaneView" fromView:keyboardWindow];
-    
-    
-    if (!keyboardView)
-    {
-        _playbackDone = YES;
-        return [self failWithMessageFormat:@"Found not UIKBKeyplaneView..." message:nil];        
-    }
 
-    
-    
-    //cf KIF: https://github.com/square/KIF/blob/master/Classes/KIFTestStep.m
-    
-    // If we didn't find the standard keyboard view, then we may have a custom keyboard
-    
-    id /*UIKBKeyplane*/ keyplane = [keyboardView valueForKey:@"keyplane"];
-    NSArray *keys = [keyplane valueForKey:@"keys"];
-    
-    id keyToTap = nil;
-    
-    for (id/*UIKBKey*/ key in keys) {
-        NSString *representedString = [key valueForKey:@"representedString"];
-        // Find the key based on the key's represented string
-        if ([representedString isEqual:characterString]) 
-        {
-            keyToTap = key;
-        }
-        
-        if ([representedString length]>0)
-        {
-            
-            if ([characterString isEqualToString:@"Return"] && [representedString characterAtIndex:0]==(unichar)10)
-            {
-                keyToTap = key;
-            }
-        }
-    }             
-    
-    if (keyToTap) 
-    {
-        UIView *v = [UIScriptParser findViewByClass:@"UIKeyboardAutomatic" fromView:keyboardWindow];
-        UIView *sup = [v superview];
-        
-        CGRect parentFrame = [sup convertRect:v.frame toView:nil];//[sup convertRect:v.frame toView:sup];
-        
-        CGRect frame = [keyToTap frame];
-        CGPoint point = CGPointMake(parentFrame.origin.x + frame.origin.x + 0.5 * frame.size.width,
-                                    parentFrame.origin.y + frame.origin.y + 0.5 * frame.size.height);
-        
-        point = [(UIWindow*)keyboardWindow convertPoint:point toWindow:nil];
-        point=[LPTouchUtils translateToScreenCoords:point];
-        _events =  [[LPResources transformEvents:events toPoint:point] retain];
-        self.done = YES;
-        self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:
-                             [NSArray arrayWithObject:v], @"results",
-                             @"SUCCESS",@"outcome",
-                             nil];
+  UIView *keyboardView = [UIScriptParser findViewByClass:@"UIKBKeyplaneView"
+                                                fromView:keyboardWindow];
 
-        [self play:_events];
-        
-    }
-    else 
-    {
-        _playbackDone = YES;
-        [self failWithMessageFormat:@"Found no key: %@" message:characterString];        
+
+  if (!keyboardView) {
+    _playbackDone = YES;
+    return [self failWithMessageFormat:@"Found not UIKBKeyplaneView..."
+                               message:nil];
+  }
+
+
+
+  //cf KIF: https://github.com/square/KIF/blob/master/Classes/KIFTestStep.m
+
+  // If we didn't find the standard keyboard view, then we may have a custom keyboard
+
+  id /*UIKBKeyplane*/ keyplane = [keyboardView valueForKey:@"keyplane"];
+  NSArray *keys = [keyplane valueForKey:@"keys"];
+
+  id keyToTap = nil;
+
+  for (id/*UIKBKey*/ key in keys) {
+    NSString *representedString = [key valueForKey:@"representedString"];
+    // Find the key based on the key's represented string
+    if ([representedString isEqual:characterString]) {
+      keyToTap = key;
     }
 
+    if ([representedString length] > 0) {
+
+      if ([characterString isEqualToString:@"Return"] && [representedString characterAtIndex:0] == (unichar) 10) {
+        keyToTap = key;
+      }
+    }
+  }
+
+  if (keyToTap) {
+    UIView *v = [UIScriptParser findViewByClass:@"UIKeyboardAutomatic"
+                                       fromView:keyboardWindow];
+    UIView *sup = [v superview];
+
+    CGRect parentFrame = [sup convertRect:v.frame
+                                   toView:nil];//[sup convertRect:v.frame toView:sup];
+
+    CGRect frame = [keyToTap frame];
+    CGPoint point = CGPointMake(
+            parentFrame.origin.x + frame.origin.x + 0.5 * frame.size.width,
+            parentFrame.origin.y + frame.origin.y + 0.5 * frame.size.height);
+
+    point = [(UIWindow *) keyboardWindow convertPoint:point toWindow:nil];
+    point = [LPTouchUtils translateToScreenCoords:point];
+    _events = [[LPResources transformEvents:events toPoint:point] retain];
+    self.done = YES;
+    self.jsonResponse = [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObject:v], @"results",
+                                                                   @"SUCCESS", @"outcome",
+                                                                   nil];
+
+    [self play:_events];
+  } else {
+    _playbackDone = YES;
+    [self failWithMessageFormat:@"Found no key: %@" message:characterString];
+  }
 }
 
--(void) play:(NSArray *)events {
-    _playbackDone = NO;
-    [[LPRecorder sharedRecorder] load: _events];
-    [[LPRecorder sharedRecorder] playbackWithDelegate: self doneSelector: @selector(playbackDone:)];
-    
+
+- (void) play:(NSArray *) events {
+  _playbackDone = NO;
+  [[LPRecorder sharedRecorder] load:_events];
+  [[LPRecorder sharedRecorder]
+          playbackWithDelegate:self doneSelector:@selector(playbackDone:)];
 }
 
 //-(void) waitUntilPlaybackDone {
@@ -127,20 +116,18 @@
 //    }
 //}
 
--(void) playbackDone:(NSDictionary *)details {
-    _playbackDone = YES;
-    [_events release];
-    _events=nil;
-    [self.conn responseHasAvailableData:self];
-
+- (void) playbackDone:(NSDictionary *) details {
+  _playbackDone = YES;
+  [_events release];
+  _events = nil;
+  [self.conn responseHasAvailableData:self];
 }
+
 
 // Should only return YES after the LPHTTPConnection has read all available data.
-- (BOOL)isDone 
-{
-    return _playbackDone && [super isDone];
+- (BOOL) isDone {
+  return _playbackDone && [super isDone];
 }
-
 
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPLocationRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPLocationRoute.h
@@ -7,9 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "LPLocationRoute.h"
 #import "LPRoute.h"
 
-@interface LPLocationRoute  : NSObject<LPRoute>
+@interface LPLocationRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPLocationRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPLocationRoute.m
@@ -9,75 +9,59 @@
 
 #import "LPLocationRoute.h"
 
+// todo missing import of UIAutomation.h in LPLocationRoute.m
 @implementation LPLocationRoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
 }
 
--(NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {
-    NSString *action = [data objectForKey:@"action"];
-    if ([action isEqualToString:@"change_location"])
-    {
-        NSNumber *lat = [data objectForKey:@"latitude"];
-        if (!lat)
-        {
-            return [NSDictionary dictionaryWithObjectsAndKeys:
-                                                 @"FAILURE",@"outcome",
-                                                 @"latitude must be specified",@"reason",
-                                                 @"",@"details",
-                                                nil];
-        }
-        NSNumber *lon = [data objectForKey:@"longitude"];
-        if (!lon)
-        {
-            return [NSDictionary dictionaryWithObjectsAndKeys:
-                                                 @"FAILURE",@"outcome",
-                                                 @"longitude must be specified",@"reason",
-                                                 @"",@"details",
-                                                 nil];
-        }
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+  NSString *action = [data objectForKey:@"action"];
+  if ([action isEqualToString:@"change_location"]) {
+    NSNumber *lat = [data objectForKey:@"latitude"];
+    if (!lat) {
+      return [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                        @"latitude must be specified", @"reason",
+                                                        @"", @"details", nil];
+    }
+    NSNumber *lon = [data objectForKey:@"longitude"];
+    if (!lon) {
+      return [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                        @"longitude must be specified", @"reason",
+                                                        @"", @"details", nil];
+    }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-method-access"
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-        id tgt = [NSClassFromString(@"UIATarget") localTarget];
-        if (tgt && [tgt respondsToSelector:@selector(setLocation:)])
-        {
-            [tgt setLocation:[NSDictionary dictionaryWithObjectsAndKeys:
-                               lat,@"latitude",
-                               lon,@"longitude",
-                              nil]];
-            return [NSDictionary dictionaryWithObjectsAndKeys:
-                                    [NSArray array], @"results",
-                                    @"SUCCESS",@"outcome",
-                                nil];
-        }
-        else
-        {
-            NSString *message = nil;
-            if (!tgt)
-            {
-                message = @"UIAutomation is not linked for some reason.";
-            }
-            else
-            {
-                message = @"setLocation is unsupported in this iOS version.";
-                                }
-                return [NSDictionary dictionaryWithObjectsAndKeys:
-                                                     @"FAILURE",@"outcome",
-                                                     message,@"reason",
-                                                     @"",@"details",
-                                                     nil];
-            }
+    id tgt = [NSClassFromString(@"UIATarget") localTarget];
+    if (tgt && [tgt respondsToSelector:@selector(setLocation:)]) {
+      [tgt setLocation:[NSDictionary dictionaryWithObjectsAndKeys:lat, @"latitude",
+                                                                  lon, @"longitude",
+                                                                  nil]];
+      return [NSDictionary dictionaryWithObjectsAndKeys:[NSArray array], @"results",
+                                                        @"SUCCESS", @"outcome",
+                                                        nil];
+    } else {
+      NSString *message = nil;
+      if (!tgt) {
+        message = @"UIAutomation is not linked for some reason.";
+      } else {
+        message = @"setLocation is unsupported in this iOS version.";
+      }
+      return [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                        message, @"reason",
+                                                        @"", @"details", nil];
     }
-    
+  }
+
 #pragma clang diagnostic pop
 
-    return [NSDictionary dictionaryWithObjectsAndKeys:
-                         @"FAILURE",@"outcome",
-                         [NSString stringWithFormat:@"action %@ not recognized",action],@"reason",
-                         @"",@"details",
-                         nil];
+  return [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                    [NSString stringWithFormat:@"action %@ not recognized",
+                                                                               action], @"reason",
+                                                    @"", @"details", nil];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.h
@@ -7,7 +7,9 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 #import "UIScriptParser.h"
-@interface LPMapRoute : NSObject<LPRoute>
 
-@property (nonatomic, retain) UIScriptParser *parser;
+@interface LPMapRoute : NSObject <LPRoute>
+
+@property(nonatomic, retain) UIScriptParser *parser;
+
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -5,7 +5,6 @@
 //
 
 #import "LPMapRoute.h"
-#import "UIScriptParser.h"
 #import "LPOperation.h"
 #import "LPTouchUtils.h"
 #import "LPOrientationOperation.h"
@@ -14,87 +13,90 @@
 @implementation LPMapRoute
 @synthesize parser;
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"];
-}
-- (NSArray*) applyOperation:(NSDictionary *)operation toViews:(NSArray *) views error:(NSError **)error {
-    if ([operation valueForKey:@"method_name"] == nil) {
-        return [[views copy] autorelease];
-    }
-    LPOperation *op = [LPOperation operationFromDictionary:operation];
-    //LPHTTPLogDDLogVerbose(@"Applying operation %@ to views...",op);
-    NSMutableArray* finalRes = [NSMutableArray arrayWithCapacity:[views count]];
-    if (views == nil) {
-        id res = [op performWithTarget:nil error:error];
-        if (res != nil) {
-            [finalRes addObject:res];
-        }
-    } else {
-        for (id view in views) {
-//            if ([view isKindOfClass:[UIView class]] && ![LPTouchUtils isViewVisible:view]) {continue;}            
-            NSError *err = nil;
-            id val = [op performWithTarget:view error:&err];
-            if (err) {continue;}
-            if (val == nil) {
-                [finalRes addObject: [NSNull null]];
-            } else {
-                [finalRes addObject: val];
-            }            
-        }
-    }
-    return finalRes;
-}
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {
-    
-    id scriptObj = [data objectForKey:@"query"];
-    NSDictionary* operation = [data objectForKey:@"operation"];
-    //DDLogVerbose(@"MapRoute received command\n%@", data);
-    NSArray* result = nil;
-    if ([NSNull null] != scriptObj) {
-        
-        self.parser = [UIScriptParser scriptParserWithObject:scriptObj];
-        [self.parser parse];
-        NSArray* tokens = [self.parser parsedTokens];
-        NSLog(@"Map %@, %@ Parsed UIScript as\n%@", method, path, tokens);
 
-		//
-        NSArray *allWindows = [LPTouchUtils applicationWindows];
-        NSMutableArray* views = [NSMutableArray arrayWithCapacity:32];
-        for (UIWindow *window in allWindows)
-        {
-            [views addObjectsFromArray:[window subviews]];
-        }
-        result = [self.parser evalWith:views];
-    } else {
-        result = nil;
-    }
-    self.parser = nil;
-    NSError* error = nil;
-    NSArray* resultArray = [self applyOperation:operation toViews:result error:&error];
-    
-    NSDictionary *resultDict = nil;
-    if (resultArray) {
-        resultDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                   [LPOrientationOperation statusBarOrientation] , @"status_bar_orientation",
-                   resultArray , @"results",
-                   @"SUCCESS",@"outcome",
-                  nil];
-    } else {
-        resultDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                  @"FAILURE",@"outcome",
-                  @"",@"reason",
-                  @"",@"details",
-                  nil];
-    }
-    [LPLog debug:@"Map results %@", resultDict];
-    
-    return resultDict;
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
 }
 
--(void)dealloc
-{
-    self.parser = nil;
-    [super dealloc];
+
+- (NSArray *) applyOperation:(NSDictionary *) operation toViews:(NSArray *) views error:(NSError **) error {
+  if ([operation valueForKey:@"method_name"] == nil) {
+    return [[views copy] autorelease];
+  }
+  LPOperation *op = [LPOperation operationFromDictionary:operation];
+  //LPHTTPLogDDLogVerbose(@"Applying operation %@ to views...",op);
+  NSMutableArray *finalRes = [NSMutableArray arrayWithCapacity:[views count]];
+  if (views == nil) {
+    id res = [op performWithTarget:nil error:error];
+    if (res != nil) {
+      [finalRes addObject:res];
+    }
+  } else {
+    for (id view in views) {
+      // if ([view isKindOfClass:[UIView class]] && ![LPTouchUtils isViewVisible:view]) {continue;}
+      NSError *err = nil;
+      id val = [op performWithTarget:view error:&err];
+      if (err) {continue;}
+      if (val == nil) {
+        [finalRes addObject:[NSNull null]];
+      } else {
+        [finalRes addObject:val];
+      }
+    }
+  }
+  return finalRes;
+}
+
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+
+  id scriptObj = [data objectForKey:@"query"];
+  NSDictionary *operation = [data objectForKey:@"operation"];
+  //DDLogVerbose(@"MapRoute received command\n%@", data);
+  NSArray *result = nil;
+  if ([NSNull null] != scriptObj) {
+
+    self.parser = [UIScriptParser scriptParserWithObject:scriptObj];
+    [self.parser parse];
+    NSArray *tokens = [self.parser parsedTokens];
+    NSLog(@"Map %@, %@ Parsed UIScript as\n%@", method, path, tokens);
+
+    //
+    NSArray *allWindows = [LPTouchUtils applicationWindows];
+    NSMutableArray *views = [NSMutableArray arrayWithCapacity:32];
+    for (UIWindow *window in allWindows) {
+      [views addObjectsFromArray:[window subviews]];
+    }
+    result = [self.parser evalWith:views];
+  } else {
+    result = nil;
+  }
+  self.parser = nil;
+  NSError *error = nil;
+  NSArray *resultArray = [self applyOperation:operation toViews:result
+                                        error:&error];
+
+  NSDictionary *resultDict = nil;
+  if (resultArray) {
+    resultDict = [NSDictionary dictionaryWithObjectsAndKeys:[LPOrientationOperation statusBarOrientation], @"status_bar_orientation",
+                                                            resultArray, @"results",
+                                                            @"SUCCESS", @"outcome",
+                                                            nil];
+  } else {
+    resultDict = [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
+                                                            @"", @"reason",
+                                                            @"", @"details",
+                                                            nil];
+  }
+  [LPLog debug:@"Map results %@", resultDict];
+
+  return resultDict;
+}
+
+
+- (void) dealloc {
+  self.parser = nil;
+  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPNoContentResponse.h
+++ b/calabash/Classes/FranklyServer/Routes/LPNoContentResponse.h
@@ -7,6 +7,6 @@
 #import <Foundation/Foundation.h>
 #import "LPHTTPResponse.h"
 
-@interface LPNoContentResponse : NSObject<LPHTTPResponse>
+@interface LPNoContentResponse : NSObject <LPHTTPResponse>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPNoContentResponse.m
+++ b/calabash/Classes/FranklyServer/Routes/LPNoContentResponse.m
@@ -9,14 +9,20 @@
 @implementation LPNoContentResponse
 
 
-- (UInt64)contentLength {return 0;}
+- (UInt64) contentLength {return 0;}
 
-- (UInt64)offset {return 0;}
-- (void)setOffset:(UInt64)offset{}
 
-- (NSData *)readDataOfLength:(NSUInteger)length {return nil;}
+- (UInt64) offset {return 0;}
 
-- (BOOL)isDone {return YES;}
 
-- (NSInteger)status {return 203;}
+- (void) setOffset:(UInt64) offset {}
+
+
+- (NSData *) readDataOfLength:(NSUInteger) length {return nil;}
+
+
+- (BOOL) isDone {return YES;}
+
+
+- (NSInteger) status {return 203;}
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPQueryLogRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPQueryLogRoute.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPQueryLogRoute : NSObject<LPRoute>
+@interface LPQueryLogRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPQueryLogRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPQueryLogRoute.m
@@ -7,102 +7,100 @@
 //
 
 #import "LPQueryLogRoute.h"
-#import "LPJSONUtils.h"
 #import "asl.h"
 
 @implementation LPQueryLogRoute
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"GET"];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"GET"];
 }
 
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {
 
-	int count = 0;
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
 
-	//Build a query message containing all our criteria.
-	aslmsg query = asl_new(ASL_TYPE_QUERY);
-	
-	for (NSString *key in [data keyEnumerator])
-	{
-		int op = ASL_QUERY_OP_EQUAL;
-		NSString *kData = [data valueForKey:key];
-		
-		if ([key isEqualToString:@"count"])
-		{
-			count = [kData intValue];
-			continue;
-		}
-		
-		//If the key string contains one or more dots, process those modifiers.
-		//Put the operation first, the modifiers following.
-		if ([key rangeOfString:@"."].location != NSNotFound)
-		{
-			NSArray *keyParts = [key componentsSeparatedByString:@"."];
-			key = [keyParts objectAtIndex:0];
-			for (int i=1; i<[keyParts count]; i++)
-			{
-				NSString *modifier = [[keyParts objectAtIndex:i] lowercaseString];
-				if ([modifier isEqualToString:@"equal"])
-					op = ASL_QUERY_OP_EQUAL;
-				else if ([modifier isEqualToString:@"greater"])
-					op = ASL_QUERY_OP_GREATER;
-				else if ([modifier isEqualToString:@"greater_equal"])
-					op = ASL_QUERY_OP_GREATER_EQUAL;
-				else if ([modifier isEqualToString:@"less"])
-					op = ASL_QUERY_OP_LESS;
-				else if ([modifier isEqualToString:@"less_equal"])
-					op = ASL_QUERY_OP_LESS_EQUAL;
-				else if ([modifier isEqualToString:@"not_equal"])
-					op = ASL_QUERY_OP_NOT_EQUAL;
-				else if ([modifier isEqualToString:@"regex"])
-					op = ASL_QUERY_OP_REGEX;
-				else if ([modifier isEqualToString:@"true"])
-					op = ASL_QUERY_OP_TRUE;
-				else if ([modifier isEqualToString:@"casefold"])
-					op |= ASL_QUERY_OP_CASEFOLD;
-				else if ([modifier isEqualToString:@"prefix"])
-					op |= ASL_QUERY_OP_PREFIX;
-				else if ([modifier isEqualToString:@"suffix"])
-					op |= ASL_QUERY_OP_SUFFIX;
-				else if ([modifier isEqualToString:@"substring"])
-					op |= ASL_QUERY_OP_SUBSTRING;
-				else if ([modifier isEqualToString:@"numeric"])
-					op |= ASL_QUERY_OP_NUMERIC;
-				//ignore unknown values
-			}
-		}
-		
-		//If we get here, assume the key is a ASL field to be set.
-		//Note this means the user must pass in correct key strings such as "Facility" or "Sender".
-		asl_set_query(query, [key UTF8String], [kData UTF8String], op);
-	}
-	
-	//Begin the search.
-	aslresponse response = asl_search(NULL, query);
-	
-	asl_free(query);
+  int count = 0;
 
-	NSMutableArray *messages = [[NSMutableArray alloc] init];
-	aslmsg msg;
-	while ((msg = aslresponse_next(response)) && count-- > 0) {
-		//Load all the key/value pairs from the message into a dictionary.
-		const char *k;
-		NSMutableDictionary *msgDict = [[NSMutableDictionary alloc] init];
-		for (unsigned i = 0U; (k = asl_key(msg, i)); ++i) {
-			const char *v = asl_get(msg, k);
-			[msgDict setObject:[NSString stringWithUTF8String:v] forKey:[NSString stringWithUTF8String:k]];
-		}
-		[messages addObject:msgDict];		
-	}
-	aslresponse_free(response);	//Also frees the messages used in the above loop.
+  //Build a query message containing all our criteria.
+  aslmsg query = asl_new(ASL_TYPE_QUERY);
 
-	NSArray *results = [NSArray arrayWithArray:messages];
+  for (NSString *key in [data keyEnumerator]) {
+    int op = ASL_QUERY_OP_EQUAL;
+    NSString *kData = [data valueForKey:key];
 
-	return [NSDictionary dictionaryWithObjectsAndKeys:
-            results, @"results",
-            @"SUCCESS",@"outcome",
-            nil];
-    
+    if ([key isEqualToString:@"count"]) {
+      count = [kData intValue];
+      continue;
+    }
+
+    //If the key string contains one or more dots, process those modifiers.
+    //Put the operation first, the modifiers following.
+    if ([key rangeOfString:@"."].location != NSNotFound) {
+      NSArray *keyParts = [key componentsSeparatedByString:@"."];
+      key = [keyParts objectAtIndex:0];
+      for (int i = 1; i < [keyParts count]; i++) {
+        NSString *modifier = [[keyParts objectAtIndex:i] lowercaseString];
+        if ([modifier isEqualToString:@"equal"]) {
+          op = ASL_QUERY_OP_EQUAL;
+        } else if ([modifier isEqualToString:@"greater"]) {
+          op = ASL_QUERY_OP_GREATER;
+        } else if ([modifier isEqualToString:@"greater_equal"]) {
+          op = ASL_QUERY_OP_GREATER_EQUAL;
+        } else if ([modifier isEqualToString:@"less"]) {
+          op = ASL_QUERY_OP_LESS;
+        } else if ([modifier isEqualToString:@"less_equal"]) {
+          op = ASL_QUERY_OP_LESS_EQUAL;
+        } else if ([modifier isEqualToString:@"not_equal"]) {
+          op = ASL_QUERY_OP_NOT_EQUAL;
+        } else if ([modifier isEqualToString:@"regex"]) {
+          op = ASL_QUERY_OP_REGEX;
+        } else if ([modifier isEqualToString:@"true"]) {
+          op = ASL_QUERY_OP_TRUE;
+        } else if ([modifier isEqualToString:@"casefold"]) {
+          op |= ASL_QUERY_OP_CASEFOLD;
+        } else if ([modifier isEqualToString:@"prefix"]) {
+          op |= ASL_QUERY_OP_PREFIX;
+        } else if ([modifier isEqualToString:@"suffix"]) {
+          op |= ASL_QUERY_OP_SUFFIX;
+        } else if ([modifier isEqualToString:@"substring"]) {
+          op |= ASL_QUERY_OP_SUBSTRING;
+        } else if ([modifier isEqualToString:@"numeric"]) {
+          op |= ASL_QUERY_OP_NUMERIC;
+        }
+        //ignore unknown values
+      }
+    }
+
+    //If we get here, assume the key is a ASL field to be set.
+    //Note this means the user must pass in correct key strings such as "Facility" or "Sender".
+    asl_set_query(query, [key UTF8String], [kData UTF8String], op);
+  }
+
+  //Begin the search.
+  aslresponse response = asl_search(NULL, query);
+
+  asl_free(query);
+
+  // todo possible memory leak in LPQueryLogRoute
+  NSMutableArray *messages = [[NSMutableArray alloc] init];
+  aslmsg msg;
+  while ((msg = aslresponse_next(response)) && count-- > 0) {
+    //Load all the key/value pairs from the message into a dictionary.
+    const char *k;
+    NSMutableDictionary *msgDict = [[NSMutableDictionary alloc] init];
+    for (unsigned i = 0U; (k = asl_key(msg, i)); ++i) {
+      const char *v = asl_get(msg, k);
+      [msgDict setObject:[NSString stringWithUTF8String:v]
+                  forKey:[NSString stringWithUTF8String:k]];
+    }
+    [messages addObject:msgDict];
+  }
+  // todo possible memory leak in LPQueryLogRoute
+  aslresponse_free(response);  //Also frees the messages used in the above loop.
+
+  NSArray *results = [NSArray arrayWithArray:messages];
+
+  return [NSDictionary dictionaryWithObjectsAndKeys:results, @"results",
+                                                    @"SUCCESS", @"outcome",
+                                                    nil];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPRecordRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPRecordRoute.h
@@ -6,8 +6,9 @@
 
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
-@interface LPRecordRoute : NSObject<LPRoute> {
-    NSDictionary *_params;
-    LPHTTPConnection *_conn;
+
+@interface LPRecordRoute : NSObject <LPRoute> {
+  NSDictionary *_params;
+  LPHTTPConnection *_conn;
 }
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPRecordRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPRecordRoute.m
@@ -9,66 +9,74 @@
 #import "LPRecorder.h"
 #import "LPNoContentResponse.h"
 
-@interface LPRecordRoute()
+@interface LPRecordRoute ()
 - (void) startRecording;
+
 - (NSData *) stopRecording;
 @end
 
 @implementation LPRecordRoute
 
-- (void) setParameters:(NSDictionary*) parameters {
-    _params = [parameters retain];
+- (void) setParameters:(NSDictionary *) parameters {
+  _params = [parameters retain];
 }
-- (void) setConnection:(LPHTTPConnection *)connection {
-    _conn = connection;
+
+
+- (void) setConnection:(LPHTTPConnection *) connection {
+  _conn = connection;
 }
+
 
 - (void) dealloc {
-    [_params release];_params=nil;
-    _conn=nil;
-    [super dealloc];
+  [_params release];
+  _params = nil;
+  _conn = nil;
+  [super dealloc];
 }
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"];
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
 }
 
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path {
-    NSString* action = [_params objectForKey:@"action"];
-    if ([action isEqualToString:@"start"]) {
-        [self startRecording];
-        return [[[LPNoContentResponse alloc] init] autorelease];
-    }
-    else if ([action isEqualToString:@"stop"]) {
-        NSData* path = [self stopRecording];
-        return [[[LPHTTPDataResponse alloc] initWithData:path] autorelease];
-    } else {
-        return nil;
-    }
-    
+
+- (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
+  NSString *action = [_params objectForKey:@"action"];
+  if ([action isEqualToString:@"start"]) {
+    [self startRecording];
+    return [[[LPNoContentResponse alloc] init] autorelease];
+  } else if ([action isEqualToString:@"stop"]) {
+    NSData *path = [self stopRecording];
+    return [[[LPHTTPDataResponse alloc] initWithData:path] autorelease];
+  } else {
+    return nil;
+  }
 }
 
 
 - (void) startRecording {
-    [[LPRecorder sharedRecorder] record];
+  [[LPRecorder sharedRecorder] record];
 }
+
+
 - (NSData *) stopRecording {
-    [[LPRecorder sharedRecorder] stop];
-    
-    NSString *error=nil;
-    
-    NSData *plistData = [NSPropertyListSerialization dataFromPropertyList:[[LPRecorder sharedRecorder] events]
-                                                                   format:NSPropertyListXMLFormat_v1_0
-                                                         errorDescription:&error];
-    if (error) {
-        NSLog(@"error getting plist data: %@",error);
-        return nil;
-    } else {
-        return plistData;
-    }
+  [[LPRecorder sharedRecorder] stop];
+
+  NSString *error = nil;
+
+  NSData *plistData = [NSPropertyListSerialization dataFromPropertyList:[[LPRecorder sharedRecorder]
+          events]
+                                                                 format:NSPropertyListXMLFormat_v1_0
+                                                       errorDescription:&error];
+  if (error) {
+    NSLog(@"error getting plist data: %@", error);
+    return nil;
+  } else {
+    return plistData;
+  }
 //
 //    NSString *rootPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-//    
+//
 //    NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
 //    static NSDateFormatter *fm = nil;
 //    if (!fm) {
@@ -77,9 +85,9 @@
 //    }
 //    NSString* timestamp = [fm stringFromDate:[NSDate date]];
 //    NSString* tempFile = [NSString stringWithFormat:@"record_%@_%@.plist",appID,timestamp,nil];
-//    
+//
 //    NSString *plistPath = [rootPath stringByAppendingPathComponent:tempFile];
-//    
+//
 //
 //    [[Recorder sharedRecorder] saveToFile:plistPath];
 //    return tempFile;

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.h
@@ -7,7 +7,8 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPScreenshotRoute : NSObject<LPRoute>
+@interface LPScreenshotRoute : NSObject <LPRoute>
 
-- (NSData*)takeScreenshot;
+- (NSData *) takeScreenshot;
+
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -7,66 +7,65 @@
 #import "LPScreenshotRoute.h"
 #import "LPHTTPDataResponse.h"
 #import "LPTouchUtils.h"
-#import <QuartzCore/QuartzCore.h>
 
 
 // UIGetScreenImage violates t
 @implementation LPScreenshotRoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"GET"];
-}
-
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path {
-    LPHTTPDataResponse* drsp = [[LPHTTPDataResponse alloc] initWithData:[self takeScreenshot]];
-    return [drsp autorelease];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"GET"];
 }
 
 
-- (NSData*)takeScreenshot 
-{
-    // Create a graphics context with the target size
-    // On iOS 4 and later, use UIGraphicsBeginImageContextWithOptions to take the scale into consideration
-    // On iOS prior to 4, fall back to use UIGraphicsBeginImageContext
-    CGSize imageSize = [[UIScreen mainScreen] bounds].size;
-    if (NULL != UIGraphicsBeginImageContextWithOptions)
-        UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
-    else
-        UIGraphicsBeginImageContext(imageSize);
-    
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    // Iterate over every window from back to front
-    for (UIWindow *window in [LPTouchUtils applicationWindows])
-    {
-        if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen])
-        {
-            // -renderInContext: renders in the coordinate space of the layer,
-            // so we must first apply the layer's geometry to the graphics context
-            CGContextSaveGState(context);
-            // Center the context around the window's anchor point
-            CGContextTranslateCTM(context, [window center].x, [window center].y);
-            // Apply the window's transform about the anchor point
-            CGContextConcatCTM(context, [window transform]);
-            // Offset by the portion of the bounds left of and above the anchor point
-            CGContextTranslateCTM(context,
-                                  -[window bounds].size.width * [[window layer] anchorPoint].x,
-                                  -[window bounds].size.height * [[window layer] anchorPoint].y);
-            
-            // Render the layer hierarchy to the current context
-            [[window layer] renderInContext:context];
-            
-            // Restore the context
-            CGContextRestoreGState(context);
-        }
+- (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
+  LPHTTPDataResponse *drsp = [[LPHTTPDataResponse alloc]
+          initWithData:[self takeScreenshot]];
+  return [drsp autorelease];
+}
+
+
+- (NSData *) takeScreenshot {
+  // Create a graphics context with the target size
+  // On iOS 4 and later, use UIGraphicsBeginImageContextWithOptions to take the scale into consideration
+  // On iOS prior to 4, fall back to use UIGraphicsBeginImageContext
+  CGSize imageSize = [[UIScreen mainScreen] bounds].size;
+  if (NULL != UIGraphicsBeginImageContextWithOptions) {
+    UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
+  } else {
+    UIGraphicsBeginImageContext(imageSize);
+  }
+
+  CGContextRef context = UIGraphicsGetCurrentContext();
+
+  // Iterate over every window from back to front
+  for (UIWindow *window in [LPTouchUtils applicationWindows]) {
+    if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen]) {
+      // -renderInContext: renders in the coordinate space of the layer,
+      // so we must first apply the layer's geometry to the graphics context
+      CGContextSaveGState(context);
+      // Center the context around the window's anchor point
+      CGContextTranslateCTM(context, [window center].x, [window center].y);
+      // Apply the window's transform about the anchor point
+      CGContextConcatCTM(context, [window transform]);
+      // Offset by the portion of the bounds left of and above the anchor point
+      CGContextTranslateCTM(context,
+              -[window bounds].size.width * [[window layer] anchorPoint].x,
+              -[window bounds].size.height * [[window layer] anchorPoint].y);
+
+      // Render the layer hierarchy to the current context
+      [[window layer] renderInContext:context];
+
+      // Restore the context
+      CGContextRestoreGState(context);
     }
-    
-    // Retrieve the screenshot image
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    
-    UIGraphicsEndImageContext();
+  }
 
-    
+  // Retrieve the screenshot image
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+
+  UIGraphicsEndImageContext();
+
+
 //    NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
 //    static NSDateFormatter *fm = nil;
 //    if (!fm) {
@@ -75,8 +74,8 @@
 //    }
 //    NSString* timestamp = [fm stringFromDate:[NSDate date]];
 //    NSString* tempFile = [NSString stringWithFormat:@"%@screenshot_%@_%@.png",tempDir,appID,timestamp,nil];
-    
-    return UIImagePNGRepresentation(image);
+
+  return UIImagePNGRepresentation(image);
 }
 
 

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute2.h
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute2.h
@@ -7,7 +7,9 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPScreenshotRoute2 : NSObject<LPRoute>
+// todo why does LPScreenshotRoute2 exist?
+@interface LPScreenshotRoute2 : NSObject <LPRoute>
 
-- (NSData*)takeScreenshot;
+- (NSData *) takeScreenshot;
+
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute2.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute2.m
@@ -6,29 +6,31 @@
 
 #import "LPScreenshotRoute2.h"
 #import "LPHTTPDataResponse.h"
-#import <QuartzCore/QuartzCore.h>
+
+
 CGImageRef UIGetScreenImage(void);
 
 // UIGetScreenImage violates t
 @implementation LPScreenshotRoute2
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"GET"];
-}
-
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path {
-    LPHTTPDataResponse* drsp = [[LPHTTPDataResponse alloc] initWithData:[self takeScreenshot]];
-    return [drsp autorelease];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"GET"];
 }
 
 
-- (NSData*)takeScreenshot 
-{
+- (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
+  LPHTTPDataResponse *drsp = [[LPHTTPDataResponse alloc]
+          initWithData:[self takeScreenshot]];
+  return [drsp autorelease];
+}
 
-    CGImageRef screen = UIGetScreenImage();
-    UIImage* image = [UIImage imageWithCGImage:screen];
-    CGImageRelease(screen); 
-    return UIImagePNGRepresentation(image);
+
+- (NSData *) takeScreenshot {
+
+  CGImageRef screen = UIGetScreenImage();
+  UIImage *image = [UIImage imageWithCGImage:screen];
+  CGImageRelease(screen);
+  return UIImagePNGRepresentation(image);
 }
 
 

--- a/calabash/Classes/FranklyServer/Routes/LPUIARoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPUIARoute.m
@@ -11,27 +11,24 @@
 
 @implementation LPUIARoute
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
 }
 
--(void) beginOperation {
-    self.done = NO;
-    
-    NSString *command = [self.data objectForKey:@"command"];
-    [LPUIAChannel runAutomationCommand: command
-                                  then:  ^(NSDictionary *result)
-    {
-            if (!result) {
-                [self failWithMessageFormat:@"Timed out running command %@" message:command];
-            }
-            else {
-                [self succeedWithResult:[NSArray arrayWithObject:[[result copy] autorelease]]];
-            }
-    }];
 
-    
-    
+- (void) beginOperation {
+  self.done = NO;
+
+  NSString *command = [self.data objectForKey:@"command"];
+  [LPUIAChannel runAutomationCommand:command then:^(NSDictionary *result) {
+    if (!result) {
+      [self failWithMessageFormat:@"Timed out running command %@"
+                          message:command];
+    } else {
+      [self succeedWithResult:[NSArray arrayWithObject:[[result copy]
+              autorelease]]];
+    }
+  }];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPUserPrefRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPUserPrefRoute.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
 
-@interface LPUserPrefRoute : NSObject<LPRoute> 
+@interface LPUserPrefRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPUserPrefRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPUserPrefRoute.m
@@ -7,47 +7,42 @@
 //
 
 #import "LPUserPrefRoute.h"
-#import "LPJSONUtils.h"
 
 @implementation LPUserPrefRoute
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
-    return [method isEqualToString:@"POST"] ||[method isEqualToString:@"GET"];
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"] || [method isEqualToString:@"GET"];
 }
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {
-    NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
-    [ud synchronize];    
 
-    NSString *key = [data valueForKey:@"key"];
-    id curVal = [ud valueForKey:key];
 
-    if ([method isEqualToString:@"POST"])
-    {    
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  [ud synchronize];
 
-        id val = [data valueForKey:@"value"];
-                         
-        if ([val isKindOfClass:[NSNull class]])
-        {
-            [ud removeObjectForKey:key];
-        }
-        else
-        {
-            [ud setValue:val forKey:key];            
-        }
+  NSString *key = [data valueForKey:@"key"];
+  id curVal = [ud valueForKey:key];
 
-        
-        [ud synchronize];    
-        
-        return [NSDictionary dictionaryWithObjectsAndKeys:
-                [NSArray arrayWithObjects:val,curVal, nil], @"results",
-                @"SUCCESS",@"outcome",
-                nil];
-        
+  if ([method isEqualToString:@"POST"]) {
+
+    id val = [data valueForKey:@"value"];
+
+    if ([val isKindOfClass:[NSNull class]]) {
+      [ud removeObjectForKey:key];
+    } else {
+      [ud setValue:val forKey:key];
     }
-    return [NSDictionary dictionaryWithObjectsAndKeys:
-            [NSArray arrayWithObjects:curVal, nil], @"results",
-            @"SUCCESS",@"outcome",
-            nil];
-                         
-    
+
+
+    [ud synchronize];
+
+    return [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObjects:val,
+                                                                                curVal,
+                                                                                nil], @"results",
+                                                      @"SUCCESS", @"outcome",
+                                                      nil];
+  }
+  return [NSDictionary dictionaryWithObjectsAndKeys:[NSArray arrayWithObjects:curVal,
+                                                                              nil], @"results",
+                                                    @"SUCCESS", @"outcome",
+                                                    nil];
 }
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
@@ -8,7 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "LPRoute.h"
+
 #define kLPCALABASHVERSION @"0.9.167"
-@interface LPVersionRoute : NSObject<LPRoute>
+
+@interface LPVersionRoute : NSObject <LPRoute>
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -9,27 +9,28 @@
 #import "LPVersionRoute.h"
 #import "LPTouchUtils.h"
 #import <sys/utsname.h>
+
 @class UIDevice;
 
 
 /*** UNEXPECTED ***
  adds git version and branch information to the server_version route
- 
+
  helps developers know exactly which server framework is installed in an ipa
- 
+
  the two defines:
- 
+
  #define LP_GIT_SHORT_REVISION <rev>  // ex. @"4fdb203"
  #define LP_GIT_BRANCH <branch>       // ex. @"0.9.x"
- 
+
  are generated before compilation and erased after to avoid git conflicts in
  LPGitVersionDefines.h
- 
+
  to see how LPGitVersionDefines.h is managed see:
- 
+
  1. Run Script - git versioning 1 of 2
  2. Run Script - git versioning 2 of 2
- 
+
  ******************/
 #import "LPGitVersionDefines.h"
 
@@ -60,74 +61,72 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
 @implementation LPVersionRoute
 
 - (BOOL) isIPhoneAppEmulatedOnIPad {
-    UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
-    NSString *model = [[UIDevice currentDevice] model];
-    return idiom == UIUserInterfaceIdiomPhone && [model hasPrefix:@"iPad"];
+  UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
+  NSString *model = [[UIDevice currentDevice] model];
+  return idiom == UIUserInterfaceIdiomPhone && [model hasPrefix:@"iPad"];
 }
 
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path
-{
-    return [method isEqualToString:@"GET"];
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"GET"];
 }
 
-- (NSDictionary *)JSONResponseForMethod:(NSString *)method URI:(NSString *)path data:(NSDictionary*)data {    
-    NSString *versionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    if (!versionString)
-    {
-        versionString = @"Unknown";
-    }
-    NSString *idString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
-    if (!idString)
-    {
-        idString = @"Unknown";
-    }
-    NSString *nameString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
 
-    if (!nameString)
-    {
-        nameString = @"Unknown";
-    }
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    
-    NSString *system = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-    
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+  NSString *versionString = [[NSBundle mainBundle]
+          objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  if (!versionString) {
+    versionString = @"Unknown";
+  }
+  NSString *idString = [[NSBundle mainBundle]
+          objectForInfoDictionaryKey:@"CFBundleIdentifier"];
+  if (!idString) {
+    idString = @"Unknown";
+  }
+  NSString *nameString = [[NSBundle mainBundle]
+          objectForInfoDictionaryKey:@"CFBundleDisplayName"];
 
-    NSDictionary *env = [[NSProcessInfo processInfo]environment];
+  if (!nameString) {
+    nameString = @"Unknown";
+  }
+  struct utsname systemInfo;
+  uname(&systemInfo);
 
-    BOOL iphone5Like = [LPTouchUtils is4InchDevice];
+  NSString *system = [NSString stringWithCString:systemInfo.machine
+                                        encoding:NSUTF8StringEncoding];
 
-    NSString *dev = [env objectForKey:@"IPHONE_SIMULATOR_DEVICE"];
-    if (!dev) {
-        dev = @"";
-    }
-    
-    NSString *sim = [env objectForKey:@"IPHONE_SIMULATOR_VERSIONS"];
-    if (!sim) {
-        sim = @"";
-    }
-    
-    BOOL isIphoneAppEmulated = [self isIPhoneAppEmulatedOnIPad];
-    NSDictionary *git = @{@"revision" : kLPGitShortRevision,
-                          @"branch" : kLPGitBranch,
-                          @"remote_origin" : kLPGitRemoteOrigin};
-    
-    NSDictionary* res = [NSDictionary dictionaryWithObjectsAndKeys:
-                         kLPCALABASHVERSION , @"version",
-                         idString,@"app_id",
-                         [[UIDevice currentDevice] systemVersion], @"iOS_version",
-                         nameString,@"app_name",
-                         system, @"system",
-                         [NSNumber numberWithBool:iphone5Like], @"4inch",
-                         dev, @"simulator_device",
-                         sim, @"simulator",
-                         versionString,@"app_version",
-                         @"SUCCESS",@"outcome",
-                         [NSNumber numberWithBool:isIphoneAppEmulated], @"iphone_app_emulated_on_ipad",
-                         git, @"git",
-                         nil];
-    return res;
-    
+  NSDictionary *env = [[NSProcessInfo processInfo] environment];
+
+  BOOL iphone5Like = [LPTouchUtils is4InchDevice];
+
+  NSString *dev = [env objectForKey:@"IPHONE_SIMULATOR_DEVICE"];
+  if (!dev) {
+    dev = @"";
+  }
+
+  NSString *sim = [env objectForKey:@"IPHONE_SIMULATOR_VERSIONS"];
+  if (!sim) {
+    sim = @"";
+  }
+
+  BOOL isIphoneAppEmulated = [self isIPhoneAppEmulatedOnIPad];
+  NSDictionary *git = @{@"revision" : kLPGitShortRevision, @"branch" : kLPGitBranch, @"remote_origin" : kLPGitRemoteOrigin};
+
+  NSDictionary *res = [NSDictionary dictionaryWithObjectsAndKeys:kLPCALABASHVERSION , @"version",
+                                                                 idString, @"app_id",
+                                                                 [[UIDevice currentDevice]
+                                                                         systemVersion], @"iOS_version",
+                                                                 nameString, @"app_name",
+                                                                 system, @"system",
+                                                                 [NSNumber numberWithBool:iphone5Like], @"4inch",
+                                                                 dev, @"simulator_device",
+                                                                 sim, @"simulator",
+                                                                 versionString, @"app_version",
+                                                                 @"SUCCESS", @"outcome",
+                                                                 [NSNumber numberWithBool:isIphoneAppEmulated], @"iphone_app_emulated_on_ipad",
+                                                                 git, @"git",
+                                                                 nil];
+  return res;
 }
 
 

--- a/calabash/Classes/MapKit/MKMapView+Test.m
+++ b/calabash/Classes/MapKit/MKMapView+Test.m
@@ -8,67 +8,73 @@
 
 @implementation MKMapView (Test)
 
-- (NSString*) mapBounds {
-    MKCoordinateRegion region = [self region];
-    double dlat = region.span.latitudeDelta / 2;
-    double dlon = region.span.longitudeDelta / 2;
-    double top = region.center.latitude + dlat;
-    double bottom = region.center.latitude - dlat;
-    double left = region.center.longitude - dlon;
-    double right = region.center.longitude + dlon;
-    return [NSString stringWithFormat:@"{\"top\":%F, \"right\":%F, \"bottom\":%F, \"left\":%F}", top, right, bottom, left];
+- (NSString *) mapBounds {
+  MKCoordinateRegion region = [self region];
+  double dlat = region.span.latitudeDelta / 2;
+  double dlon = region.span.longitudeDelta / 2;
+  double top = region.center.latitude + dlat;
+  double bottom = region.center.latitude - dlat;
+  double left = region.center.longitude - dlon;
+  double right = region.center.longitude + dlon;
+  return [NSString stringWithFormat:@"{\"top\":%F, \"right\":%F, \"bottom\":%F, \"left\":%F}", top, right, bottom, left];
 }
 
-- (void) setCenterToLat:(double)lat lon:(double)lon {
-    CLLocationCoordinate2D coordinate = (CLLocationCoordinate2D){lat, lon};
-    [self setCenterCoordinate:coordinate animated:NO];
+
+- (void) setCenterToLat:(double) lat lon:(double) lon {
+  CLLocationCoordinate2D coordinate = (CLLocationCoordinate2D) {lat, lon};
+  [self setCenterCoordinate:coordinate animated:NO];
 }
 
-- (void) panToLat:(double)lat lon:(double)lon {
-    CLLocationCoordinate2D coordinate = (CLLocationCoordinate2D){lat, lon};
-    [self setCenterCoordinate:coordinate animated:YES];
+
+- (void) panToLat:(double) lat lon:(double) lon {
+  CLLocationCoordinate2D coordinate = (CLLocationCoordinate2D) {lat, lon};
+  [self setCenterCoordinate:coordinate animated:YES];
 }
 
-- (NSString*) currentCenterLocation {
-    CLLocationCoordinate2D center = self.centerCoordinate;	
-    return [NSString stringWithFormat:@"%3.6F,%3.6F", center.latitude, center.longitude];
+
+- (NSString *) currentCenterLocation {
+  CLLocationCoordinate2D center = self.centerCoordinate;
+  return [NSString stringWithFormat:@"%3.6F,%3.6F", center.latitude, center.longitude];
 }
 
-- (void) showUserLocation:(NSString*)show {
-    BOOL showUser = [@"false" isEqualToString:show] == NO;
-    //    [self showsUserLocation:showUser];
-    self.showsUserLocation = showUser;
+
+- (void) showUserLocation:(NSString *) show {
+  BOOL showUser = [@"false" isEqualToString:show] == NO;
+  //    [self showsUserLocation:showUser];
+  self.showsUserLocation = showUser;
 }
+
 
 /**
  * selects or deselects the named marker (AKA annotation)
  */
-- (NSNumber*) tapMarkerByTitle:(NSString*)title {
-    for (NSObject<MKAnnotation> *annotation in [self annotations]) {
-        BOOL matched = [[annotation title] isEqualToString:title];
-        if( !matched ) {
-            // If we can't match by title, perhaps we can match against something in the description
-            // for iPhone 3.2 or better we can check the :description for the title
-            NSString *regEx = [NSString stringWithFormat:@"[\\b_]%@\\b", title];
-            NSRange r = [[annotation description] rangeOfString:regEx options:NSRegularExpressionSearch];
-            if (r.location != NSNotFound) {
-                matched = TRUE;
-            }
-            // for older phones, we could fall back to  [[annotation description] hasSuffix:title] 
-        }
-        
-        if( matched ) {
-            if( [[self selectedAnnotations] containsObject:annotation] ) {
-                [self deselectAnnotation:(id <MKAnnotation>)annotation animated:NO];
-            } else {
-                [self selectAnnotation:(id <MKAnnotation>)annotation animated:NO];
-            }
-            return [NSNumber numberWithBool:YES];
-        }
+- (NSNumber *) tapMarkerByTitle:(NSString *) title {
+  for (NSObject <MKAnnotation> *annotation in [self annotations]) {
+    BOOL matched = [[annotation title] isEqualToString:title];
+    if (!matched) {
+      // If we can't match by title, perhaps we can match against something in the description
+      // for iPhone 3.2 or better we can check the :description for the title
+      NSString *regEx = [NSString stringWithFormat:@"[\\b_]%@\\b", title];
+      NSRange r = [[annotation description] rangeOfString:regEx options:NSRegularExpressionSearch];
+      if (r.location != NSNotFound) {
+        matched = TRUE;
+      }
+      // for older phones, we could fall back to  [[annotation description] hasSuffix:title]
     }
-    
-    return [NSNumber numberWithBool:NO];
+
+    if (matched) {
+      if ([[self selectedAnnotations] containsObject:annotation]) {
+        [self deselectAnnotation:(id <MKAnnotation>) annotation animated:NO];
+      } else {
+        [self selectAnnotation:(id <MKAnnotation>) annotation animated:NO];
+      }
+      return [NSNumber numberWithBool:YES];
+    }
+  }
+
+  return [NSNumber numberWithBool:NO];
 }
+
 
 /**
  * Provides useful information for a specified marker (MKAnnotation) using the annotation's "debugDescription" method
@@ -76,35 +82,33 @@
  *
  * @return nil or (for example)) {title:"My Marker", "latitude":-33.123456, "longitude":151.123456, "foo":"bar", "focused":true}
  */
-- (NSString*) getMarkerByTitle:(NSString*)title {
-    for (NSObject<MKAnnotation> *annotation in [self annotations]) {
-        BOOL matched = [[annotation title] isEqualToString:title];
-        if( !matched ) {
-            // If we can't match by title, perhaps we can match against something in the description
-            // for iPhone 3.2 or better we can check the :description for the title
-            NSString *regEx = [NSString stringWithFormat:@"[\\b_]%@\\b", title];
-            NSRange r = [[annotation description] rangeOfString:regEx options:NSRegularExpressionSearch];
-            if (r.location != NSNotFound) {
-                matched = TRUE;
-            }
-            // for older phones, we could fall back to  [[annotation description] hasSuffix:title] 
-        }
-        
-        if( matched ) {
-            NSString* str = [annotation debugDescription];
-            
-            if( [[self selectedAnnotations] containsObject:annotation] ) {
-                //str = [str stringByReplacingOccurrencesOfString:@"}" withString:@", \"focused\":true}"];               
-                str = [str substringToIndex:([str length] - 1)];  // up to but not including index
-                str = [str stringByAppendingString:@", \"focused\":true}"];
-            }
-            
-            return str;
-        }
+- (NSString *) getMarkerByTitle:(NSString *) title {
+  for (NSObject <MKAnnotation> *annotation in [self annotations]) {
+    BOOL matched = [[annotation title] isEqualToString:title];
+    if (!matched) {
+      // If we can't match by title, perhaps we can match against something in the description
+      // for iPhone 3.2 or better we can check the :description for the title
+      NSString *regEx = [NSString stringWithFormat:@"[\\b_]%@\\b", title];
+      NSRange r = [[annotation description] rangeOfString:regEx options:NSRegularExpressionSearch];
+      if (r.location != NSNotFound) {
+        matched = TRUE;
+      }
+      // for older phones, we could fall back to  [[annotation description] hasSuffix:title]
     }
-    
-    return nil;
-}
 
+    if (matched) {
+      NSString *str = [annotation debugDescription];
+
+      if ([[self selectedAnnotations] containsObject:annotation]) {
+        //str = [str stringByReplacingOccurrencesOfString:@"}" withString:@", \"focused\":true}"];
+        str = [str substringToIndex:([str length] - 1)];  // up to but not including index
+        str = [str stringByAppendingString:@", \"focused\":true}"];
+      }
+
+      return str;
+    }
+  }
+  return nil;
+}
 
 @end

--- a/calabash/Classes/MapKit/MKMapView+ZoomLevel.h
+++ b/calabash/Classes/MapKit/MKMapView+ZoomLevel.h
@@ -7,9 +7,7 @@
 
 @interface MKMapView (ZoomLevel)
 
-- (void)calSetCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
-                  zoomLevel:(NSUInteger)zoomLevel
-                   animated:(BOOL)animated;
+- (void) calSetCenterCoordinate:(CLLocationCoordinate2D) centerCoordinate zoomLevel:(NSUInteger) zoomLevel animated:(BOOL) animated;
 
 - (NSUInteger) calZoomLevel;
 

--- a/calabash/Classes/MapKit/MKMapView+ZoomLevel.m
+++ b/calabash/Classes/MapKit/MKMapView+ZoomLevel.m
@@ -12,122 +12,120 @@
 #pragma mark -
 #pragma mark Map conversion methods
 
-- (double)calLongitudeToPixelSpaceX:(double)longitude
-{
-    return round(CAL_MERCATOR_OFFSET + CAL_MERCATOR_RADIUS * longitude * M_PI / 180.0);
+- (double) calLongitudeToPixelSpaceX:(double) longitude {
+  return round(CAL_MERCATOR_OFFSET + CAL_MERCATOR_RADIUS * longitude * M_PI / 180.0);
 }
 
-- (double)calLatitudeToPixelSpaceY:(double)latitude
-{
-    return round(CAL_MERCATOR_OFFSET - CAL_MERCATOR_RADIUS * logf((1 + sinf(latitude * M_PI / 180.0)) / (1 - sinf(latitude * M_PI / 180.0))) / 2.0);
+
+- (double) calLatitudeToPixelSpaceY:(double) latitude {
+  return round(CAL_MERCATOR_OFFSET - CAL_MERCATOR_RADIUS * logf((1 + sinf(latitude * M_PI / 180.0)) / (1 - sinf(latitude * M_PI / 180.0))) / 2.0);
 }
 
-- (double)calPixelSpaceXToLongitude:(double)pixelX
-{
-    return ((round(pixelX) - CAL_MERCATOR_OFFSET) / CAL_MERCATOR_RADIUS) * 180.0 / M_PI;
+
+- (double) calPixelSpaceXToLongitude:(double) pixelX {
+  return ((round(pixelX) - CAL_MERCATOR_OFFSET) / CAL_MERCATOR_RADIUS) * 180.0 / M_PI;
 }
 
-- (double)calPixelSpaceYToLatitude:(double)pixelY
-{
-    return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - CAL_MERCATOR_OFFSET) / CAL_MERCATOR_RADIUS))) * 180.0 / M_PI;
+
+- (double) calPixelSpaceYToLatitude:(double) pixelY {
+  return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - CAL_MERCATOR_OFFSET) / CAL_MERCATOR_RADIUS))) * 180.0 / M_PI;
 }
 
 #pragma mark -
 #pragma mark Helper methods
 
-- (MKCoordinateSpan)calCoordinateSpanWithMapView:(MKMapView *)mapView
-                             centerCoordinate:(CLLocationCoordinate2D)centerCoordinate
-                                 andZoomLevel:(NSUInteger)zoomLevel
-{
-    // convert center coordiate to pixel space
-    double centerPixelX = [self calLongitudeToPixelSpaceX:centerCoordinate.longitude];
-    double centerPixelY = [self calLatitudeToPixelSpaceY:centerCoordinate.latitude];
-    
-    // determine the scale value from the zoom level
-    NSInteger zoomExponent = 20 - zoomLevel;
-    double zoomScale = pow(2, zoomExponent);
-    
-    // scale the map’s size in pixel space
-    CGSize mapSizeInPixels = mapView.bounds.size;
-    double scaledMapWidth = mapSizeInPixels.width * zoomScale;
-    double scaledMapHeight = mapSizeInPixels.height * zoomScale;
-    
-    // figure out the position of the top-left pixel
-    double topLeftPixelX = centerPixelX - (scaledMapWidth / 2);
-    double topLeftPixelY = centerPixelY - (scaledMapHeight / 2);
-    
-    // find delta between left and right longitudes
-    CLLocationDegrees minLng = [self calPixelSpaceXToLongitude:topLeftPixelX];
-    CLLocationDegrees maxLng = [self calPixelSpaceXToLongitude:topLeftPixelX + scaledMapWidth];
-    CLLocationDegrees longitudeDelta = maxLng - minLng;
-    
-    // find delta between top and bottom latitudes
-    CLLocationDegrees minLat = [self calPixelSpaceYToLatitude:topLeftPixelY];
-    CLLocationDegrees maxLat = [self calPixelSpaceYToLatitude:topLeftPixelY + scaledMapHeight];
-    CLLocationDegrees latitudeDelta = -1 * (maxLat - minLat);
-    
-    // create and return the lat/lng span
-    MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
-    return span;
+- (MKCoordinateSpan) calCoordinateSpanWithMapView:(MKMapView *) mapView centerCoordinate:(CLLocationCoordinate2D) centerCoordinate andZoomLevel:(NSUInteger) zoomLevel {
+  // convert center coordiate to pixel space
+  double centerPixelX = [self calLongitudeToPixelSpaceX:centerCoordinate.longitude];
+  double centerPixelY = [self calLatitudeToPixelSpaceY:centerCoordinate.latitude];
+
+  // determine the scale value from the zoom level
+  NSInteger zoomExponent = 20 - zoomLevel;
+  double zoomScale = pow(2, zoomExponent);
+
+  // scale the map’s size in pixel space
+  CGSize mapSizeInPixels = mapView.bounds.size;
+  double scaledMapWidth = mapSizeInPixels.width * zoomScale;
+  double scaledMapHeight = mapSizeInPixels.height * zoomScale;
+
+  // figure out the position of the top-left pixel
+  double topLeftPixelX = centerPixelX - (scaledMapWidth / 2);
+  double topLeftPixelY = centerPixelY - (scaledMapHeight / 2);
+
+  // find delta between left and right longitudes
+  CLLocationDegrees minLng = [self calPixelSpaceXToLongitude:topLeftPixelX];
+  CLLocationDegrees maxLng = [self calPixelSpaceXToLongitude:topLeftPixelX + scaledMapWidth];
+  CLLocationDegrees longitudeDelta = maxLng - minLng;
+
+  // find delta between top and bottom latitudes
+  CLLocationDegrees minLat = [self calPixelSpaceYToLatitude:topLeftPixelY];
+  CLLocationDegrees maxLat = [self calPixelSpaceYToLatitude:topLeftPixelY + scaledMapHeight];
+  CLLocationDegrees latitudeDelta = -1 * (maxLat - minLat);
+
+  // create and return the lat/lng span
+  MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
+  return span;
 }
 
-- (NSUInteger) calZoomLevelWithMapView: (MKMapView*) mapView {
-    MKCoordinateRegion region = self.region;
-    
-    double centerPixelX = [self calLongitudeToPixelSpaceX: region.center.longitude];
-    double topLeftPixelX = [self calLongitudeToPixelSpaceX: region.center.longitude - region.span.longitudeDelta / 2];
-    
-    double scaledMapWidth = (centerPixelX - topLeftPixelX) * 2;
-    CGSize mapSizeInPixels = mapView.bounds.size;
-    double zoomScale = scaledMapWidth / mapSizeInPixels.width;
-    double zoomExponent = log(zoomScale) / log(2);
-    double zoomLevel = 20 - zoomExponent;
-    
-    return zoomLevel;
+
+- (NSUInteger) calZoomLevelWithMapView:(MKMapView *) mapView {
+  MKCoordinateRegion region = self.region;
+
+  double centerPixelX = [self calLongitudeToPixelSpaceX:region.center.longitude];
+  double topLeftPixelX = [self calLongitudeToPixelSpaceX:region.center.longitude - region.span.longitudeDelta / 2];
+
+  double scaledMapWidth = (centerPixelX - topLeftPixelX) * 2;
+  CGSize mapSizeInPixels = mapView.bounds.size;
+  double zoomScale = scaledMapWidth / mapSizeInPixels.width;
+  double zoomExponent = log(zoomScale) / log(2);
+  double zoomLevel = 20 - zoomExponent;
+  // TODO suspicious conversion of double to NSUInteger in MKMapView+ZoomLevel.m
+  return zoomLevel;
 }
 
 #pragma mark -
 #pragma mark Public methods
 
-- (void)calSetCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
-                  zoomLevel:(NSUInteger)zoomLevel
-                   animated:(BOOL)animated
-{
-    // clamp large numbers to 28
-    zoomLevel = MIN(zoomLevel, 28);
-    
-    // use the zoom level to compute the region
-    MKCoordinateSpan span = [self calCoordinateSpanWithMapView:self centerCoordinate:centerCoordinate andZoomLevel:zoomLevel];
-    MKCoordinateRegion region = MKCoordinateRegionMake(centerCoordinate, span);
-    
-    // set the region like normal
-    [self setRegion:region animated:animated];
+- (void) calSetCenterCoordinate:(CLLocationCoordinate2D) centerCoordinate zoomLevel:(NSUInteger) zoomLevel animated:(BOOL) animated {
+  // clamp large numbers to 28
+  zoomLevel = MIN(zoomLevel, 28);
+
+  // use the zoom level to compute the region
+  MKCoordinateSpan span = [self calCoordinateSpanWithMapView:self centerCoordinate:centerCoordinate andZoomLevel:zoomLevel];
+  MKCoordinateRegion region = MKCoordinateRegionMake(centerCoordinate, span);
+
+  // set the region like normal
+  [self setRegion:region animated:animated];
 }
 
-- (NSNumber*) calSetZoomLevel:(int)zoomLevel {
-    CLLocationCoordinate2D center = self.centerCoordinate;	
-    [self calSetCenterCoordinate:center zoomLevel:zoomLevel animated:NO];
-    
-    NSUInteger newZoomLevel = [self calZoomLevel];
-    BOOL success = (newZoomLevel == zoomLevel);
-    return [NSNumber numberWithBool:success];
+
+- (NSNumber *) calSetZoomLevel:(int) zoomLevel {
+  CLLocationCoordinate2D center = self.centerCoordinate;
+  [self calSetCenterCoordinate:center zoomLevel:zoomLevel animated:NO];
+
+  NSUInteger newZoomLevel = [self calZoomLevel];
+  BOOL success = (newZoomLevel == zoomLevel);
+  return [NSNumber numberWithBool:success];
 }
 
-- (NSNumber*) calZoomIn {
-    NSUInteger prevZoomLevel = [self calZoomLevel];
-    NSUInteger reqZoomLevel = prevZoomLevel + 1;
-    return [self calSetZoomLevel:reqZoomLevel];
+
+- (NSNumber *) calZoomIn {
+  NSUInteger prevZoomLevel = [self calZoomLevel];
+  NSUInteger reqZoomLevel = prevZoomLevel + 1;
+  return [self calSetZoomLevel:reqZoomLevel];
 }
 
-- (NSNumber*) calZoomOut {
-    NSUInteger prevZoomLevel = [self calZoomLevel];
-    NSUInteger reqZoomLevel = prevZoomLevel - 1;
-    return [self calSetZoomLevel:reqZoomLevel];
+
+- (NSNumber *) calZoomOut {
+  NSUInteger prevZoomLevel = [self calZoomLevel];
+  NSUInteger reqZoomLevel = prevZoomLevel - 1;
+  return [self calSetZoomLevel:reqZoomLevel];
 }
+
 
 - (NSUInteger) calZoomLevel {
-    NSUInteger zoom = [self calZoomLevelWithMapView:self];
-    return zoom;
+  NSUInteger zoom = [self calZoomLevelWithMapView:self];
+  return zoom;
 }
 
 @end

--- a/calabash/Classes/MapKit/MKPolylineView+Test.m
+++ b/calabash/Classes/MapKit/MKPolylineView+Test.m
@@ -11,30 +11,29 @@
 /**
  * @return {"width: 1, "color":[r,g,b], "points":[[lat,lon], ...]}
  */
-- (NSString*) calDebugDescription {
-    int count = self.polyline.pointCount;
-    CLLocationCoordinate2D* coords = malloc(sizeof(CLLocationCoordinate2D) * count);
-    NSRange range = NSMakeRange(0, count);
-    [[self polyline] getCoordinates:coords range:range];
-    
-    CGFloat lineWidth = self.lineWidth;
-    
-    CGFloat red, green, blue, alpha;
-    [[self strokeColor] getRed:&red green:&green blue:&blue alpha:&alpha];
-    
-    NSString *str = [NSString stringWithFormat:@"{\"width\":%F, \"color\":[%d, %d, %d], \"points\":[", lineWidth, 
-                                                (int)(red * 255), (int)(green * 255), (int)(blue * 255) ];
+- (NSString *) calDebugDescription {
+  int count = self.polyline.pointCount;
+  CLLocationCoordinate2D *coords = malloc(sizeof(CLLocationCoordinate2D) * count);
+  NSRange range = NSMakeRange(0, count);
+  [[self polyline] getCoordinates:coords range:range];
 
-    for( int i = 0; i < count; i++ ) {
-        if( i != 0 ) {
-            str = [str stringByAppendingString:@","];
-        }
-        str = [str stringByAppendingFormat:@"[%F,%F]", coords[i].latitude, coords[i].longitude];
+  CGFloat lineWidth = self.lineWidth;
+
+  CGFloat red, green, blue, alpha;
+  [[self strokeColor] getRed:&red green:&green blue:&blue alpha:&alpha];
+
+  NSString *str = [NSString stringWithFormat:@"{\"width\":%F, \"color\":[%d, %d, %d], \"points\":[", lineWidth, (int) (red * 255), (int) (green * 255), (int) (blue * 255)];
+
+  for (int i = 0; i < count; i++) {
+    if (i != 0) {
+      str = [str stringByAppendingString:@","];
     }
-    str = [str stringByAppendingFormat:@"]}"];
-    
-    free(coords);
-    return str;
+    str = [str stringByAppendingFormat:@"[%F,%F]", coords[i].latitude, coords[i].longitude];
+  }
+  str = [str stringByAppendingFormat:@"]}"];
+
+  free(coords);
+  return str;
 }
 
 @end

--- a/calabash/Classes/Resources/LPResources.h
+++ b/calabash/Classes/Resources/LPResources.h
@@ -5,11 +5,12 @@
 //
 
 #import <Foundation/Foundation.h>
+
 @interface LPResources : NSObject
 
 
-+ (NSArray*) eventsFromEncoding:(NSString *) encoded;
-+ (NSArray *) transformEvents:(NSArray*) eventsRecord toPoint:(CGPoint) viewCenter;
-+ (NSArray *) interpolateEvents:(NSArray*) baseEvents fromPoint:(CGPoint)startAt toPoint:(CGPoint) endAt;
++ (NSArray *) eventsFromEncoding:(NSString *) encoded;
++ (NSArray *) transformEvents:(NSArray *) eventsRecord toPoint:(CGPoint) viewCenter;
++ (NSArray *) interpolateEvents:(NSArray *) baseEvents fromPoint:(CGPoint) startAt toPoint:(CGPoint) endAt;
 
 @end

--- a/calabash/Classes/Resources/LPResources.m
+++ b/calabash/Classes/Resources/LPResources.m
@@ -2,17 +2,17 @@
 //  Resources.m
 /* Copyright (c) 2010 - 2011, Quasidea Development, LLC
  * For more information, please go to http://www.quasidea.com/
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,304 +37,278 @@
 
 @implementation LPResources
 
-static const short _base64DecodingTable[256] = {
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -1, -1, -2, -1, -1, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-1, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, 62, -2, -2, -2, 63,
-	52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -2, -2, -2, -2, -2, -2,
-	-2,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-	15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -2, -2, -2, -2, -2,
-	-2, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-	41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2
-};
+static const short _base64DecodingTable[256] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -1, -1, -2, -1, -1, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -1, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, 62, -2, -2, -2, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -2, -2, -2, -2, -2, -2, -2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -2, -2, -2, -2, -2, -2, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2};
 
 
-+ (NSData *)decodeBase64WithString:(NSString *)strBase64 {
-	const char * objPointer = [strBase64 cStringUsingEncoding:NSASCIIStringEncoding];
-	if (objPointer == NULL)  return nil;
-	size_t intLength = strlen(objPointer);
-	int intCurrent;
-	int i = 0, j = 0, k;
-    
-	unsigned char * objResult;
-	objResult = calloc(intLength, sizeof(unsigned char));
-    
-	// Run through the whole string, converting as we go
-	while ( ((intCurrent = *objPointer++) != '\0') && (intLength-- > 0) ) {
-		if (intCurrent == '=') {
-			if (*objPointer != '=' && ((i % 4) == 1)) {// || (intLength > 0)) {
-				// the padding character is invalid at this point -- so this entire string is invalid
-				free(objResult);
-				return nil;
-			}
-			continue;
-		}
-        
-		intCurrent = _base64DecodingTable[intCurrent];
-		if (intCurrent == -1) {
-			// we're at a whitespace -- simply skip over
-			continue;
-		} else if (intCurrent == -2) {
-			// we're at an invalid character
-			free(objResult);
-			return nil;
-		}
-        
-		switch (i % 4) {
-			case 0:
-				objResult[j] = intCurrent << 2;
-				break;
-                
-			case 1:
-				objResult[j++] |= intCurrent >> 4;
-				objResult[j] = (intCurrent & 0x0f) << 4;
-				break;
-                
-			case 2:
-				objResult[j++] |= intCurrent >>2;
-				objResult[j] = (intCurrent & 0x03) << 6;
-				break;
-                
-			case 3:
-				objResult[j++] |= intCurrent;
-				break;
-		}
-		i++;
-	}
-    
-	// mop things up if we ended on a boundary
-	k = j;
-	if (intCurrent == '=') {
-		switch (i % 4) {
-			case 1:
-				// Invalid state
-				free(objResult);
-				return nil;
-                
-			case 2:
-				k++;
-				// flow through
-			case 3:
-				objResult[k] = 0;
-		}
-	}
-    
-	// Cleanup and setup the return NSData
-	return [[[NSData alloc] initWithBytesNoCopy:objResult length:j freeWhenDone:YES] autorelease];
-}
-+ (NSArray*) eventsFromEncoding:(NSString *) encoded {
-    NSData* data = [self decodeBase64WithString: encoded];
-    NSString* err=nil;
-    NSPropertyListFormat format;
-    return [NSPropertyListSerialization propertyListFromData:data mutabilityOption:NSPropertyListImmutable format:&format errorDescription:&err];
++ (NSData *) decodeBase64WithString:(NSString *) strBase64 {
+  const char *objPointer = [strBase64 cStringUsingEncoding:NSASCIIStringEncoding];
+  if (objPointer == NULL) {return nil;}
+  size_t intLength = strlen(objPointer);
+  int intCurrent;
+  int i = 0, j = 0, k;
 
+  unsigned char *objResult;
+  objResult = calloc(intLength, sizeof(unsigned char));
+
+  // Run through the whole string, converting as we go
+  while (((intCurrent = *objPointer++) != '\0') && (intLength-- > 0)) {
+    if (intCurrent == '=') {
+      if (*objPointer != '=' && ((i % 4) == 1)) {// || (intLength > 0)) {
+        // the padding character is invalid at this point -- so this entire string is invalid
+        free(objResult);
+        return nil;
+      }
+      continue;
+    }
+
+    intCurrent = _base64DecodingTable[intCurrent];
+    if (intCurrent == -1) {
+      // we're at a whitespace -- simply skip over
+      continue;
+    } else if (intCurrent == -2) {
+      // we're at an invalid character
+      free(objResult);
+      return nil;
+    }
+
+    switch (i % 4) {
+      case 0: objResult[j] = intCurrent << 2;
+        break;
+
+      case 1: objResult[j++] |= intCurrent >> 4;
+        objResult[j] = (intCurrent & 0x0f) << 4;
+        break;
+
+      case 2: objResult[j++] |= intCurrent >> 2;
+        objResult[j] = (intCurrent & 0x03) << 6;
+        break;
+
+      case 3: objResult[j++] |= intCurrent;
+        break;
+    }
+    i++;
+  }
+
+  // mop things up if we ended on a boundary
+  k = j;
+  if (intCurrent == '=') {
+    switch (i % 4) {
+      case 1:
+        // Invalid state
+        free(objResult);
+        return nil;
+
+      case 2: k++;
+        // flow through
+      case 3: objResult[k] = 0;
+    }
+  }
+
+  // Cleanup and setup the return NSData
+  return [[[NSData alloc]
+          initWithBytesNoCopy:objResult length:j freeWhenDone:YES] autorelease];
 }
 
-+ (NSArray *) transformEvents:(NSArray*) eventsRecord toPoint:(CGPoint) _viewCenter {
-    NSMutableArray *transformedEvents = [NSMutableArray arrayWithCapacity:[eventsRecord count]];
-    
+
++ (NSArray *) eventsFromEncoding:(NSString *) encoded {
+  NSData *data = [self decodeBase64WithString:encoded];
+  NSString *err = nil;
+  NSPropertyListFormat format;
+  return [NSPropertyListSerialization propertyListFromData:data
+                                          mutabilityOption:NSPropertyListImmutable
+                                                    format:&format
+                                          errorDescription:&err];
+}
+
+
++ (NSArray *) transformEvents:(NSArray *) eventsRecord toPoint:(CGPoint) _viewCenter {
+  NSMutableArray *transformedEvents = [NSMutableArray arrayWithCapacity:[eventsRecord count]];
+
 //    NSRange iosRange = NSMakeRange(32, 4);
-    
-    NSRange xRange  = NSMakeRange(48, 4);
-    NSRange yRange  = NSMakeRange(52, 4);
-    
-    
-    CGPoint currentPoint,
-    lastPoint = CGRectNull.origin;
-    CGPoint delta = CGPointZero;
-    float x_buf[1];
-    float y_buf[1];
+
+  NSRange xRange = NSMakeRange(48, 4);
+  NSRange yRange = NSMakeRange(52, 4);
+
+  CGPoint currentPoint, lastPoint = CGRectNull.origin;
+  CGPoint delta = CGPointZero;
+  float x_buf[1];
+  float y_buf[1];
 //    unsigned short *ios_buf[4];
-    for (NSDictionary *d in eventsRecord) {
-        
-        NSDictionary* loc = [d valueForKey:@"Location"];
-        NSDictionary* windowLoc = [d valueForKey:@"WindowLocation"];
-        if (loc == nil || windowLoc == nil || [[d valueForKey:@"Type"] integerValue] == 50) {
-            continue;
-        }
-        
-        currentPoint = CGPointMake([[windowLoc valueForKey:@"X"] floatValue], 
-                                   [[windowLoc valueForKey:@"Y"] floatValue]);
-        if (!CGPointEqualToPoint(CGRectNull.origin,lastPoint)) {
-            delta = CGPointMake(delta.x + (currentPoint.x-lastPoint.x),delta.y+(currentPoint.y-lastPoint.y));            
-            
-        }
-        
-        
-        NSMutableDictionary* newLoc = [NSMutableDictionary dictionaryWithDictionary:loc];
-        NSMutableDictionary* newWindowLoc = [NSMutableDictionary dictionaryWithDictionary:windowLoc];
-        
-        [newLoc setValue:
-         [NSNumber numberWithFloat:_viewCenter.x + delta.x] forKey:@"X"];
-        [newLoc setValue:
-         [NSNumber numberWithFloat:_viewCenter.y+ delta.y] forKey:@"Y"];
-        
-        [newWindowLoc setValue:
-         [NSNumber numberWithFloat:_viewCenter.x+ delta.x] forKey:@"X"];
-        [newWindowLoc setValue:
-         [NSNumber numberWithFloat:_viewCenter.y + delta.y] forKey:@"Y"];
-        
-        
-        
-        
-        NSData *data = [d valueForKey:@"Data"];
-        
-        [data getBytes:x_buf   range:xRange];
-        [data getBytes:y_buf   range:yRange];
+  for (NSDictionary *d in eventsRecord) {
+
+    NSDictionary *loc = [d valueForKey:@"Location"];
+    NSDictionary *windowLoc = [d valueForKey:@"WindowLocation"];
+    if (loc == nil || windowLoc == nil || [[d valueForKey:@"Type"]
+            integerValue] == 50) {
+      continue;
+    }
+
+    currentPoint = CGPointMake([[windowLoc valueForKey:@"X"] floatValue],
+            [[windowLoc valueForKey:@"Y"] floatValue]);
+    if (!CGPointEqualToPoint(CGRectNull.origin, lastPoint)) {
+      delta = CGPointMake(delta.x + (currentPoint.x - lastPoint.x),
+              delta.y + (currentPoint.y - lastPoint.y));
+    }
+
+
+    NSMutableDictionary *newLoc = [NSMutableDictionary dictionaryWithDictionary:loc];
+    NSMutableDictionary *newWindowLoc = [NSMutableDictionary dictionaryWithDictionary:windowLoc];
+
+    [newLoc setValue:[NSNumber numberWithFloat:_viewCenter.x + delta.x]
+              forKey:@"X"];
+    [newLoc setValue:[NSNumber numberWithFloat:_viewCenter.y + delta.y]
+              forKey:@"Y"];
+
+    [newWindowLoc setValue:[NSNumber numberWithFloat:_viewCenter.x + delta.x]
+                    forKey:@"X"];
+    [newWindowLoc setValue:[NSNumber numberWithFloat:_viewCenter.y + delta.y]
+                    forKey:@"Y"];
+
+
+    NSData *data = [d valueForKey:@"Data"];
+
+    [data getBytes:x_buf range:xRange];
+    [data getBytes:y_buf range:yRange];
 //        [data getBytes:ios_buf   range:iosRange];
 //        NSData *iosData = [[NSData alloc] initWithBytes:ios_buf length:4];
 //        NSLog(@"iosData: %@",iosData);
 //        [iosData release];
-        
-        NSMutableDictionary* newD = [NSMutableDictionary dictionaryWithDictionary:d];
-        NSMutableData *newData = [NSMutableData dataWithData:data];
-        
-        
-        x_buf[0] = _viewCenter.x + delta.x;
-        y_buf[0] = _viewCenter.y + delta.y;
-        [newData replaceBytesInRange:xRange withBytes:x_buf];            
-        [newData replaceBytesInRange:yRange withBytes:y_buf]; 
-        
-        
-        [newD setValue:newData forKey:@"Data"];
-        [newD setValue:newLoc forKey:@"Location"];
-        [newD setValue:newWindowLoc forKey:@"WindowLocation"];
-        
-        [transformedEvents addObject:newD];
-        lastPoint = currentPoint;
-        
-        
-    }
-    return transformedEvents;
+
+    NSMutableDictionary *newD = [NSMutableDictionary dictionaryWithDictionary:d];
+    NSMutableData *newData = [NSMutableData dataWithData:data];
+
+
+    x_buf[0] = _viewCenter.x + delta.x;
+    y_buf[0] = _viewCenter.y + delta.y;
+    [newData replaceBytesInRange:xRange withBytes:x_buf];
+    [newData replaceBytesInRange:yRange withBytes:y_buf];
+
+
+    [newD setValue:newData forKey:@"Data"];
+    [newD setValue:newLoc forKey:@"Location"];
+    [newD setValue:newWindowLoc forKey:@"WindowLocation"];
+
+    [transformedEvents addObject:newD];
+    lastPoint = currentPoint;
+  }
+  return transformedEvents;
 }
+
 
 //https://www.maa.org/EbusPPRO/pdf/meg_ch12.pdf
 //Theorem 12.8 - fundamental theorem of Affine Transformations
-+ (NSArray *) interpolateEvents:(NSArray*) baseEvents fromPoint:(CGPoint)startAt toPoint:(CGPoint) endAt
-{
-    NSMutableArray *transformedEvents = [NSMutableArray arrayWithCapacity:[baseEvents count]];
-    
-    NSDictionary *baseStart =  [[baseEvents objectAtIndex:0] valueForKey:@"WindowLocation"];
-    NSDictionary *baseCenter = [[baseEvents objectAtIndex:[baseEvents count]/2] valueForKey:@"WindowLocation"];
-    NSDictionary *baseEnd =    [[baseEvents objectAtIndex:[baseEvents count]-1] valueForKey:@"WindowLocation"];
-    
-    
-    CGPoint centerAt = CGPointMake(startAt.x + (endAt.x-startAt.x)/2 + 3, startAt.y + (endAt.y-startAt.y)/2 + 3);
-    
-    CGPoint p = CGPointMake([[baseStart valueForKey:@"X"] floatValue], 
-                                      [[baseStart valueForKey:@"Y"] floatValue]);
-    
-    CGPoint q = CGPointMake([[baseCenter valueForKey:@"X"] floatValue], 
-                                       [[baseCenter valueForKey:@"Y"] floatValue]);
++ (NSArray *) interpolateEvents:(NSArray *) baseEvents fromPoint:(CGPoint) startAt toPoint:(CGPoint) endAt {
+  NSMutableArray *transformedEvents = [NSMutableArray arrayWithCapacity:[baseEvents count]];
 
-    CGPoint r = CGPointMake([[baseEnd valueForKey:@"X"] floatValue], 
-                                    [[baseEnd valueForKey:@"Y"] floatValue]);
+  NSDictionary *baseStart = [[baseEvents objectAtIndex:0]
+          valueForKey:@"WindowLocation"];
+  NSDictionary *baseCenter = [[baseEvents objectAtIndex:[baseEvents count] / 2]
+          valueForKey:@"WindowLocation"];
+  NSDictionary *baseEnd = [[baseEvents objectAtIndex:[baseEvents count] - 1]
+          valueForKey:@"WindowLocation"];
 
-    CGFloat a1 = q.x - p.x;    
-    CGFloat c1 = r.x - p.x;
-    CGFloat b1 = q.y - p.y;
-    CGFloat d1 = r.y - p.y;
-    
-    CGFloat a2 = centerAt.x - startAt.x;
-    CGFloat c2 = endAt.x - startAt.x;
-    CGFloat b2 = centerAt.y - startAt.y;
-    CGFloat d2 = endAt.y - startAt.y;
+  CGPoint centerAt = CGPointMake(startAt.x + (endAt.x - startAt.x) / 2 + 3,
+          startAt.y + (endAt.y - startAt.y) / 2 + 3);
 
-    CGAffineTransform f = CGAffineTransformMake(a1, b1, c1, d1, p.x, p.y);
-    
-    CGAffineTransform f_inv = CGAffineTransformInvert(f);
-    
-    CGAffineTransform g = CGAffineTransformMake(a2, b2, c2, d2, startAt.x, startAt.y);
-    
-      
-    
-    CGAffineTransform interpolate = CGAffineTransformConcat(f_inv,g);    
+  CGPoint p = CGPointMake([[baseStart valueForKey:@"X"] floatValue],
+          [[baseStart valueForKey:@"Y"] floatValue]);
+
+  CGPoint q = CGPointMake([[baseCenter valueForKey:@"X"] floatValue],
+          [[baseCenter valueForKey:@"Y"] floatValue]);
+
+  CGPoint r = CGPointMake([[baseEnd valueForKey:@"X"] floatValue],
+          [[baseEnd valueForKey:@"Y"] floatValue]);
+
+  CGFloat a1 = q.x - p.x;
+  CGFloat c1 = r.x - p.x;
+  CGFloat b1 = q.y - p.y;
+  CGFloat d1 = r.y - p.y;
+
+  CGFloat a2 = centerAt.x - startAt.x;
+  CGFloat c2 = endAt.x - startAt.x;
+  CGFloat b2 = centerAt.y - startAt.y;
+  CGFloat d2 = endAt.y - startAt.y;
+
+  CGAffineTransform f = CGAffineTransformMake(a1, b1, c1, d1, p.x, p.y);
+
+  CGAffineTransform f_inv = CGAffineTransformInvert(f);
+
+  CGAffineTransform g = CGAffineTransformMake(a2, b2, c2, d2, startAt.x,
+          startAt.y);
+
+  CGAffineTransform interpolate = CGAffineTransformConcat(f_inv, g);
 
 //    CGPoint should_be_startAt = CGPointApplyAffineTransform(p, interpolate);
 //    CGPoint should_be_centerAt = CGPointApplyAffineTransform(q, interpolate);
 //    CGPoint should_be_endAt = CGPointApplyAffineTransform(r, interpolate);
-//    
+//
 //
 //    NSLog(@"should_be_start_at = [ %@]", CGPointCreateDictionaryRepresentation(should_be_startAt));
 //
 //    NSLog(@"should_be_center_at = [ %@]", CGPointCreateDictionaryRepresentation(should_be_centerAt));
 //    NSLog(@"should_be_should_be_endAt = [ %@]", CGPointCreateDictionaryRepresentation(should_be_endAt));
-    
 
-    NSRange xRange  = NSMakeRange(48, 4);
-    NSRange yRange  = NSMakeRange(52, 4);
-        
-    CGPoint currentPoint,
-            translatedPoint;
 
-    float x_buf[1];
-    float y_buf[1];
-    //    unsigned short *ios_buf[4];
-    for (NSDictionary *d in baseEvents) {
-        
-        NSDictionary* loc = [d valueForKey:@"Location"];
-        NSDictionary* windowLoc = [d valueForKey:@"WindowLocation"];
-        if (loc == nil || windowLoc == nil || [[d valueForKey:@"Type"] integerValue] == 50) {
-            continue;
-        }
-        
-        currentPoint = CGPointMake([[windowLoc valueForKey:@"X"] floatValue], 
-                                   [[windowLoc valueForKey:@"Y"] floatValue]);        
-        
-        NSMutableDictionary* newLoc = [NSMutableDictionary dictionaryWithDictionary:loc];
-        NSMutableDictionary* newWindowLoc = [NSMutableDictionary dictionaryWithDictionary:windowLoc];
-        
-        translatedPoint = CGPointApplyAffineTransform(currentPoint, interpolate);
-        
-        [newLoc setValue:
-         [NSNumber numberWithFloat:translatedPoint.x] forKey:@"X"];
-        [newLoc setValue:
-         [NSNumber numberWithFloat:translatedPoint.y] forKey:@"Y"];
-        
-        [newWindowLoc setValue:
-         [NSNumber numberWithFloat:translatedPoint.x] forKey:@"X"];
-        [newWindowLoc setValue:
-         [NSNumber numberWithFloat:translatedPoint.y] forKey:@"Y"];
-        
-        
-        
-        
-        NSData *data = [d valueForKey:@"Data"];
-        
-        [data getBytes:x_buf   range:xRange];
-        [data getBytes:y_buf   range:yRange];
-        //        [data getBytes:ios_buf   range:iosRange];
-        //        NSData *iosData = [[NSData alloc] initWithBytes:ios_buf length:4];
-        //        NSLog(@"iosData: %@",iosData);
-        //        [iosData release];
-        
-        NSMutableDictionary* newD = [NSMutableDictionary dictionaryWithDictionary:d];
-        NSMutableData *newData = [NSMutableData dataWithData:data];
-        
-        
-        x_buf[0] = translatedPoint.x;
-        y_buf[0] = translatedPoint.y;
-        [newData replaceBytesInRange:xRange withBytes:x_buf];            
-        [newData replaceBytesInRange:yRange withBytes:y_buf]; 
-        
-        
-        [newD setValue:newData forKey:@"Data"];
-        [newD setValue:newLoc forKey:@"Location"];
-        [newD setValue:newWindowLoc forKey:@"WindowLocation"];
-        
-        [transformedEvents addObject:newD];
-        
-        
+  NSRange xRange = NSMakeRange(48, 4);
+  NSRange yRange = NSMakeRange(52, 4);
+
+  CGPoint currentPoint, translatedPoint;
+
+  float x_buf[1];
+  float y_buf[1];
+  //    unsigned short *ios_buf[4];
+  for (NSDictionary *d in baseEvents) {
+
+    NSDictionary *loc = [d valueForKey:@"Location"];
+    NSDictionary *windowLoc = [d valueForKey:@"WindowLocation"];
+    if (loc == nil || windowLoc == nil || [[d valueForKey:@"Type"]
+            integerValue] == 50) {
+      continue;
     }
-    return transformedEvents;
+
+    currentPoint = CGPointMake([[windowLoc valueForKey:@"X"] floatValue],
+            [[windowLoc valueForKey:@"Y"] floatValue]);
+
+    NSMutableDictionary *newLoc = [NSMutableDictionary dictionaryWithDictionary:loc];
+    NSMutableDictionary *newWindowLoc = [NSMutableDictionary dictionaryWithDictionary:windowLoc];
+
+    translatedPoint = CGPointApplyAffineTransform(currentPoint, interpolate);
+
+    [newLoc setValue:[NSNumber numberWithFloat:translatedPoint.x] forKey:@"X"];
+    [newLoc setValue:[NSNumber numberWithFloat:translatedPoint.y] forKey:@"Y"];
+
+    [newWindowLoc setValue:[NSNumber numberWithFloat:translatedPoint.x]
+                    forKey:@"X"];
+    [newWindowLoc setValue:[NSNumber numberWithFloat:translatedPoint.y]
+                    forKey:@"Y"];
+
+
+    NSData *data = [d valueForKey:@"Data"];
+
+    [data getBytes:x_buf range:xRange];
+    [data getBytes:y_buf range:yRange];
+    //        [data getBytes:ios_buf   range:iosRange];
+    //        NSData *iosData = [[NSData alloc] initWithBytes:ios_buf length:4];
+    //        NSLog(@"iosData: %@",iosData);
+    //        [iosData release];
+
+    NSMutableDictionary *newD = [NSMutableDictionary dictionaryWithDictionary:d];
+    NSMutableData *newData = [NSMutableData dataWithData:data];
+
+
+    x_buf[0] = translatedPoint.x;
+    y_buf[0] = translatedPoint.y;
+    [newData replaceBytesInRange:xRange withBytes:x_buf];
+    [newData replaceBytesInRange:yRange withBytes:y_buf];
+
+
+    [newD setValue:newData forKey:@"Data"];
+    [newD setValue:newLoc forKey:@"Location"];
+    [newD setValue:newWindowLoc forKey:@"WindowLocation"];
+
+    [transformedEvents addObject:newD];
+  }
+  return transformedEvents;
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptAST.h
+++ b/calabash/Classes/UISpec/UIScriptAST.h
@@ -5,23 +5,17 @@
 //
 
 #import <Foundation/Foundation.h>
+
 typedef enum {
-    UIScriptASTDirectionTypeDescendant,
-    UIScriptASTDirectionTypeParent,
-    UIScriptASTDirectionTypeChild,
-    UIScriptASTDirectionTypeSibling
+  UIScriptASTDirectionTypeDescendant, UIScriptASTDirectionTypeParent, UIScriptASTDirectionTypeChild, UIScriptASTDirectionTypeSibling
 } UIScriptASTDirectionType;
 
 typedef enum {
-    UIScriptASTVisibilityTypeVisible,
-    UIScriptASTVisibilityTypeAll
+  UIScriptASTVisibilityTypeVisible, UIScriptASTVisibilityTypeAll
 } UIScriptASTVisibilityType;
 
 @interface UIScriptAST : NSObject
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility;
-
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility;
 
 @end

--- a/calabash/Classes/UISpec/UIScriptAST.m
+++ b/calabash/Classes/UISpec/UIScriptAST.m
@@ -5,13 +5,11 @@
 //
 
 #import "UIScriptAST.h"
-#import "UIScriptASTDirection.h"
+
 @implementation UIScriptAST
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
-    return nil;
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+  return nil;
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTALL.m
+++ b/calabash/Classes/UISpec/UIScriptASTALL.m
@@ -8,14 +8,14 @@
 
 @implementation UIScriptASTALL
 
-- (NSString*) description {
-    return @"all";
+- (NSString *) description {
+  return @"all";
 }
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
 
-    return [[views mutableCopy]autorelease];
+
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+
+  return [[views mutableCopy] autorelease];
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTClassName.h
+++ b/calabash/Classes/UISpec/UIScriptASTClassName.h
@@ -7,11 +7,12 @@
 #import "UIScriptAST.h"
 
 @interface UIScriptASTClassName : UIScriptAST {
-    NSString *_className;
-    Class _class;
+  NSString *_className;
+  Class _class;
 }
 
-@property (nonatomic,retain) NSString *className;
-- (id) initWithClassName:(NSString*) className;
+@property(nonatomic, retain) NSString *className;
+
+- (id) initWithClassName:(NSString *) className;
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTClassName.m
+++ b/calabash/Classes/UISpec/UIScriptASTClassName.m
@@ -5,130 +5,136 @@
 //
 
 #import "UIScriptASTClassName.h"
-#import "UIScriptASTDirection.h"
-#import "UIScriptASTVisibility.h"
 #import "LPTouchUtils.h"
 
 
 @implementation UIScriptASTClassName
-@synthesize className=_className;
+@synthesize className = _className;
 
-- (id) initWithClassName:(NSString *)className {
-    self = [super init];
-    if (self) {
-        if ([@"*" isEqualToString:className]) {
-            className = @"UIView";
-        }
-        self.className = [[className copy] autorelease];
-        _class = NSClassFromString(self.className);
+
+- (id) initWithClassName:(NSString *) className {
+  self = [super init];
+  if (self) {
+    if ([@"*" isEqualToString:className]) {
+      className = @"UIView";
     }
-    return self;
+    self.className = [[className copy] autorelease];
+    _class = NSClassFromString(self.className);
+  }
+  return self;
 }
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
 
-    NSMutableArray* res = [NSMutableArray arrayWithCapacity:8];
-    
-    for (UIView* view in views) {
-        switch (dir) {
-            case UIScriptASTDirectionTypeDescendant:
-                [self evalDescWith: view result:res visibility:visibility];
-                break;
-            case UIScriptASTDirectionTypeChild:
-                [self evalChildWith: view result:res visibility:visibility];
-                break;
-            case UIScriptASTDirectionTypeParent:
-                [self evalParentsWith: view result:res visibility:visibility];
-                break;
-            case UIScriptASTDirectionTypeSibling:
-                [self evalSiblingsWith: view result:res visibility:visibility];
-                break;
-        }
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+
+  NSMutableArray *res = [NSMutableArray arrayWithCapacity:8];
+
+  for (UIView *view in views) {
+    switch (dir) {
+      case UIScriptASTDirectionTypeDescendant:
+        [self evalDescWith:view result:res visibility:visibility];
+        break;
+      case UIScriptASTDirectionTypeChild:
+        [self evalChildWith:view result:res visibility:visibility];
+        break;
+      case UIScriptASTDirectionTypeParent:
+        [self evalParentsWith:view result:res visibility:visibility];
+        break;
+      case UIScriptASTDirectionTypeSibling:
+        [self evalSiblingsWith:view result:res visibility:visibility];
+        break;
     }
-    
-    
-    return res;
+  }
+
+
+  return res;
 }
 
-static NSInteger sortFunction(UIView* v1, UIView* v2, void *ctx) {
-    CGPoint p1 = v1.frame.origin;
-    CGPoint p2 = v2.frame.origin;
-    if (p1.x < p2.x) {
-        return -1;
-    } else if (p1.x == p2.x) {
-        if (p1.y < p2.y) {
-            return -1;
-        } else if (p1.y == p2.y) {
-            return 0;
-        } else {
-            return 1;
-        }
+
+static NSInteger sortFunction(UIView *v1, UIView *v2, void *ctx) {
+  CGPoint p1 = v1.frame.origin;
+  CGPoint p2 = v2.frame.origin;
+  if (p1.x < p2.x) {
+    return -1;
+  } else if (p1.x == p2.x) {
+    if (p1.y < p2.y) {
+      return -1;
+    } else if (p1.y == p2.y) {
+      return 0;
     } else {
-        return 1;
+      return 1;
     }
+  } else {
+    return 1;
+  }
 }
 
--(void)addView:(UIView*)view toArray:(NSMutableArray*) res ifMatchesVisibility:(UIScriptASTVisibilityType)visibility {
-    if (visibility == UIScriptASTVisibilityTypeAll || [LPTouchUtils isViewVisible:view]) {
-        [res addObject:view];
-    }    
+
+- (void) addView:(UIView *) view toArray:(NSMutableArray *) res ifMatchesVisibility:(UIScriptASTVisibilityType) visibility {
+  if (visibility == UIScriptASTVisibilityTypeAll || [LPTouchUtils isViewVisible:view]) {
+    [res addObject:view];
+  }
 }
 
-- (void) evalDescWith:(UIView*) view result:(NSMutableArray*) res visibility:(UIScriptASTVisibilityType)visibility{
-    if ([view isKindOfClass:_class]) {
-        [self addView: view toArray:res ifMatchesVisibility:visibility];
-    }
-    
-    for (UIView* subview in [[view subviews] sortedArrayUsingFunction:sortFunction context:view] ) {
-        [self evalDescWith:subview result:res visibility:visibility];
-    }
-    
+
+- (void) evalDescWith:(UIView *) view result:(NSMutableArray *) res visibility:(UIScriptASTVisibilityType) visibility {
+  if ([view isKindOfClass:_class]) {
+    [self addView:view toArray:res ifMatchesVisibility:visibility];
+  }
+
+  for (UIView *subview in [[view subviews]
+          sortedArrayUsingFunction:sortFunction context:view]) {
+    [self evalDescWith:subview result:res visibility:visibility];
+  }
 }
-- (void) evalChildWith:(UIView*) view result:(NSMutableArray*) res visibility:(UIScriptASTVisibilityType)visibility {
-    for (UIView* childView in [view subviews]) {
-        if ([childView isKindOfClass:_class]) {
-            [self addView: childView toArray:res ifMatchesVisibility:visibility];            
-        }
+
+
+- (void) evalChildWith:(UIView *) view result:(NSMutableArray *) res visibility:(UIScriptASTVisibilityType) visibility {
+  for (UIView *childView in [view subviews]) {
+    if ([childView isKindOfClass:_class]) {
+      [self addView:childView toArray:res ifMatchesVisibility:visibility];
     }
+  }
 }
-- (void) evalParentsWith:(UIView*) view result:(NSMutableArray*) res visibility:(UIScriptASTVisibilityType)visibility{
+
+
+- (void) evalParentsWith:(UIView *) view result:(NSMutableArray *) res visibility:(UIScriptASTVisibilityType) visibility {
 //    if ([view isKindOfClass:_class]) {
 //        [res addObject:view];
 //    }
-    //I guess view itself isnt part of parents.
-    UIView* parentView = [view superview];
-    if ([parentView isKindOfClass:_class]) {
-        [self addView: parentView toArray:res ifMatchesVisibility:visibility];
-    }
-    
-    if (parentView) {
-        [self evalParentsWith:parentView result:res visibility:visibility];
-    }
-    
-}
+  //I guess view itself isnt part of parents.
+  UIView *parentView = [view superview];
+  if ([parentView isKindOfClass:_class]) {
+    [self addView:parentView toArray:res ifMatchesVisibility:visibility];
+  }
 
-- (void) evalSiblingsWith:(UIView*) view result:(NSMutableArray*) res visibility:(UIScriptASTVisibilityType)visibility{
-    UIView* parentView = [view superview];
-    NSArray* children = [parentView subviews];
-    for (UIView *siblingOrSelf in children) {
-        if (siblingOrSelf != view && [siblingOrSelf isKindOfClass:_class]) {
-            [self addView: siblingOrSelf toArray:res ifMatchesVisibility:visibility];
-        }
-    }
+  if (parentView) {
+    [self evalParentsWith:parentView result:res visibility:visibility];
+  }
 }
 
 
-
-- (NSString*) description {
-    return [NSString stringWithFormat:@"view:'%@'",self.className];
+- (void) evalSiblingsWith:(UIView *) view result:(NSMutableArray *) res visibility:(UIScriptASTVisibilityType) visibility {
+  UIView *parentView = [view superview];
+  NSArray *children = [parentView subviews];
+  for (UIView *siblingOrSelf in children) {
+    if (siblingOrSelf != view && [siblingOrSelf isKindOfClass:_class]) {
+      [self addView:siblingOrSelf toArray:res ifMatchesVisibility:visibility];
+    }
+  }
 }
+
+
+- (NSString *) description {
+  return [NSString stringWithFormat:@"view:'%@'", self.className];
+}
+
 
 - (void) dealloc {
-    _class = NULL;
-    [_className release];_className=nil;
-    [super dealloc];
+  _class = NULL;
+  [_className release];
+  _className = nil;
+  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTDirection.h
+++ b/calabash/Classes/UISpec/UIScriptASTDirection.h
@@ -7,12 +7,12 @@
 #import "UIScriptAST.h"
 
 @interface UIScriptASTDirection : UIScriptAST {
-    UIScriptASTDirectionType _directionType;
+  UIScriptASTDirectionType _directionType;
 }
 
-@property (nonatomic, assign) UIScriptASTDirectionType directionType;
+@property(nonatomic, assign) UIScriptASTDirectionType directionType;
 
-- (id)initWithDirection:(UIScriptASTDirectionType) direction;
+- (id) initWithDirection:(UIScriptASTDirectionType) direction;
 
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTDirection.m
+++ b/calabash/Classes/UISpec/UIScriptASTDirection.m
@@ -7,31 +7,27 @@
 #import "UIScriptASTDirection.h"
 
 @implementation UIScriptASTDirection
-@synthesize directionType=_directionType;
-- (id)initWithDirection:(UIScriptASTDirectionType) direction
-{
-    self = [super init];
-    if (self) {
-        self.directionType=direction;
-    }
-    
-    return self;
+@synthesize directionType = _directionType;
+
+
+- (id) initWithDirection:(UIScriptASTDirectionType) direction {
+  self = [super init];
+  if (self) {
+    self.directionType = direction;
+  }
+
+  return self;
 }
 
-- (NSString*) description {
-    switch (self.directionType) {
-        case UIScriptASTDirectionTypeDescendant:
-            return @"descendant";
-        case UIScriptASTDirectionTypeParent:
-            return @"parent";
-        case UIScriptASTDirectionTypeChild:
-            return @"child";
-        case UIScriptASTDirectionTypeSibling:
-            return @"sibling";
-        default:
-            return @"<UNKNOWNDIRECTION";
-    }
-}
 
+- (NSString *) description {
+  switch (self.directionType) {
+    case UIScriptASTDirectionTypeDescendant:return @"descendant";
+    case UIScriptASTDirectionTypeParent:return @"parent";
+    case UIScriptASTDirectionTypeChild:return @"child";
+    case UIScriptASTDirectionTypeSibling:return @"sibling";
+    default:return @"<UNKNOWNDIRECTION";
+  }
+}
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTFirst.m
+++ b/calabash/Classes/UISpec/UIScriptASTFirst.m
@@ -7,18 +7,17 @@
 #import "UIScriptASTFirst.h"
 
 @implementation UIScriptASTFirst
-- (NSString*) description {
-    return @"first";
+- (NSString *) description {
+  return @"first";
 }
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
 
-    if ([views count] > 0) {
-        return [NSMutableArray arrayWithObject:[views objectAtIndex:0]];
-    }
-    return [NSMutableArray array];
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+
+  if ([views count] > 0) {
+    return [NSMutableArray arrayWithObject:[views objectAtIndex:0]];
+  }
+  return [NSMutableArray array];
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTIndex.h
+++ b/calabash/Classes/UISpec/UIScriptASTIndex.h
@@ -7,8 +7,10 @@
 #import "UIScriptAST.h"
 
 @interface UIScriptASTIndex : UIScriptAST {
-    NSUInteger _index;
+  NSUInteger _index;
 }
-@property (nonatomic,assign) NSUInteger index;
-- (id)initWithIndex:(NSUInteger)index;
+@property(nonatomic, assign) NSUInteger index;
+
+- (id) initWithIndex:(NSUInteger) index;
+
 @end

--- a/calabash/Classes/UISpec/UIScriptASTIndex.m
+++ b/calabash/Classes/UISpec/UIScriptASTIndex.m
@@ -7,28 +7,28 @@
 #import "UIScriptASTIndex.h"
 
 @implementation UIScriptASTIndex
-@synthesize index=_index;
-- (id)initWithIndex:(NSUInteger)index
-{
-    self = [super init];
-    if (self) {
-        self.index=index;
-    }
-    
-    return self;
+@synthesize index = _index;
+
+
+- (id) initWithIndex:(NSUInteger) index {
+  self = [super init];
+  if (self) {
+    self.index = index;
+  }
+
+  return self;
 }
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
 
-    if (_index >= [views count]) {return nil;}
-    return [NSMutableArray arrayWithObject:[views objectAtIndex:self.index]];
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+
+  if (_index >= [views count]) {return nil;}
+  return [NSMutableArray arrayWithObject:[views objectAtIndex:self.index]];
 }
 
-- (NSString*) description {
-    return [NSString stringWithFormat:@"index:%d",self.index];
-}
 
+- (NSString *) description {
+  return [NSString stringWithFormat:@"index:%d", self.index];
+}
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTLast.m
+++ b/calabash/Classes/UISpec/UIScriptASTLast.m
@@ -7,19 +7,17 @@
 #import "UIScriptASTLast.h"
 
 @implementation UIScriptASTLast
-- (NSString*) description {
-    return @"last";
+- (NSString *) description {
+  return @"last";
 }
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
 
-    if ([views count] > 0) {
-        return [NSMutableArray arrayWithObject:[views objectAtIndex:[views count]-1]];
-    }
-    return [NSMutableArray array];
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
 
+  if ([views count] > 0) {
+    return [NSMutableArray arrayWithObject:[views objectAtIndex:[views count] - 1]];
+  }
+  return [NSMutableArray array];
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTPredicate.h
+++ b/calabash/Classes/UISpec/UIScriptASTPredicate.h
@@ -10,12 +10,12 @@
 #import "UIScriptAST.h"
 
 @interface UIScriptASTPredicate : UIScriptAST {
-    NSPredicate *_predicate;
-    SEL _selector;
+  NSPredicate *_predicate;
+  SEL _selector;
 }
-@property (nonatomic, retain) NSPredicate *predicate;
-@property (nonatomic, assign) SEL selector;
+@property(nonatomic, retain) NSPredicate *predicate;
+@property(nonatomic, assign) SEL selector;
 
--(id) initWithPredicate:(NSPredicate *)pred selector:(SEL) sel;
+- (id) initWithPredicate:(NSPredicate *) pred selector:(SEL) sel;
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTPredicate.m
+++ b/calabash/Classes/UISpec/UIScriptASTPredicate.m
@@ -7,45 +7,45 @@
 //
 
 #import "UIScriptASTPredicate.h"
-#import "LPTouchUtils.h"
 
 @implementation UIScriptASTPredicate
-@synthesize predicate=_predicate;
-@synthesize selector=_selector;
+@synthesize predicate = _predicate;
+@synthesize selector = _selector;
 
--(id) initWithPredicate:(NSPredicate *)pred selector:(SEL) sel {
-    self = [super init];
-    if (self) {
-        self.predicate = pred;
-        self.selector = sel;
+
+- (id) initWithPredicate:(NSPredicate *) pred selector:(SEL) sel {
+  self = [super init];
+  if (self) {
+    self.predicate = pred;
+    self.selector = sel;
+  }
+  return self;
+}
+
+
+- (NSString *) description {
+  return [NSString stringWithFormat:@"UIScriptASTPredicate: %@",
+                                    [self.predicate description]];
+}
+
+
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+
+  NSMutableArray *res = [NSMutableArray arrayWithCapacity:8];
+  for (id v in views) {
+    if ([v isKindOfClass:[NSDictionary class]] || [v respondsToSelector:self.selector]) {
+      if ([self.predicate evaluateWithObject:v]) {
+        [res addObject:v];
+      }
     }
-    return self;
+  }
+  return res;
 }
 
-- (NSString*) description {
-    return [NSString stringWithFormat:@"UIScriptASTPredicate: %@",[self.predicate description]];
-}
-
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
-
-    NSMutableArray* res = [NSMutableArray arrayWithCapacity:8];    
-    for (id v in views) {
-        if ([v isKindOfClass:[NSDictionary class]] || [v respondsToSelector:self.selector])
-        {
-            if([self.predicate evaluateWithObject:v]) {
-                [res addObject:v];
-            }
-        }
-            
-    }
-    return res;
-}
 
 - (void) dealloc {
-    self.predicate=nil;
-    [super dealloc];
+  self.predicate = nil;
+  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTVisibility.h
+++ b/calabash/Classes/UISpec/UIScriptASTVisibility.h
@@ -7,12 +7,12 @@
 #import "UIScriptAST.h"
 
 @interface UIScriptASTVisibility : UIScriptAST {
-    UIScriptASTVisibilityType _visibilityType;
+  UIScriptASTVisibilityType _visibilityType;
 }
 
-@property (nonatomic, assign) UIScriptASTVisibilityType visibilityType;
+@property(nonatomic, assign) UIScriptASTVisibilityType visibilityType;
 
-- (id)initWithVisibility:(UIScriptASTVisibilityType) visibility;
+- (id) initWithVisibility:(UIScriptASTVisibilityType) visibility;
 
 
 @end

--- a/calabash/Classes/UISpec/UIScriptASTVisibility.m
+++ b/calabash/Classes/UISpec/UIScriptASTVisibility.m
@@ -7,27 +7,24 @@
 #import "UIScriptASTVisibility.h"
 
 @implementation UIScriptASTVisibility
-@synthesize visibilityType=_visibilityType;
+@synthesize visibilityType = _visibilityType;
 
-- (id)initWithVisibility:(UIScriptASTVisibilityType) visibility
-{
-    self = [super init];
-    if (self) {
-        self.visibilityType=visibility;
-    }
-    
-    return self;
+
+- (id) initWithVisibility:(UIScriptASTVisibilityType) visibility {
+  self = [super init];
+  if (self) {
+    self.visibilityType = visibility;
+  }
+  return self;
 }
 
-- (NSString*) description {
-    switch (self.visibilityType) {
-        case UIScriptASTVisibilityTypeVisible:
-            return @"visible";
-        case UIScriptASTVisibilityTypeAll:
-            return @"all";
-        default:
-            return @"<UNKNOWN_VISIBILITY>";
-    }
+
+- (NSString *) description {
+  switch (self.visibilityType) {
+    case UIScriptASTVisibilityTypeVisible:return @"visible";
+    case UIScriptASTVisibilityTypeAll:return @"all";
+    default:return @"<UNKNOWN_VISIBILITY>";
+  }
 }
 
 

--- a/calabash/Classes/UISpec/UIScriptASTWith.h
+++ b/calabash/Classes/UISpec/UIScriptASTWith.h
@@ -5,38 +5,33 @@
 //
 
 #import "UIScriptAST.h"
+
 typedef enum {
-    UIScriptLiteralTypeUnknown,
-    UIScriptLiteralTypeIndexPath,
-    UIScriptLiteralTypeString,
-    UIScriptLiteralTypeInteger,
-    UIScriptLiteralTypeBool
+  UIScriptLiteralTypeUnknown, UIScriptLiteralTypeIndexPath, UIScriptLiteralTypeString, UIScriptLiteralTypeInteger, UIScriptLiteralTypeBool
 } UIScriptLiteralType;
 
-
 @interface UIScriptASTWith : UIScriptAST {
-    NSString *_selectorName;
-    SEL _selector;
-    NSObject* _objectValue;
-    BOOL _boolValue;
-    NSInteger _integerValue;
-    
-    UIScriptLiteralType _valueType;
-    
+  NSString *_selectorName;
+  SEL _selector;
+  NSObject *_objectValue;
+  BOOL _boolValue;
+  NSInteger _integerValue;
+  UIScriptLiteralType _valueType;
 }
-@property (nonatomic, retain) NSArray *selectorSpec;
-@property (nonatomic, retain) NSString *selectorName;
-@property (nonatomic,assign) SEL selector;
-@property (nonatomic, assign) NSInteger timeout;
-@property (nonatomic,retain) NSObject *objectValue;
-@property (nonatomic,assign) BOOL boolValue;
-@property (nonatomic,assign) BOOL boolValue2;
-@property (nonatomic,assign) NSInteger integerValue;
-@property (nonatomic,assign) NSInteger integerValue2;
-@property (nonatomic,assign) UIScriptLiteralType valueType;
-@property (nonatomic,assign) UIScriptLiteralType valueType2;
- 
 
-- (id)initWithSelectorName:(NSString *)selectorName;
-- (id)initWithSelectorSpec:(NSArray *)selectorSpec;
+@property(nonatomic, retain) NSArray *selectorSpec;
+@property(nonatomic, retain) NSString *selectorName;
+@property(nonatomic, assign) SEL selector;
+@property(nonatomic, assign) NSInteger timeout;
+@property(nonatomic, retain) NSObject *objectValue;
+@property(nonatomic, assign) BOOL boolValue;
+@property(nonatomic, assign) BOOL boolValue2;
+@property(nonatomic, assign) NSInteger integerValue;
+@property(nonatomic, assign) NSInteger integerValue2;
+@property(nonatomic, assign) UIScriptLiteralType valueType;
+@property(nonatomic, assign) UIScriptLiteralType valueType2;
+
+- (id) initWithSelectorName:(NSString *) selectorName;
+- (id) initWithSelectorSpec:(NSArray *) selectorSpec;
+
 @end

--- a/calabash/Classes/UISpec/UIScriptASTWith.m
+++ b/calabash/Classes/UISpec/UIScriptASTWith.m
@@ -5,266 +5,229 @@
 //
 
 #import "UIScriptASTWith.h"
-#import "LPJSONUtils.h"
-#import "LPTouchUtils.h"
 #import "LPWebQuery.h"
 #import "LPReflectUtils.h"
 
 @implementation UIScriptASTWith
-@synthesize selectorName=_selectorName;
-@synthesize selector=_selector;
-@synthesize objectValue=_objectValue;
-@synthesize boolValue=_boolValue;
+@synthesize selectorName = _selectorName;
+@synthesize selector = _selector;
+@synthesize objectValue = _objectValue;
+@synthesize boolValue = _boolValue;
 @synthesize boolValue2;
-@synthesize integerValue=_integerValue;
+@synthesize integerValue = _integerValue;
 @synthesize integerValue2;
 @synthesize timeout;
 @synthesize selectorSpec;
 
-@synthesize valueType=_valueType;
+@synthesize valueType = _valueType;
 @synthesize valueType2;
 
-- (id)initWithSelectorName:(NSString *)selectorName {
-        self = [super init];
-        if (self) {
-            self.valueType=UIScriptLiteralTypeUnknown;
-            self.valueType2=UIScriptLiteralTypeUnknown;
-            self.selectorName = selectorName;
-            self.selector = NSSelectorFromString(selectorName);
-            self.timeout = 3;
-        }
-        return self;
-}
-- (id)initWithSelectorSpec:(NSArray *)selectorSpec_ {
-    self = [super init];
-    if (self) {
-        self.valueType=UIScriptLiteralTypeUnknown;
-        self.valueType2=UIScriptLiteralTypeUnknown;
-        self.selectorSpec = selectorSpec_;
-        self.timeout = 3;
-    }
-    return self;
+
+- (id) initWithSelectorName:(NSString *) selectorName {
+  self = [super init];
+  if (self) {
+    self.valueType = UIScriptLiteralTypeUnknown;
+    self.valueType2 = UIScriptLiteralTypeUnknown;
+    self.selectorName = selectorName;
+    self.selector = NSSelectorFromString(selectorName);
+    self.timeout = 3;
+  }
+  return self;
 }
 
-- (NSString*) description {
-    NSString* fm = nil;
-    if (self.selectorName)
-        fm = [NSString stringWithFormat:@"with %@:",NSStringFromSelector(self.selector)];
-    else
-        fm = [NSString stringWithFormat:@"with %@:",self.selectorSpec];
-    
-    switch (self.valueType) {
-        case UIScriptLiteralTypeIndexPath:
-        {
-            NSIndexPath *ip = (id)[self objectValue];
-            return [NSString stringWithFormat:@"%@%d,%d",fm,[ip row],[ip section]];            
-        }
 
-        case UIScriptLiteralTypeString:
-            return [NSString stringWithFormat:@"%@'%@'",fm,self.objectValue];
-        case UIScriptLiteralTypeInteger:
-            return [NSString stringWithFormat:@"%@%d",fm,self.integerValue];
-        case UIScriptLiteralTypeBool:
-            return [NSString stringWithFormat:@"%@%@",fm,self.boolValue?@"YES":@"NO"];
-        default:
-            return @"UIScriptLiteralTypeUnknown";
-    }
+- (id) initWithSelectorSpec:(NSArray *) selectorSpec_ {
+  self = [super init];
+  if (self) {
+    self.valueType = UIScriptLiteralTypeUnknown;
+    self.valueType2 = UIScriptLiteralTypeUnknown;
+    self.selectorSpec = selectorSpec_;
+    self.timeout = 3;
+  }
+  return self;
 }
 
--(NSArray *)handleWebView:(UIWebView *)webView visibility:(UIScriptASTVisibilityType)visibility {
-    if (!self.selectorName)
-    {
-        NSLog(@"WebView only supports css/xpath selectors");
-        return [NSMutableArray array];
+
+- (NSString *) description {
+  NSString *fm = nil;
+  if (self.selectorName) {
+    fm = [NSString stringWithFormat:@"with %@:",
+                                    NSStringFromSelector(self.selector)];
+  } else {
+    fm = [NSString stringWithFormat:@"with %@:", self.selectorSpec];
+  }
+
+  switch (self.valueType) {
+    case UIScriptLiteralTypeIndexPath: {
+      NSIndexPath *ip = (id) [self objectValue];
+      return [NSString stringWithFormat:@"%@%d,%d", fm, [ip row], [ip section]];
     }
 
-    if (self.valueType == UIScriptLiteralTypeString) {
-        LPWebQueryType type = LPWebQueryTypeCSS;
-        if ([[self selectorName] isEqualToString:@"marked"]) 
-        {
-            type = LPWebQueryTypeFreeText;                           
-        }
-        else if ([[self selectorName] isEqualToString:@"xpath"])
-        {
-            type = LPWebQueryTypeXPATH;
-        }
-        else if ([[self selectorName] isEqualToString:@"css"])
-        {
-            type = LPWebQueryTypeCSS;
-        }
+    case UIScriptLiteralTypeString:
+      return [NSString stringWithFormat:@"%@'%@'", fm, self.objectValue];
+    case UIScriptLiteralTypeInteger:
+      return [NSString stringWithFormat:@"%@%d", fm, self.integerValue];
+    case UIScriptLiteralTypeBool:
+      return [NSString stringWithFormat:@"%@%@", fm,
+                                        self.boolValue ? @"YES" : @"NO"];
+    default:return @"UIScriptLiteralTypeUnknown";
+  }
+}
 
-        return [LPWebQuery evaluateQuery:(NSString*)self.objectValue
-                                  ofType:type
-                               inWebView:webView
-                        includeInvisible: visibility == UIScriptASTVisibilityTypeAll];
+
+- (NSArray *) handleWebView:(UIWebView *) webView visibility:(UIScriptASTVisibilityType) visibility {
+  if (!self.selectorName) {
+    NSLog(@"WebView only supports css/xpath selectors");
+    return [NSMutableArray array];
+  }
+
+  if (self.valueType == UIScriptLiteralTypeString) {
+    LPWebQueryType type = LPWebQueryTypeCSS;
+    if ([[self selectorName] isEqualToString:@"marked"]) {
+      type = LPWebQueryTypeFreeText;
+    } else if ([[self selectorName] isEqualToString:@"xpath"]) {
+      type = LPWebQueryTypeXPATH;
+    } else if ([[self selectorName] isEqualToString:@"css"]) {
+      type = LPWebQueryTypeCSS;
+    }
+
+    return [LPWebQuery evaluateQuery:(NSString *) self.objectValue ofType:type
+                           inWebView:webView
+                    includeInvisible:visibility == UIScriptASTVisibilityTypeAll];
+  } else {
+    NSLog(@"Attempting to look for non string in web view");
+    return [NSMutableArray array];
+  }
+}
+
+
+- (NSMutableArray *) evalWith:(NSArray *) views direction:(UIScriptASTDirectionType) dir visibility:(UIScriptASTVisibilityType) visibility {
+
+  NSMutableArray *res = [NSMutableArray arrayWithCapacity:8];
+
+  for (UIView *v in views) {
+    if ([v isKindOfClass:[NSDictionary class]]) {
+      NSDictionary *dict = (NSDictionary *) v;
+      NSString *key = NSStringFromSelector(self.selector);
+      if ([[dict valueForKey:key] isEqual:self.objectValue]) {
+        [res addObject:dict];
+      }
     } else {
-        NSLog(@"Attempting to look for non string in web view");
-        return [NSMutableArray array];
-    }
+      if ([v isKindOfClass:[UIWebView class]]) {
+        [res addObjectsFromArray:[self handleWebView:(UIWebView *) v
+                                          visibility:visibility]];
+        continue;
+      }
+      if ([self.selectorName isEqualToString:@"marked"]) {
+        NSString *val = nil;
+        if ([v respondsToSelector:@selector(accessibilityIdentifier)]) {
+          val = [v accessibilityIdentifier];
+          if ([val isEqualToString:(NSString *) self.objectValue]) {
+            [res addObject:v];
+            continue;
+          }
+        }
+        val = [v accessibilityLabel];
+        if ([val isEqualToString:(NSString *) self.objectValue]) {
+          [res addObject:v];
+        }
+        continue;
+      }
+      if ([self.selectorName isEqualToString:@"id"]) {
+        NSString *val = nil;
+        if ([v respondsToSelector:@selector(accessibilityIdentifier)]) {
+          val = [v accessibilityIdentifier];
+          if ([val isEqualToString:(NSString *) self.objectValue]) {
+            [res addObject:v];
+            continue;
+          }
+        }
+        continue;
+      }
 
+      if ([v isKindOfClass:[UITableViewCell class]] && [self.selectorName isEqualToString:@"indexPath"]) {
+        UITableViewCell *cell = (UITableViewCell *) v;
+        NSIndexPath *indexPath = (NSIndexPath *) self.objectValue;
+        id tableView = [cell superview];
+        while (tableView && ![tableView isKindOfClass:[UITableView class]]) {
+          tableView = [tableView superview];
+        }
+        if (tableView) {
+          UITableView *tv = (UITableView *) tableView;
+          if ([indexPath isEqual:[tv indexPathForCell:cell]]) {
+            [res addObject:cell];
+          }
+        }
+        continue;
+      }
+
+      if (self.selectorName) {
+        if ([v respondsToSelector:_selector]) {
+          void *val = [v performSelector:_selector];
+          switch (self.valueType) {
+            case UIScriptLiteralTypeInteger:
+              if ((NSInteger) val == self.integerValue) {
+                [res addObject:v];
+              }
+              break;
+            case UIScriptLiteralTypeString: {
+              if (val != nil && ([(NSString *) val isEqualToString:(NSString *) self.objectValue])) {
+                [res addObject:v];
+              }
+              break;
+            }
+            case UIScriptLiteralTypeBool:
+              if (self.boolValue == (BOOL) val) {
+                [res addObject:v];
+              }
+              break;
+            default:break;
+          }
+        }
+      } else {
+        NSError *error = nil;
+        id val = [LPReflectUtils invokeSpec:self.selectorSpec onTarget:v
+                                  withError:&error];
+        if (val && !error) {
+          switch (self.valueType) {
+            case UIScriptLiteralTypeInteger: {
+              NSInteger i = [val integerValue];
+              if (i == self.integerValue) {
+                [res addObject:v];
+              }
+              break;
+            }
+            case UIScriptLiteralTypeString: {
+              if (val != nil && ([(NSString *) val isEqualToString:(NSString *) self.objectValue])) {
+                [res addObject:v];
+              }
+              break;
+            }
+            case UIScriptLiteralTypeBool: {
+              BOOL b = [val boolValue];
+              if (self.boolValue == b) {
+                [res addObject:v];
+              }
+              break;
+            }
+            default:break;
+          }
+        }
+      }
+    }
+  }
+  return res;
 }
 
 
-- (NSMutableArray*) evalWith:(NSArray*) views
-                   direction:(UIScriptASTDirectionType) dir
-                  visibility:(UIScriptASTVisibilityType)visibility {
-
-    NSMutableArray* res = [NSMutableArray arrayWithCapacity:8];
-
-    for (UIView* v in views) {
-        if ([v isKindOfClass:[NSDictionary class]])
-        {
-            NSDictionary *dict = (NSDictionary *)v;
-            NSString *key = NSStringFromSelector(self.selector);
-            if ([[dict valueForKey:key] isEqual:self.objectValue])
-            {
-                [res addObject:dict];
-            }
-            
-        }
-        else
-        {
-            if ([v isKindOfClass:[UIWebView class]]) 
-            {            
-                [res addObjectsFromArray: [self handleWebView:(UIWebView *)v visibility: visibility]];
-                continue;            
-            }
-            if ([self.selectorName isEqualToString:@"marked"]) 
-            {
-                NSString *val = nil;
-                if ([v respondsToSelector:@selector(accessibilityIdentifier)])
-                {
-                    val = [v accessibilityIdentifier];                
-                    if ([val isEqualToString:(NSString*)self.objectValue])
-                    {
-                        [res addObject:v];
-                        continue;
-                    }
-                }            
-                val = [v accessibilityLabel];
-                if ([val isEqualToString:(NSString*)self.objectValue])
-                {
-                    [res addObject:v];
-                }            
-                continue;
-            }
-            if ([self.selectorName isEqualToString:@"id"])
-            {
-                NSString *val = nil;
-                if ([v respondsToSelector:@selector(accessibilityIdentifier)])
-                {
-                    val = [v accessibilityIdentifier];
-                    if ([val isEqualToString:(NSString*)self.objectValue])
-                    {
-                        [res addObject:v];
-                        continue;
-                    }
-                }
-                continue;
-            }
-            
-            if ([v isKindOfClass:[UITableViewCell class]] && 
-                [self.selectorName isEqualToString:@"indexPath"])
-            {
-                UITableViewCell *cell = (UITableViewCell*)v;
-                NSIndexPath *indexPath = (NSIndexPath *) self.objectValue;
-                id tableView = [cell superview];
-                while(tableView && ![tableView isKindOfClass:[UITableView class]])
-                {
-                    tableView = [tableView superview];
-                }
-                if (tableView)
-                {
-                    UITableView *tv = (UITableView*)tableView;
-                    if ([indexPath isEqual:[tv indexPathForCell:cell]])
-                    {
-                        [res addObject:cell];
-                    }
-                }
-                continue;            
-            }
-            
-            if (self.selectorName)
-            {
-                if ([v respondsToSelector:_selector])
-                {
-                    void* val = [v performSelector:_selector];
-                    switch (self.valueType) {
-                        case UIScriptLiteralTypeInteger:
-                            if ((NSInteger) val == self.integerValue) {
-                                [res addObject:v];
-                            }
-                            break;
-                        case UIScriptLiteralTypeString: {
-                            if (val != nil &&
-                                ([(NSString*)val isEqualToString:(NSString*)self.objectValue])) {
-                                [res addObject:v];
-                            }
-                            break;
-                        }
-                        case UIScriptLiteralTypeBool:
-                            if (self.boolValue == (BOOL)val) {
-                                [res addObject:v];
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                }
-            }
-            else
-            {
-                NSError *error = nil;
-                id val = [LPReflectUtils invokeSpec:self.selectorSpec onTarget:v withError:&error];
-                if (val && !error)
-                {
-                    switch (self.valueType) {
-                        case UIScriptLiteralTypeInteger:
-                        {
-                            NSInteger i = [val integerValue];
-                            if (i == self.integerValue) {
-                                [res addObject:v];
-                            }
-                            break;                            
-                        }
-                        case UIScriptLiteralTypeString: {
-                            if (val != nil &&
-                                ([(NSString*)val isEqualToString:(NSString*)self.objectValue])) {
-                                [res addObject:v];
-                            }
-                            break;
-                        }
-                        case UIScriptLiteralTypeBool:
-                        {
-                            BOOL b = [val boolValue];
-                            if (self.boolValue == b) {
-                                [res addObject:v];
-                            }
-                            break;
-
-                        }
-                        default:
-                            break;
-                    }
-
-                }
-            }
-            
-        }
-        
-    }
-    return res;
-}
-
-
-    
 - (void) dealloc {
-    self.selector=nil;
-    self.selectorName = nil;
-    self.selectorSpec = nil;
-    [_objectValue release];_objectValue=nil;
-    [super dealloc];
+  self.selector = nil;
+  self.selectorName = nil;
+  self.selectorSpec = nil;
+  [_objectValue release];
+  _objectValue = nil;
+  [super dealloc];
 }
-    
+
 
 @end

--- a/calabash/Classes/UISpec/UIScriptParser.h
+++ b/calabash/Classes/UISpec/UIScriptParser.h
@@ -7,21 +7,19 @@
 #import <Foundation/Foundation.h>
 
 @interface UIScriptParser : NSObject {
-    NSMutableArray *_res;
-    NSString *_script;
+  NSMutableArray *_res;
+  NSString *_script;
 }
 
-@property (nonatomic, retain) NSString* script;
-@property (nonatomic, retain) NSArray* arrayQuery;
+@property(nonatomic, retain) NSString *script;
+@property(nonatomic, retain) NSArray *arrayQuery;
 
-+(UIScriptParser*)scriptParserWithObject:(id)obj;
-+(UIView*)findViewByClass:(NSString*) className fromView:(UIView*) parent;
-- (id) initWithUIScript:(NSString*) script;
-- (id) initWithQuery:(NSArray*) aq;
-
++ (UIScriptParser *) scriptParserWithObject:(id) obj;
++ (UIView *) findViewByClass:(NSString *) className fromView:(UIView *) parent;
+- (id) initWithUIScript:(NSString *) script;
+- (id) initWithQuery:(NSArray *) aq;
 - (void) parse;
-- (NSArray*) parsedTokens;
-
-- (NSArray*) evalWith:(NSArray*) views;
+- (NSArray *) parsedTokens;
+- (NSArray *) evalWith:(NSArray *) views;
 
 @end

--- a/calabash/Classes/UISpec/UIScriptParser.m
+++ b/calabash/Classes/UISpec/UIScriptParser.m
@@ -8,578 +8,574 @@
 #import "UIScriptASTClassName.h"
 #import "UIScriptASTIndex.h"
 #import "UIScriptASTWith.h"
-#import "UIScriptASTALL.h"
 #import "UIScriptASTFirst.h"
 #import "UIScriptASTLast.h"
 #import "UIScriptASTDirection.h"
 #import "UIScriptASTVisibility.h"
 #import "UIScriptASTPredicate.h"
-#import "LPReflectUtils.h"
-#import <UIKit/UIKit.h>
 
 #define CALABASH_TYPE_KEY @"_calabash-type"
 
 
-@interface UIScriptParser()
-    - (NSString*) parseClassName:(NSString*) token;
-    - (UIScriptAST*) parseIndexPropertyOrPredicate:(NSString*) token;
-    - (void) parseLiteralValue:(NSString*) literalToken addToWithAST:(UIScriptASTWith*) ast;
-    - (UIScriptASTDirection*) parseDirectionIfPresent:(NSString*) token;
-    - (NSString *)findNextToken:(NSUInteger *)index;
+@interface UIScriptParser ()
+
+- (NSString *) parseClassName:(NSString *) token;
+- (UIScriptAST *) parseIndexPropertyOrPredicate:(NSString *) token;
+- (void) parseLiteralValue:(NSString *) literalToken addToWithAST:(UIScriptASTWith *) ast;
+- (UIScriptASTDirection *) parseDirectionIfPresent:(NSString *) token;
+- (NSString *) findNextToken:(NSUInteger *) index;
+
 @end
 
 @implementation UIScriptParser
-@synthesize script=_script;
+@synthesize script = _script;
 
-+(UIScriptParser*)scriptParserWithObject:(id)obj
-{
-    if ([obj isKindOfClass:[NSString class]])
-    {
-        return [[[UIScriptParser alloc] initWithUIScript:(NSString*) obj] autorelease];
-    }
-    else if ([obj isKindOfClass:[NSArray class]])
-    {
-        return [[[UIScriptParser alloc] initWithQuery:(NSArray*) obj] autorelease];
-    }
-    return nil;
+
++ (UIScriptParser *) scriptParserWithObject:(id) obj {
+  if ([obj isKindOfClass:[NSString class]]) {
+    return [[[UIScriptParser alloc] initWithUIScript:(NSString *) obj]
+            autorelease];
+  } else if ([obj isKindOfClass:[NSArray class]]) {
+    return [[[UIScriptParser alloc] initWithQuery:(NSArray *) obj] autorelease];
+  }
+  return nil;
 }
 
-+(UIView*)findViewByClass:(NSString*) className fromView:(UIView*) parent
-{
-    
-    for (UIView *viewCandidate in [parent subviews])
-    {
-        if ([NSStringFromClass([viewCandidate class]) isEqual:className])
-        {
-            return viewCandidate;
-        }
-        else
-        {
-            UIView *result = [UIScriptParser findViewByClass:className fromView:viewCandidate];
-            if (result)
-            {
-                return result;
-            }
-        }
+
++ (UIView *) findViewByClass:(NSString *) className fromView:(UIView *) parent {
+
+  for (UIView *viewCandidate in [parent subviews]) {
+    if ([NSStringFromClass([viewCandidate class]) isEqual:className]) {
+      return viewCandidate;
+    } else {
+      UIView *result = [UIScriptParser findViewByClass:className
+                                              fromView:viewCandidate];
+      if (result) {
+        return result;
+      }
     }
-    return nil;
+  }
+  return nil;
 }
 
-- (id) initWithUIScript:(NSString*) script {
-    self = [super init];
-    if (self) {
-        self.script = script;
-        _res = [[NSMutableArray alloc] initWithCapacity:8];
-    }
-    return self;
+
+- (id) initWithUIScript:(NSString *) script {
+  self = [super init];
+  if (self) {
+    self.script = script;
+    _res = [[NSMutableArray alloc] initWithCapacity:8];
+  }
+  return self;
 }
 
-- (id) initWithQuery:(NSArray*) aq {
-    self = [super init];
-    if (self) {
-        self.arrayQuery = aq;
-        _res = [[NSMutableArray alloc] initWithCapacity:8];
-    }
-    return self;
+
+- (id) initWithQuery:(NSArray *) aq {
+  self = [super init];
+  if (self) {
+    self.arrayQuery = aq;
+    _res = [[NSMutableArray alloc] initWithCapacity:8];
+  }
+  return self;
 }
+
 
 - (void) dealloc {
-    [_res autorelease];_res=nil;
-    self.script = nil;
-    [super dealloc];
+  [_res autorelease];
+  _res = nil;
+  self.script = nil;
+  [super dealloc];
 }
 
 #pragma mark Parsing
-static NSCharacterSet* colon = nil;
-static NSCharacterSet* ping = nil;
-static NSCharacterSet* curlyBrackets = nil;
+static NSCharacterSet *colon = nil;
+static NSCharacterSet *ping = nil;
+static NSCharacterSet *curlyBrackets = nil;
+
 
 - (void) parse {
-    
-    if (colon==nil) {colon=[[NSCharacterSet characterSetWithCharactersInString:@":"] retain];}
-    if (ping==nil) {ping=[[NSCharacterSet characterSetWithCharactersInString:@"'"] retain];}
-    if (curlyBrackets==nil) {curlyBrackets=[[NSCharacterSet characterSetWithCharactersInString:@"{}"] retain];}
-    
-    if (self.script)
-    {
-        [self parseString];
-    }
-    else
-    {
-        [self parseArray];
-    }
-    
+
+  if (colon == nil) {
+    colon = [[NSCharacterSet characterSetWithCharactersInString:@":"] retain];
+  }
+  if (ping == nil) {
+    ping = [[NSCharacterSet characterSetWithCharactersInString:@"'"] retain];
+  }
+  if (curlyBrackets == nil) {
+    curlyBrackets = [[NSCharacterSet characterSetWithCharactersInString:@"{}"]
+            retain];
+  }
+
+  if (self.script) {
+    [self parseString];
+  } else {
+    [self parseArray];
+  }
 }
 
--(void)parseArray
-{
-    for (NSObject *obj in self.arrayQuery)
-    {
-        //each object can be one of
-        //String/Symbol/keyword
-        //Example direction: descendant, child, parent
-        //Example classname: UITableView
-        if ([obj isKindOfClass:[NSString class]])
-        {
-            NSString* token = (NSString*)obj;
-            UIScriptASTDirection* direction = nil;
-            direction = [self parseDirectionIfPresent:token];
-            if (direction)
-            {
-                [_res addObject:direction];
-            } else {// default is descendant
-                //should be a classname
-                UIScriptASTClassName *cn = [[[UIScriptASTClassName alloc] initWithClassName:token] autorelease];
-                [_res addObject:cn];
-            }
-            
+
+- (void) parseArray {
+  for (NSObject *obj in self.arrayQuery) {
+    //each object can be one of
+    //String/Symbol/keyword
+    //Example direction: descendant, child, parent
+    //Example classname: UITableView
+    if ([obj isKindOfClass:[NSString class]]) {
+      NSString *token = (NSString *) obj;
+      UIScriptASTDirection *direction = nil;
+      direction = [self parseDirectionIfPresent:token];
+      if (direction) {
+        [_res addObject:direction];
+      } else {// default is descendant
+        //should be a classname
+        UIScriptASTClassName *cn = [[[UIScriptASTClassName alloc]
+                initWithClassName:token] autorelease];
+        [_res addObject:cn];
+      }
+    } else if ([obj isKindOfClass:[NSDictionary class]]) {//NSDictionary
+      //Example direction: {:text "Karl, :length 42}
+
+      NSDictionary *dic = (NSDictionary *) obj;
+      NSString *typeIfPresent = [dic valueForKey:CALABASH_TYPE_KEY];
+      if (typeIfPresent) {
+        if ([@"index" isEqualToString:typeIfPresent]) {
+          NSNumber *numVal = [dic objectForKey:@"index"];
+          if (!numVal) {
+            @throw [NSException exceptionWithName:@"Bad query"
+                                           reason:@"Bad query of type index should have an index key"
+                                         userInfo:nil];
+          }
+          NSUInteger val = [numVal unsignedIntegerValue];
+          [_res addObject:[[[UIScriptASTIndex alloc] initWithIndex:val]
+                  autorelease]];
+        } else if ([@"css" isEqualToString:typeIfPresent] || [@"xpath" isEqualToString:typeIfPresent]) {
+          UIScriptASTWith *w = [[[UIScriptASTWith alloc]
+                  initWithSelectorName:typeIfPresent] autorelease];
+          w.valueType = UIScriptLiteralTypeString;
+          NSString *strVal = [dic objectForKey:typeIfPresent];
+          if (!strVal) {
+            @throw [NSException exceptionWithName:@"Bad query"
+                                           reason:[NSString stringWithFormat:@"Bad query of type %@ should have an %@ key",
+                                                                             typeIfPresent,
+                                                                             typeIfPresent]
+                                         userInfo:nil];
+          }
+          w.objectValue = strVal;
+
+          [_res addObject:w];
         }
-        else if ([obj isKindOfClass:[NSDictionary class]])
-        {//NSDictionary
-            //Example direction: {:text "Karl, :length 42}
-            
-            NSDictionary *dic = (NSDictionary*)obj;
-            NSString *typeIfPresent = [dic valueForKey:CALABASH_TYPE_KEY];
-            if (typeIfPresent)
-            {
-                if ([@"index" isEqualToString:typeIfPresent])
-                {
-                    NSNumber* numVal = [dic objectForKey:@"index"];
-                    if (!numVal)
-                    {
-                        @throw [NSException exceptionWithName:@"Bad query" reason:@"Bad query of type index should have an index key" userInfo:nil];
-                    }
-                    NSUInteger val = [numVal unsignedIntegerValue];
-                    [_res addObject: [[[UIScriptASTIndex alloc] initWithIndex:val] autorelease]];
-    
-                }
-                else if ([@"css" isEqualToString:typeIfPresent] || [@"xpath" isEqualToString:typeIfPresent])
-                {
-                    UIScriptASTWith *w = [[[UIScriptASTWith alloc] initWithSelectorName:typeIfPresent] autorelease];
-                    w.valueType = UIScriptLiteralTypeString;
-                    NSString* strVal = [dic objectForKey:typeIfPresent];
-                    if (!strVal)
-                    {
-                        @throw [NSException exceptionWithName:@"Bad query" reason:
-                                [NSString stringWithFormat:@"Bad query of type %@ should have an %@ key",typeIfPresent,typeIfPresent] userInfo:nil];
-                    }
-                    w.objectValue = strVal;
-                    
-                    [_res addObject:w];
+      } else {
 
-                }
-            }
-            else
-            {
+        for (NSString *key in [dic keyEnumerator]) {
+          id val = [dic valueForKey:key];
+          UIScriptASTWith *w = [[[UIScriptASTWith alloc]
+                  initWithSelectorName:key] autorelease];
 
-                for (NSString *key in [dic keyEnumerator])
-                {
-                    id val = [dic valueForKey:key];
-                    UIScriptASTWith *w = [[[UIScriptASTWith alloc] initWithSelectorName:key] autorelease];
-                
-                    if ([val isKindOfClass:[NSString class]])
-                    {
-                        w.valueType = UIScriptLiteralTypeString;
-                        w.objectValue = val;
-                    }
-                    else if ([val isKindOfClass:[NSNumber class]])
-                    {
-                        w.valueType = UIScriptLiteralTypeInteger;
-                        w.integerValue = [val integerValue];
-                    }
-                    else if ([val isKindOfClass:[NSArray class]])
-                    {
-                        NSNumber *i1 = [val objectAtIndex:0];
-                        NSNumber *i2 = [val objectAtIndex:1];
-                    
-                        w.valueType = UIScriptLiteralTypeIndexPath;
-                        w.objectValue = [NSIndexPath indexPathForRow: [i1 integerValue]
-                                                       inSection:[i2 integerValue]];
+          if ([val isKindOfClass:[NSString class]]) {
+            w.valueType = UIScriptLiteralTypeString;
+            w.objectValue = val;
+          } else if ([val isKindOfClass:[NSNumber class]]) {
+            w.valueType = UIScriptLiteralTypeInteger;
+            w.integerValue = [val integerValue];
+          } else if ([val isKindOfClass:[NSArray class]]) {
+            NSNumber *i1 = [val objectAtIndex:0];
+            NSNumber *i2 = [val objectAtIndex:1];
 
-                    } else
-                    {
-                        NSLog(@"Unknown value type %@",val);
-                    }
-                    [_res addObject:w];
-                
-                }
-                
-            }
-            
+            w.valueType = UIScriptLiteralTypeIndexPath;
+            w.objectValue = [NSIndexPath indexPathForRow:[i1 integerValue]
+                                               inSection:[i2 integerValue]];
+          } else {
+            NSLog(@"Unknown value type %@", val);
+          }
+          [_res addObject:w];
         }
-        else if ([obj isKindOfClass:[NSArray class]])
-        {
-            NSArray *arr = (NSArray*)obj;
-            if ([arr count] == 2)
-            {//type selector value
+      }
+    } else if ([obj isKindOfClass:[NSArray class]]) {
+      NSArray *arr = (NSArray *) obj;
+      if ([arr count] == 2) {//type selector value
 //                id selObj = [arr objectAtIndex:0];
 //                id val = [arr objectAtIndex:1];
-                NSArray *spec = [arr objectAtIndex:0];
-                id val = [arr objectAtIndex:1];
-                UIScriptASTWith *w = [[UIScriptASTWith alloc] initWithSelectorSpec:spec];
-                if ([val isKindOfClass:[NSString class]])
-                {
-                    w.valueType = UIScriptLiteralTypeString;
-                    w.objectValue = val;
-                }
-                else if ([val isKindOfClass:[NSNumber class]])
-                {
-                    w.valueType = UIScriptLiteralTypeInteger;
-                    w.integerValue = [val integerValue];
-                }
-                else if ([val isKindOfClass:[NSArray class]])
-                {
-                    NSNumber *i1 = [val objectAtIndex:0];
-                    NSNumber *i2 = [val objectAtIndex:1];
-                    
-                    w.valueType = UIScriptLiteralTypeIndexPath;
-                    w.objectValue = [NSIndexPath indexPathForRow: [i1 integerValue]
-                                                       inSection:[i2 integerValue]];
-                    
-                } else
-                {
-                    NSLog(@"Unknown value type %@",val);
-                }
+        NSArray *spec = [arr objectAtIndex:0];
+        id val = [arr objectAtIndex:1];
+        UIScriptASTWith *w = [[UIScriptASTWith alloc]
+                initWithSelectorSpec:spec];
+        if ([val isKindOfClass:[NSString class]]) {
+          w.valueType = UIScriptLiteralTypeString;
+          w.objectValue = val;
+        } else if ([val isKindOfClass:[NSNumber class]]) {
+          w.valueType = UIScriptLiteralTypeInteger;
+          w.integerValue = [val integerValue];
+        } else if ([val isKindOfClass:[NSArray class]]) {
+          NSNumber *i1 = [val objectAtIndex:0];
+          NSNumber *i2 = [val objectAtIndex:1];
 
-                [_res addObject:w];
-                [w release];
-                
-                
-            }
-            if ([arr count] == 3)
-            {//relation/NSPredicate
-                NSString *selStr = [arr objectAtIndex:0];
-                NSString *rel = [arr objectAtIndex:1];
-                id val = [arr objectAtIndex:2];
-                SEL sel = NSSelectorFromString(selStr);
-                NSPredicate *pred = nil;
-                if ([val isKindOfClass:[NSString class]])
-                {
-                    pred = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"%@ %@ '%@'",selStr,rel,val]];
-                }
-                else
-                {
-                    pred = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"%@ %@ %@",selStr,rel,val]];
-                }
-                [_res addObject:[[[UIScriptASTPredicate alloc] initWithPredicate:pred selector:sel] autorelease]];
-
-            }
-            
-        }
-        
-        
-
-    }
-}
-
--(void)parseString
-{
-    NSUInteger index=0;
-    NSUInteger N=[_script length];
-    NSString* token = [self findNextToken:&index];
-    while (token) {
-
-        UIScriptASTVisibility* visibility = [self parseVisibilityIfPresent:token];
-        if (visibility!=nil) {
-            [_res addObject:visibility];
-            if (index == N) {return;}
-            token = [self findNextToken:&index];
-        } 
-
-        //token should be a direction or classname
-        UIScriptASTDirection* direction = [self parseDirectionIfPresent:token];
-        if (direction!=nil) {
-            [_res addObject:direction];
-            if (index == N) {return;}
-            token = [self findNextToken:&index];
-        } else {// default is descendant
-            
-        }
-        
-        if ([token isEqualToString:@"last"]) {
-            UIScriptAST* last = [UIScriptASTLast new];
-            [_res addObject:last];
-            [last release];
-            return;//ignore everything past last
-        } else if ([token isEqualToString:@"first"]) {
-            UIScriptAST* first = [UIScriptASTFirst new];
-            [_res addObject:first];
-            [first release];
-            return;//ignore everything past first
-        }
-        
-        
-        //token should be a classname, e.g., view:'UITableView' or tableView
-        NSString* clzName = [self parseClassName:token];
-        UIScriptASTClassName* c = [[UIScriptASTClassName alloc] initWithClassName:clzName];
-        [_res addObject:c];
-        [c release];
-        
-        if (index == N) {return;}
-        token = [self findNextToken:&index];
-        if (token==nil) { break; }
-        
-        UIScriptAST* indexPropOrPred = [self parseIndexPropertyOrPredicate:token];
-        while (indexPropOrPred != nil) {
-            //token is an index or property
-            
-            [_res addObject:indexPropOrPred];
-            
-            if (index == N) {return;}
-            token = [self findNextToken:&index];
-            indexPropOrPred=[self parseIndexPropertyOrPredicate:token];
-            
-        }//else lookahead reveals another classname so continue
-    }
-
-}
-
-- (NSString *)findNextToken:(NSUInteger *)index {
-    static NSCharacterSet *notWhite = nil;
-    
-    if (notWhite==nil) {
-        NSMutableCharacterSet *cs = [NSMutableCharacterSet whitespaceCharacterSet];
-        [cs invert];
-        notWhite = [cs retain];
-    }
-    static NSCharacterSet *whiteSpaceSquareOrPing = nil;
-    
-    if (whiteSpaceSquareOrPing==nil) {
-        NSMutableCharacterSet *cs = [NSMutableCharacterSet whitespaceCharacterSet];
-        [cs formUnionWithCharacterSet:ping];
-        [cs formUnionWithCharacterSet:curlyBrackets];
-        whiteSpaceSquareOrPing = [cs retain];
-    }
-    
-    NSUInteger i = *index;
-    NSUInteger N = [_script length];
-    if (i==N) {
-        return nil;
-    }
-    NSRange range=[_script rangeOfCharacterFromSet:whiteSpaceSquareOrPing options:NSLiteralSearch range:NSMakeRange(i, N-i)];
-    if (range.location==NSNotFound) {
-        //last token
-        *index=N;
-        return [_script substringFromIndex:i];
-    }
-
-    NSString *firstChar = [_script substringWithRange:range];
-    if ([firstChar isEqualToString:@"'"]) {
-        NSRange endPing = [_script rangeOfCharacterFromSet:ping options:NSLiteralSearch range:NSMakeRange(range.location+1, N-range.location-1)];
-        if (endPing.location==NSNotFound) {
-            return nil;
+          w.valueType = UIScriptLiteralTypeIndexPath;
+          w.objectValue = [NSIndexPath indexPathForRow:[i1 integerValue]
+                                             inSection:[i2 integerValue]];
         } else {
-            while (endPing.location > 0 && 
-                   [[_script substringWithRange:NSMakeRange(endPing.location-1,1)] isEqualToString:@"\\"]) {
-                endPing = [_script rangeOfCharacterFromSet:ping options:NSLiteralSearch range:NSMakeRange(endPing.location+1, N-endPing.location-1)];                
-                if (endPing.location == NSNotFound) {
-                    return nil;
-                }                 
-            } 
-            
+          NSLog(@"Unknown value type %@", val);
         }
-        NSString *res = [_script substringWithRange:NSMakeRange(i, endPing.location-i+1)];
-        *index = endPing.location+1;
-        if (*index < N) {
-            i=*index;
-            NSRange range=[_script rangeOfCharacterFromSet:notWhite options:NSLiteralSearch range:NSMakeRange(i, N-i)];
-            *index = range.location;
+
+        [_res addObject:w];
+        [w release];
+      }
+      if ([arr count] == 3) {//relation/NSPredicate
+        NSString *selStr = [arr objectAtIndex:0];
+        NSString *rel = [arr objectAtIndex:1];
+        id val = [arr objectAtIndex:2];
+        SEL sel = NSSelectorFromString(selStr);
+        NSPredicate *pred = nil;
+        if ([val isKindOfClass:[NSString class]]) {
+          pred = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"%@ %@ '%@'",
+                                                                             selStr,
+                                                                             rel,
+                                                                             val]];
+        } else {
+          pred = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"%@ %@ %@",
+                                                                             selStr,
+                                                                             rel,
+                                                                             val]];
         }
-        return [res stringByReplacingOccurrencesOfString:@"\\'" withString:@"'"];
-    } else if ([firstChar isEqualToString:@"}"]) {
-        NSLog(@"Illegal unbalanced [] found %@",_script);
-        return nil;
-    } else if ([firstChar isEqualToString:@"{"]) {
-        NSRange endBrack = [_script rangeOfString:@"}" options:NSLiteralSearch range:NSMakeRange(range.location+1, N-range.location-1)];
-        if (endBrack.location==NSNotFound) {
-            return nil;
-        }
-        NSString *res = [_script substringWithRange:NSMakeRange(i, endBrack.location-i+1)];
-        *index = endBrack.location+1;
-        if (*index < N) {
-            i=*index;
-            NSRange range=[_script rangeOfCharacterFromSet:notWhite options:NSLiteralSearch range:NSMakeRange(i, N-i)];
-            *index = range.location;
-        }
-        return res;
-    } else {//whitespace
-        *index = range.location+range.length;
-        NSRange txtRange = NSMakeRange(i,range.location-i);
-        return [_script substringWithRange:txtRange];
+        [_res addObject:[[[UIScriptASTPredicate alloc]
+                initWithPredicate:pred selector:sel] autorelease]];
+      }
     }
+  }
 }
 
-- (NSArray*) parsedTokens {return [[_res mutableCopy] autorelease];}
 
-- (UIScriptASTVisibility*) parseVisibilityIfPresent:(NSString*) token {
-    if ([token isEqualToString:@"all"]) {
-        UIScriptASTVisibility* d = [[UIScriptASTVisibility alloc] initWithVisibility:UIScriptASTVisibilityTypeAll];
-        return [d autorelease];
+- (void) parseString {
+  NSUInteger index = 0;
+  NSUInteger N = [_script length];
+  NSString *token = [self findNextToken:&index];
+  while (token) {
+
+    UIScriptASTVisibility *visibility = [self parseVisibilityIfPresent:token];
+    if (visibility != nil) {
+      [_res addObject:visibility];
+      if (index == N) {return;}
+      token = [self findNextToken:&index];
     }
-    if ([token isEqualToString:@"visible"]) {
-        UIScriptASTVisibility* d = [[UIScriptASTVisibility alloc] initWithVisibility:UIScriptASTVisibilityTypeVisible];
-        return [d autorelease];
+
+    //token should be a direction or classname
+    UIScriptASTDirection *direction = [self parseDirectionIfPresent:token];
+    if (direction != nil) {
+      [_res addObject:direction];
+      if (index == N) {return;}
+      token = [self findNextToken:&index];
+    } else {// default is descendant
+
     }
+
+    if ([token isEqualToString:@"last"]) {
+      UIScriptAST *last = [UIScriptASTLast new];
+      [_res addObject:last];
+      [last release];
+      return;//ignore everything past last
+    } else if ([token isEqualToString:@"first"]) {
+      UIScriptAST *first = [UIScriptASTFirst new];
+      [_res addObject:first];
+      [first release];
+      return;//ignore everything past first
+    }
+
+
+    //token should be a classname, e.g., view:'UITableView' or tableView
+    NSString *clzName = [self parseClassName:token];
+    UIScriptASTClassName *c = [[UIScriptASTClassName alloc]
+            initWithClassName:clzName];
+    [_res addObject:c];
+    [c release];
+
+    if (index == N) {return;}
+    token = [self findNextToken:&index];
+    if (token == nil) {break;}
+
+    UIScriptAST *indexPropOrPred = [self parseIndexPropertyOrPredicate:token];
+    while (indexPropOrPred != nil) {
+      //token is an index or property
+
+      [_res addObject:indexPropOrPred];
+
+      if (index == N) {return;}
+      token = [self findNextToken:&index];
+      indexPropOrPred = [self parseIndexPropertyOrPredicate:token];
+    }//else lookahead reveals another classname so continue
+  }
+}
+
+
+- (NSString *) findNextToken:(NSUInteger *) index {
+  static NSCharacterSet *notWhite = nil;
+
+  if (notWhite == nil) {
+    NSMutableCharacterSet *cs = [NSMutableCharacterSet whitespaceCharacterSet];
+    [cs invert];
+    notWhite = [cs retain];
+  }
+  static NSCharacterSet *whiteSpaceSquareOrPing = nil;
+
+  if (whiteSpaceSquareOrPing == nil) {
+    NSMutableCharacterSet *cs = [NSMutableCharacterSet whitespaceCharacterSet];
+    [cs formUnionWithCharacterSet:ping];
+    [cs formUnionWithCharacterSet:curlyBrackets];
+    whiteSpaceSquareOrPing = [cs retain];
+  }
+
+  NSUInteger i = *index;
+  NSUInteger N = [_script length];
+  if (i == N) {
     return nil;
-}
+  }
+  NSRange range = [_script rangeOfCharacterFromSet:whiteSpaceSquareOrPing
+                                           options:NSLiteralSearch
+                                             range:NSMakeRange(i, N - i)];
+  if (range.location == NSNotFound) {
+    //last token
+    *index = N;
+    return [_script substringFromIndex:i];
+  }
 
-
-- (UIScriptASTDirection*) parseDirectionIfPresent:(NSString*) token {
-    UIScriptASTDirection* d = nil;
-    if ([token isEqualToString:@"parent"]) {
-        d = [[UIScriptASTDirection alloc] initWithDirection:UIScriptASTDirectionTypeParent];
-    }
-    else if ([token isEqualToString:@"find"] || [token isEqualToString:@"descendant"]) {
-        d = [[UIScriptASTDirection alloc] initWithDirection:UIScriptASTDirectionTypeDescendant];
-    }
-    else if ([token isEqualToString:@"child"]) {
-        d = [[UIScriptASTDirection alloc] initWithDirection:UIScriptASTDirectionTypeChild];
-    }
-    else if ([token isEqualToString:@"sibling"]) {
-        d = [[UIScriptASTDirection alloc] initWithDirection:UIScriptASTDirectionTypeSibling];
-    }
-    return d ? [d autorelease] : nil;
-}
-
-- (NSString*) parseClassName:(NSString*) token {
-    NSArray* colonSep=[token componentsSeparatedByCharactersInSet:colon];
-    if ([colonSep count] > 1) {//view:'xx'
-        NSString *viewTok = [colonSep objectAtIndex:0];
-        if (![viewTok isEqualToString:@"view"]) {return nil;}
-        //'xx'
-        NSString *clzTok = [colonSep objectAtIndex:1];
-        NSArray* nameArr = [clzTok componentsSeparatedByCharactersInSet:ping];
-        if ([nameArr count]!=3) {return nil;}
-        return [nameArr objectAtIndex:1];
+  NSString *firstChar = [_script substringWithRange:range];
+  if ([firstChar isEqualToString:@"'"]) {
+    NSRange endPing = [_script rangeOfCharacterFromSet:ping
+                                               options:NSLiteralSearch
+                                                 range:NSMakeRange(
+                                                         range.location + 1,
+                                                         N - range.location - 1)];
+    if (endPing.location == NSNotFound) {
+      return nil;
     } else {
-        NSString* smallCaseName = [colonSep objectAtIndex:0];
-        if ([@"*" isEqualToString:smallCaseName]) {
-            return @"UIView";
+      while (endPing.location > 0 && [[_script substringWithRange:NSMakeRange(
+              endPing.location - 1, 1)] isEqualToString:@"\\"]) {
+        endPing = [_script rangeOfCharacterFromSet:ping options:NSLiteralSearch
+                                             range:NSMakeRange(
+                                                     endPing.location + 1,
+                                                     N - endPing.location - 1)];
+        if (endPing.location == NSNotFound) {
+          return nil;
         }
-        //tableView
-        NSString* upCaseFirst = [[smallCaseName substringToIndex:1] uppercaseString];
-        return [NSString stringWithFormat:@"UI%@%@",upCaseFirst,[smallCaseName substringFromIndex:1]];
+      }
     }
-}
-
-- (UIScriptAST*) parseIndexPropertyOrPredicate:(NSString*) token {
-    NSRange r = [token rangeOfString:@"{"];
-    if (r.location == 0) {
-        NSString *str = [token substringWithRange:NSMakeRange(1, token.length - 2)];
-        NSCharacterSet* white = [NSCharacterSet whitespaceCharacterSet];
-        NSRange range = [str rangeOfCharacterFromSet:white];
-        NSString *selString = [str substringWithRange:NSMakeRange(0, range.location)];
-        SEL sel = NSSelectorFromString(selString);
-
-        NSPredicate *pred = [NSPredicate predicateWithFormat:str];        
-        return [[[UIScriptASTPredicate alloc] initWithPredicate:pred selector:sel] autorelease];
-        
+    NSString *res = [_script substringWithRange:NSMakeRange(i,
+            endPing.location - i + 1)];
+    *index = endPing.location + 1;
+    if (*index < N) {
+      i = *index;
+      NSRange range = [_script rangeOfCharacterFromSet:notWhite
+                                               options:NSLiteralSearch
+                                                 range:NSMakeRange(i, N - i)];
+      *index = range.location;
     }
-
-    NSArray* colonSep=[token componentsSeparatedByCharactersInSet:colon];
-    if ([colonSep count] < 2) {
-        
-        
-        NSLog(@"Warning: token %@ has no : separator", token);
-        return nil;
+    return [res stringByReplacingOccurrencesOfString:@"\\'" withString:@"'"];
+  } else if ([firstChar isEqualToString:@"}"]) {
+    NSLog(@"Illegal unbalanced [] found %@", _script);
+    return nil;
+  } else if ([firstChar isEqualToString:@"{"]) {
+    NSRange endBrack = [_script rangeOfString:@"}" options:NSLiteralSearch
+                                        range:NSMakeRange(range.location + 1,
+                                                N - range.location - 1)];
+    if (endBrack.location == NSNotFound) {
+      return nil;
     }
-    
-    //handle general case...
-    //propOrIndex:value
-    NSString *propNameOrIndex = [colonSep objectAtIndex:0];
-    if ([@"view" isEqualToString:propNameOrIndex]) {
-        return nil;//property can't be view
-    }
-    if ([propNameOrIndex isEqualToString:@"index"]) {
-        NSString* value = [colonSep objectAtIndex:1];
-        NSNumberFormatter* nf = [[NSNumberFormatter alloc] init];
-        NSNumber* numVal = [nf numberFromString:value];
-        [nf release];
-        NSUInteger val = [numVal unsignedIntegerValue];
-        return [[[UIScriptASTIndex alloc] initWithIndex:val] autorelease];
-    }
-    //general property
-    NSString *propName = [colonSep objectAtIndex:0];
-    NSString* propValTok = [[colonSep subarrayWithRange:NSMakeRange(1, [colonSep count]-1)] componentsJoinedByString:@":"];
-    UIScriptASTWith* withProp = [[UIScriptASTWith alloc] initWithSelectorName:propName];
-    
-    [self parseLiteralValue:propValTok addToWithAST:withProp];
-    
-    return [withProp autorelease];
-}
-
-- (void) parseLiteralValue:(NSString*) literalToken addToWithAST:(UIScriptASTWith*) ast {
-    if ([@"NO" isEqualToString:literalToken]) {
-        ast.valueType = UIScriptLiteralTypeBool;
-        [ast setBoolValue:NO];
-        return;
-    }
-    if ([@"YES" isEqualToString:literalToken]) {
-        ast.valueType = UIScriptLiteralTypeBool;
-        [ast setBoolValue:YES];
-        return;
-    }     
-    if ([literalToken length] >= 2) {
-        NSString* startChar = [literalToken substringToIndex:1];    
-        NSString* endChar = [literalToken substringFromIndex:[literalToken length]-1];
-        if ([startChar isEqualToString:@"'"]) {
-            if (![endChar isEqualToString:@"'"]) {
-                //log err
-                ast.valueType = UIScriptLiteralTypeUnknown;
-                return;
-            }
-            //literalToken = 'VAL'
-            ast.valueType = UIScriptLiteralTypeString;
-            ast.objectValue = [literalToken substringWithRange:NSMakeRange(1, [literalToken length]-2)];
-            return;
-        }
-        else
-        {
-            NSRange rng = [literalToken rangeOfString:@","];
-            if (rng.location != NSNotFound)
-            {
-                NSString *str1 = [literalToken substringWithRange:NSMakeRange(0, rng.location)];
-                NSString *str2 = [literalToken substringFromIndex:rng.location+1];
-                ast.valueType = UIScriptLiteralTypeIndexPath;
-                ast.objectValue = [NSIndexPath indexPathForRow:[str1 integerValue] inSection:[str2 integerValue]];
-                return;
-                
-                
-            }
-        }
-    }
-    NSNumberFormatter* nf = [[NSNumberFormatter alloc] init];
-    NSNumber* numVal = [nf numberFromString:literalToken];
-    [nf release];
-    ast.valueType = UIScriptLiteralTypeInteger;
-    ast.integerValue = [numVal integerValue];
-    //does not handle float/double
-}
-
-- (NSArray*) evalWith:(NSArray*) views {
-    if ([_res count] == 0) {return nil;}
-    NSUInteger index = 0;
-    UIScriptASTDirectionType dir = UIScriptASTDirectionTypeDescendant;
-    UIScriptASTVisibilityType visibility = UIScriptASTVisibilityTypeVisible;
-    
-
-    //index and first match first = [res objectAtIndex:index];
-    //dir is direction or default direction
-    NSArray* res = views;
-    NSUInteger N = [_res count];
-    while (index<N) {
-        UIScriptAST* cur = [_res objectAtIndex:index++];
-        if ([cur isKindOfClass:[UIScriptASTDirection class]]) {
-            dir = [(UIScriptASTDirection*)cur directionType];
-        }
-        else if ([cur isKindOfClass:[UIScriptASTVisibility class]]) {
-            visibility = [(UIScriptASTVisibility*)cur visibilityType];
-        }
-        else {
-            res = [cur evalWith:res direction:dir visibility:visibility];
-        }
+    NSString *res = [_script substringWithRange:NSMakeRange(i,
+            endBrack.location - i + 1)];
+    *index = endBrack.location + 1;
+    if (*index < N) {
+      i = *index;
+      NSRange range = [_script rangeOfCharacterFromSet:notWhite
+                                               options:NSLiteralSearch
+                                                 range:NSMakeRange(i, N - i)];
+      *index = range.location;
     }
     return res;
+  } else {//whitespace
+    *index = range.location + range.length;
+    NSRange txtRange = NSMakeRange(i, range.location - i);
+    return [_script substringWithRange:txtRange];
+  }
+}
+
+
+- (NSArray *) parsedTokens {return [[_res mutableCopy] autorelease];}
+
+
+- (UIScriptASTVisibility *) parseVisibilityIfPresent:(NSString *) token {
+  if ([token isEqualToString:@"all"]) {
+    UIScriptASTVisibility *d = [[UIScriptASTVisibility alloc]
+            initWithVisibility:UIScriptASTVisibilityTypeAll];
+    return [d autorelease];
+  }
+  if ([token isEqualToString:@"visible"]) {
+    UIScriptASTVisibility *d = [[UIScriptASTVisibility alloc]
+            initWithVisibility:UIScriptASTVisibilityTypeVisible];
+    return [d autorelease];
+  }
+  return nil;
+}
+
+
+- (UIScriptASTDirection *) parseDirectionIfPresent:(NSString *) token {
+  UIScriptASTDirection *d = nil;
+  if ([token isEqualToString:@"parent"]) {
+    d = [[UIScriptASTDirection alloc]
+            initWithDirection:UIScriptASTDirectionTypeParent];
+  } else if ([token isEqualToString:@"find"] || [token isEqualToString:@"descendant"]) {
+    d = [[UIScriptASTDirection alloc]
+            initWithDirection:UIScriptASTDirectionTypeDescendant];
+  } else if ([token isEqualToString:@"child"]) {
+    d = [[UIScriptASTDirection alloc]
+            initWithDirection:UIScriptASTDirectionTypeChild];
+  } else if ([token isEqualToString:@"sibling"]) {
+    d = [[UIScriptASTDirection alloc]
+            initWithDirection:UIScriptASTDirectionTypeSibling];
+  }
+  return d ? [d autorelease] : nil;
+}
+
+
+- (NSString *) parseClassName:(NSString *) token {
+  NSArray *colonSep = [token componentsSeparatedByCharactersInSet:colon];
+  if ([colonSep count] > 1) {//view:'xx'
+    NSString *viewTok = [colonSep objectAtIndex:0];
+    if (![viewTok isEqualToString:@"view"]) {return nil;}
+    //'xx'
+    NSString *clzTok = [colonSep objectAtIndex:1];
+    NSArray *nameArr = [clzTok componentsSeparatedByCharactersInSet:ping];
+    if ([nameArr count] != 3) {return nil;}
+    return [nameArr objectAtIndex:1];
+  } else {
+    NSString *smallCaseName = [colonSep objectAtIndex:0];
+    if ([@"*" isEqualToString:smallCaseName]) {
+      return @"UIView";
+    }
+    //tableView
+    NSString *upCaseFirst = [[smallCaseName substringToIndex:1]
+            uppercaseString];
+    return [NSString stringWithFormat:@"UI%@%@", upCaseFirst,
+                                      [smallCaseName substringFromIndex:1]];
+  }
+}
+
+
+- (UIScriptAST *) parseIndexPropertyOrPredicate:(NSString *) token {
+  NSRange r = [token rangeOfString:@"{"];
+  if (r.location == 0) {
+    NSString *str = [token substringWithRange:NSMakeRange(1, token.length - 2)];
+    NSCharacterSet *white = [NSCharacterSet whitespaceCharacterSet];
+    NSRange range = [str rangeOfCharacterFromSet:white];
+    NSString *selString = [str substringWithRange:NSMakeRange(0,
+            range.location)];
+    SEL sel = NSSelectorFromString(selString);
+
+    NSPredicate *pred = [NSPredicate predicateWithFormat:str];
+    return [[[UIScriptASTPredicate alloc] initWithPredicate:pred selector:sel]
+            autorelease];
+  }
+
+  NSArray *colonSep = [token componentsSeparatedByCharactersInSet:colon];
+  if ([colonSep count] < 2) {
+
+
+    NSLog(@"Warning: token %@ has no : separator", token);
+    return nil;
+  }
+
+  //handle general case...
+  //propOrIndex:value
+  NSString *propNameOrIndex = [colonSep objectAtIndex:0];
+  if ([@"view" isEqualToString:propNameOrIndex]) {
+    return nil;//property can't be view
+  }
+  if ([propNameOrIndex isEqualToString:@"index"]) {
+    NSString *value = [colonSep objectAtIndex:1];
+    NSNumberFormatter *nf = [[NSNumberFormatter alloc] init];
+    NSNumber *numVal = [nf numberFromString:value];
+    [nf release];
+    NSUInteger val = [numVal unsignedIntegerValue];
+    return [[[UIScriptASTIndex alloc] initWithIndex:val] autorelease];
+  }
+  //general property
+  NSString *propName = [colonSep objectAtIndex:0];
+  NSString *propValTok = [[colonSep subarrayWithRange:NSMakeRange(1,
+          [colonSep count] - 1)] componentsJoinedByString:@":"];
+  UIScriptASTWith *withProp = [[UIScriptASTWith alloc]
+          initWithSelectorName:propName];
+
+  [self parseLiteralValue:propValTok addToWithAST:withProp];
+
+  return [withProp autorelease];
+}
+
+
+- (void) parseLiteralValue:(NSString *) literalToken addToWithAST:(UIScriptASTWith *) ast {
+  if ([@"NO" isEqualToString:literalToken]) {
+    ast.valueType = UIScriptLiteralTypeBool;
+    [ast setBoolValue:NO];
+    return;
+  }
+  if ([@"YES" isEqualToString:literalToken]) {
+    ast.valueType = UIScriptLiteralTypeBool;
+    [ast setBoolValue:YES];
+    return;
+  }
+  if ([literalToken length] >= 2) {
+    NSString *startChar = [literalToken substringToIndex:1];
+    NSString *endChar = [literalToken substringFromIndex:[literalToken length] - 1];
+    if ([startChar isEqualToString:@"'"]) {
+      if (![endChar isEqualToString:@"'"]) {
+        //log err
+        ast.valueType = UIScriptLiteralTypeUnknown;
+        return;
+      }
+      //literalToken = 'VAL'
+      ast.valueType = UIScriptLiteralTypeString;
+      ast.objectValue = [literalToken substringWithRange:NSMakeRange(1,
+              [literalToken length] - 2)];
+      return;
+    } else {
+      NSRange rng = [literalToken rangeOfString:@","];
+      if (rng.location != NSNotFound) {
+        NSString *str1 = [literalToken substringWithRange:NSMakeRange(0,
+                rng.location)];
+        NSString *str2 = [literalToken substringFromIndex:rng.location + 1];
+        ast.valueType = UIScriptLiteralTypeIndexPath;
+        ast.objectValue = [NSIndexPath indexPathForRow:[str1 integerValue]
+                                             inSection:[str2 integerValue]];
+        return;
+      }
+    }
+  }
+  NSNumberFormatter *nf = [[NSNumberFormatter alloc] init];
+  NSNumber *numVal = [nf numberFromString:literalToken];
+  [nf release];
+  ast.valueType = UIScriptLiteralTypeInteger;
+  ast.integerValue = [numVal integerValue];
+  //does not handle float/double
+}
+
+
+- (NSArray *) evalWith:(NSArray *) views {
+  if ([_res count] == 0) {return nil;}
+  NSUInteger index = 0;
+  UIScriptASTDirectionType dir = UIScriptASTDirectionTypeDescendant;
+  UIScriptASTVisibilityType visibility = UIScriptASTVisibilityTypeVisible;
+
+
+  //index and first match first = [res objectAtIndex:index];
+  //dir is direction or default direction
+  NSArray *res = views;
+  NSUInteger N = [_res count];
+  while (index < N) {
+    UIScriptAST *cur = [_res objectAtIndex:index++];
+    if ([cur isKindOfClass:[UIScriptASTDirection class]]) {
+      dir = [(UIScriptASTDirection *) cur directionType];
+    } else if ([cur isKindOfClass:[UIScriptASTVisibility class]]) {
+      visibility = [(UIScriptASTVisibility *) cur visibilityType];
+    } else {
+      res = [cur evalWith:res direction:dir visibility:visibility];
+    }
+  }
+  return res;
 }
 
 @end

--- a/calabash/Classes/Utils/LPEnv.h
+++ b/calabash/Classes/Utils/LPEnv.h
@@ -9,7 +9,9 @@
 #import <Foundation/Foundation.h>
 
 @interface LPEnv : NSObject
-+(LPEnv *)sharedEnv;
--(BOOL)isSet:(NSString *)key;
-+(BOOL)calabashDebugEnabled ;
++ (LPEnv *) sharedEnv;
+
+- (BOOL) isSet:(NSString *) key;
+
++ (BOOL) calabashDebugEnabled;
 @end

--- a/calabash/Classes/Utils/LPEnv.m
+++ b/calabash/Classes/Utils/LPEnv.m
@@ -9,45 +9,48 @@
 #import "LPEnv.h"
 
 
-@implementation LPEnv
-{
-    NSDictionary *_env;
+@implementation LPEnv {
+  NSDictionary *_env;
 }
-+(LPEnv *)sharedEnv {
-    static LPEnv *sharedEnv = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedEnv = [[LPEnv alloc] init];
-    });
-    return sharedEnv;
-}
-
--(id)init {
-    self = [super init];
-    if (self) {
-        _env = [[[NSProcessInfo processInfo] environment] retain];
-    }
-    return self;
++ (LPEnv *) sharedEnv {
+  static LPEnv *sharedEnv = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedEnv = [[LPEnv alloc] init];
+  });
+  return sharedEnv;
 }
 
--(void)dealloc {
-    [super dealloc];
-    [_env release];
-    
-}
--(BOOL)isSet:(NSString *)key
-{
-    return [_env valueForKey:key] != nil;
+
+- (id) init {
+  self = [super init];
+  if (self) {
+    _env = [[[NSProcessInfo processInfo] environment] retain];
+  }
+  return self;
 }
 
--(id)valueForKey:(NSString*) key
-{
-    return [_env valueForKey:key];
+
+// TODO LPEnv.m [super dealloc] must be called _last_
+- (void) dealloc {
+  [super dealloc];
+  [_env release];
 }
 
-+(BOOL)calabashDebugEnabled {
-    NSString *debugVal = [[LPEnv sharedEnv] valueForKey:@"CALABASH_DEBUG"];
-    return debugVal && ![debugVal isEqualToString:@"0"];
+
+- (BOOL) isSet:(NSString *) key {
+  return [_env valueForKey:key] != nil;
+}
+
+
+- (id) valueForKey:(NSString *) key {
+  return [_env valueForKey:key];
+}
+
+
++ (BOOL) calabashDebugEnabled {
+  NSString *debugVal = [[LPEnv sharedEnv] valueForKey:@"CALABASH_DEBUG"];
+  return debugVal && ![debugVal isEqualToString:@"0"];
 }
 
 @end

--- a/calabash/Classes/Utils/LPJSONUtils.h
+++ b/calabash/Classes/Utils/LPJSONUtils.h
@@ -4,17 +4,19 @@
 //  Copyright 2011 LessPainful. All rights reserved.
 //
 
-
-
 @interface LPJSONUtils : NSObject
 
-+ (NSString*) serializeDictionary:(NSDictionary*) dictionary;
-+ (NSDictionary*) deserializeDictionary:(NSString*) string;
-+ (NSString*) serializeArray:(NSArray*) array;
-+ (NSArray*) deserializeArray:(NSString*) string;
-+(NSString *)serializeObject:(id)obj;
++ (NSString *) serializeDictionary:(NSDictionary *) dictionary;
 
-+(id)jsonifyObject:(id)obj;
++ (NSDictionary *) deserializeDictionary:(NSString *) string;
+
++ (NSString *) serializeArray:(NSArray *) array;
+
++ (NSArray *) deserializeArray:(NSString *) string;
+
++ (NSString *) serializeObject:(id) obj;
+
++ (id) jsonifyObject:(id) obj;
 
 
 @end

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -11,151 +11,136 @@
 
 @implementation LPJSONUtils
 
-+ (NSString*) serializeDictionary:(NSDictionary*) dictionary {
-    LPCJSONSerializer* s = [LPCJSONSerializer serializer];
-    NSError* error = nil;
-    NSData* d = [s serializeDictionary:dictionary error:&error];
-    if (error) {
-        NSLog(@"Unable to serialize dictionary (%@), %@",error,dictionary);
-    }
-    NSString* res = [[NSString alloc]  initWithBytes:[d bytes]
-                              length:[d length] encoding: NSUTF8StringEncoding];
-    return [res autorelease];
-}
-+ (NSDictionary*) deserializeDictionary:(NSString*) string {
-    LPCJSONDeserializer* ds = [LPCJSONDeserializer deserializer];
-    NSError* error = nil;
-    NSDictionary* res = [ds deserializeAsDictionary:[string dataUsingEncoding:NSUTF8StringEncoding]error:&error];
-    if (error) {
-        NSLog(@"Unable to deserialize  %@",string);
-    }
-    return res;
++ (NSString *) serializeDictionary:(NSDictionary *) dictionary {
+  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
+  NSError *error = nil;
+  NSData *d = [s serializeDictionary:dictionary error:&error];
+  if (error) {
+    NSLog(@"Unable to serialize dictionary (%@), %@", error, dictionary);
+  }
+  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
+                                         encoding:NSUTF8StringEncoding];
+  return [res autorelease];
 }
 
-+ (NSString*) serializeArray:(NSArray*) array {
-    LPCJSONSerializer* s = [LPCJSONSerializer serializer];
-    NSError* error = nil;
-    NSData* d = [s serializeArray:array error:&error];
-    if (error) {
-        NSLog(@"Unable to serialize arrayy (%@), %@",error,array);
-    }
-    NSString* res = [[NSString alloc]  initWithBytes:[d bytes]
-                                              length:[d length] encoding: NSUTF8StringEncoding];
-    return [res autorelease];
-}
-+ (NSArray*) deserializeArray:(NSString*) string {
-    LPCJSONDeserializer* ds = [LPCJSONDeserializer deserializer];
-    NSError* error = nil;
-    NSArray* res = [ds deserializeAsArray:[string dataUsingEncoding:NSUTF8StringEncoding] error:&error];
-    if (error) {
-        NSLog(@"Unable to deserialize  %@",string);
-    }
-    return res;
+
++ (NSDictionary *) deserializeDictionary:(NSString *) string {
+  LPCJSONDeserializer *ds = [LPCJSONDeserializer deserializer];
+  NSError *error = nil;
+  NSDictionary *res = [ds deserializeAsDictionary:[string dataUsingEncoding:NSUTF8StringEncoding]
+                                            error:&error];
+  if (error) {
+    NSLog(@"Unable to deserialize  %@", string);
+  }
+  return res;
 }
 
-+(NSString *)serializeObject:(id)obj
-{
-    LPCJSONSerializer* s = [LPCJSONSerializer serializer];
-    NSError* error = nil;
-    NSData* d = [s serializeObject:obj error:&error];
-    if (error) {
-        NSLog(@"Unable to serialize object (%@), %@",error,[obj description]);
-    }
-    NSString* res = [[NSString alloc]  initWithBytes:[d bytes]
-                                              length:[d length] encoding: NSUTF8StringEncoding];
-    return [res autorelease];
 
++ (NSString *) serializeArray:(NSArray *) array {
+  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
+  NSError *error = nil;
+  NSData *d = [s serializeArray:array error:&error];
+  if (error) {
+    NSLog(@"Unable to serialize arrayy (%@), %@", error, array);
+  }
+  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
+                                         encoding:NSUTF8StringEncoding];
+  return [res autorelease];
 }
 
-+(id)jsonifyObject:(id)object
-{
-        if (!object) {return nil;}
-        if ([object isKindOfClass:[UIColor class]]) 
-        {
-            //todo special handling
-            return [object description];        
-        }
-        if ([object isKindOfClass:[UIView class]])
-        {
-            UIView *v = (UIView*)object;
-            NSMutableDictionary *result = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                           NSStringFromClass([object class]),@"class",
-                                           
-                                           nil];
-            
 
-            NSString *lbl = [object accessibilityLabel];
-            if (lbl)
-            {
-                [result setObject:lbl forKey:@"label"];
-            }
-            else
-            {
-                [result setObject:[NSNull null] forKey:@"label"];                
-            }
++ (NSArray *) deserializeArray:(NSString *) string {
+  LPCJSONDeserializer *ds = [LPCJSONDeserializer deserializer];
+  NSError *error = nil;
+  NSArray *res = [ds deserializeAsArray:[string dataUsingEncoding:NSUTF8StringEncoding]
+                                  error:&error];
+  if (error) {
+    NSLog(@"Unable to deserialize  %@", string);
+  }
+  return res;
+}
 
-            if ([result respondsToSelector:@selector(accessibilityIdentifier)]) {
 
-                NSString *aid = [object accessibilityIdentifier];
-                if (aid)
-                {
-                    [result setObject:aid forKey:@"id"];
-                }
-                else
-                {
-                    [result setObject:[NSNull null] forKey:@"id"];
-                }
++ (NSString *) serializeObject:(id) obj {
+  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
+  NSError *error = nil;
+  NSData *d = [s serializeObject:obj error:&error];
+  if (error) {
+    NSLog(@"Unable to serialize object (%@), %@", error, [obj description]);
+  }
+  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
+                                         encoding:NSUTF8StringEncoding];
+  return [res autorelease];
+}
 
-            }
-            
-            
-            CGRect frame = [object frame];
-            
-            UIWindow *frontWindow = [[UIApplication sharedApplication] keyWindow];
-            UIWindow *window = [LPTouchUtils windowForView:v];
-            if (window)
-            {
-                CGRect rect = [window convertRect:v.bounds fromView:v];
-                rect = [frontWindow convertRect:rect fromWindow:window];
-                CGPoint center = [LPTouchUtils centerOfFrame:rect shouldTranslate:YES];
-                NSDictionary *rectDic =
-                [NSDictionary dictionaryWithObjectsAndKeys:
-                 [NSNumber numberWithFloat:center.x], @"center_x",
-                 [NSNumber numberWithFloat:center.y], @"center_y",
-                 [NSNumber numberWithFloat:rect.origin.x],@"x",
-                 [NSNumber numberWithFloat:rect.origin.y],@"y",
-                 [NSNumber numberWithFloat:rect.size.width],@"width",
-                 [NSNumber numberWithFloat:rect.size.height],@"height",
-                 nil];
-                
-                [result setObject:rectDic forKey:@"rect"];
-                
-                
-            }
-            
-            NSDictionary *frameDic =  
-            [NSDictionary dictionaryWithObjectsAndKeys:
-             [NSNumber numberWithFloat:frame.origin.x],@"x",
-             [NSNumber numberWithFloat:frame.origin.y],@"y",
-             [NSNumber numberWithFloat:frame.size.width],@"width",
-             [NSNumber numberWithFloat:frame.size.height],@"height",
-             nil];
-            
-            [result setObject:frameDic forKey:@"frame"];
-            
-            [result setObject:[object description] forKey:@"description"];
-            
-            return result;
-        }
-        
-        LPCJSONSerializer* s = [LPCJSONSerializer serializer];
-        NSError* error = nil;
-        if (![s serializeObject:object error:&error] || error) 
-        {
-            return [object description];
-        }    
-        return object;
-        
 
++ (id) jsonifyObject:(id) object {
+  if (!object) {return nil;}
+  if ([object isKindOfClass:[UIColor class]]) {
+    //todo special handling
+    return [object description];
+  }
+  if ([object isKindOfClass:[UIView class]]) {
+    UIView *v = (UIView *) object;
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithObjectsAndKeys:NSStringFromClass(
+            [object class]), @"class", nil];
+
+    NSString *lbl = [object accessibilityLabel];
+    if (lbl) {
+      [result setObject:lbl forKey:@"label"];
+    } else {
+      [result setObject:[NSNull null] forKey:@"label"];
+    }
+
+    // TODO LPJSONUtils.h has bug around accessibilityIdentifier
+    if ([result respondsToSelector:@selector(accessibilityIdentifier)]) {
+
+      NSString *aid = [object accessibilityIdentifier];
+      if (aid) {
+        [result setObject:aid forKey:@"id"];
+      } else {
+        [result setObject:[NSNull null] forKey:@"id"];
+      }
+    }
+
+
+    CGRect frame = [object frame];
+
+    UIWindow *frontWindow = [[UIApplication sharedApplication] keyWindow];
+    UIWindow *window = [LPTouchUtils windowForView:v];
+    if (window) {
+      CGRect rect = [window convertRect:v.bounds fromView:v];
+      rect = [frontWindow convertRect:rect fromWindow:window];
+      CGPoint center = [LPTouchUtils centerOfFrame:rect shouldTranslate:YES];
+      NSDictionary *rectDic = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:center.x], @"center_x",
+                                                                         [NSNumber numberWithFloat:center.y], @"center_y",
+                                                                         [NSNumber numberWithFloat:rect.origin.x], @"x",
+                                                                         [NSNumber numberWithFloat:rect.origin.y], @"y",
+                                                                         [NSNumber numberWithFloat:rect.size.width], @"width",
+                                                                         [NSNumber numberWithFloat:rect.size.height], @"height",
+                                                                         nil];
+
+      [result setObject:rectDic forKey:@"rect"];
+    }
+
+    NSDictionary *frameDic = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:frame.origin.x], @"x",
+                                                                        [NSNumber numberWithFloat:frame.origin.y], @"y",
+                                                                        [NSNumber numberWithFloat:frame.size.width], @"width",
+                                                                        [NSNumber numberWithFloat:frame.size.height], @"height",
+                                                                        nil];
+
+    [result setObject:frameDic forKey:@"frame"];
+
+    [result setObject:[object description] forKey:@"description"];
+
+    return result;
+  }
+
+  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
+  NSError *error = nil;
+  if (![s serializeObject:object error:&error] || error) {
+    return [object description];
+  }
+  return object;
 }
 @end

--- a/calabash/Classes/Utils/LPLog.h
+++ b/calabash/Classes/Utils/LPLog.h
@@ -8,16 +8,20 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum { LPLogLevelDebug=1, LPLogLevelInfo=5, LPLogLevelError=10 } LPLogLevel;
+typedef enum {LPLogLevelDebug = 1, LPLogLevelInfo = 5, LPLogLevelError = 10} LPLogLevel;
 
 @interface LPLog : NSObject
 
-+(LPLogLevel)currentLevel;
-+(NSString*)currentLevelString;
-+(void)setLevelFromString:(NSString*)logLevel;
++ (LPLogLevel) currentLevel;
 
-+(void)debug:(NSString *)formatString, ...;
-+(void)info:(NSString *)formatString, ...;
-+(void)error:(NSString *)formatString, ...;
++ (NSString *) currentLevelString;
+
++ (void) setLevelFromString:(NSString *) logLevel;
+
++ (void) debug:(NSString *) formatString, ...;
+
++ (void) info:(NSString *) formatString, ...;
+
++ (void) error:(NSString *) formatString, ...;
 
 @end

--- a/calabash/Classes/Utils/LPLog.m
+++ b/calabash/Classes/Utils/LPLog.m
@@ -10,105 +10,95 @@
 #import "LPEnv.h"
 
 
-@implementation LPLog 
-{
-    LPLogLevel _logLevel;
+@implementation LPLog {
+  LPLogLevel _logLevel;
 }
 
-+(LPLog *)sharedLog {
-    static LPLog *sharedLog = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedLog = [[LPLog alloc] init];
-    });
-    return sharedLog;
++ (LPLog *) sharedLog {
+  static LPLog *sharedLog = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedLog = [[LPLog alloc] init];
+  });
+  return sharedLog;
 }
 
-+(LPLogLevel)currentLevel
-{
-    return [[LPLog sharedLog] currentLevel];
+
++ (LPLogLevel) currentLevel {
+  return [[LPLog sharedLog] currentLevel];
 }
 
-+(void)setLevelFromString:(NSString*)logLevel
-{
-    [[LPLog sharedLog] setLevelFromString:logLevel];
+
++ (void) setLevelFromString:(NSString *) logLevel {
+  [[LPLog sharedLog] setLevelFromString:logLevel];
 }
 
--(void)setLevelFromString:(NSString*)logLevel
-{
-    if ([@"debug" isEqualToString:[logLevel lowercaseString]])
-    {
-        _logLevel = LPLogLevelDebug;
-    }
-    else if ([@"info" isEqualToString:[logLevel lowercaseString]])
-    {
-        _logLevel = LPLogLevelInfo;
-    }
-    else if ([@"error" isEqualToString:[logLevel lowercaseString]])
-    {
-        _logLevel = LPLogLevelError;
-    }
+
+- (void) setLevelFromString:(NSString *) logLevel {
+  if ([@"debug" isEqualToString:[logLevel lowercaseString]]) {
+    _logLevel = LPLogLevelDebug;
+  } else if ([@"info" isEqualToString:[logLevel lowercaseString]]) {
+    _logLevel = LPLogLevelInfo;
+  } else if ([@"error" isEqualToString:[logLevel lowercaseString]]) {
+    _logLevel = LPLogLevelError;
+  }
 }
 
--(LPLogLevel)currentLevel
-{
-    return _logLevel;
+
+- (LPLogLevel) currentLevel {
+  return _logLevel;
 }
 
-+(NSString*)currentLevelString
-{
-    switch ([LPLog currentLevel]) {
-        case LPLogLevelDebug:
-            return @"debug";
-        case LPLogLevelInfo:
-            return @"info";
-        case LPLogLevelError:
-            return @"error";
-        default:
-            return nil;
-    }
+
++ (NSString *) currentLevelString {
+  switch ([LPLog currentLevel]) {
+    case LPLogLevelDebug:return @"debug";
+    case LPLogLevelInfo:return @"info";
+    case LPLogLevelError:return @"error";
+    default:return nil;
+  }
 }
 
--(id)init {
-    self = [super init];
-    if (self) {
-        _logLevel = [LPEnv calabashDebugEnabled] ? LPLogLevelDebug : LPLogLevelInfo;
-    }
-    return self;
+
+- (id) init {
+  self = [super init];
+  if (self) {
+    _logLevel = [LPEnv calabashDebugEnabled] ? LPLogLevelDebug : LPLogLevelInfo;
+  }
+  return self;
 }
 
--(BOOL)shouldLogAtLevel:(LPLogLevel) level
-{
-    return (level >= _logLevel);
+
+- (BOOL) shouldLogAtLevel:(LPLogLevel) level {
+  return (level >= _logLevel);
 }
 
 
 //Not 100% sure if this va_* is necessary
-+(void)debug:(NSString *)formatString, ...;
-{
-    if (![[LPLog sharedLog] shouldLogAtLevel: LPLogLevelDebug]) {return;}
-    va_list args;
-    va_start(args, formatString);
-    NSLogv(formatString, args);
-    va_end(args);
++ (void) debug:(NSString *) formatString, ...; {
+  if (![[LPLog sharedLog] shouldLogAtLevel:LPLogLevelDebug]) {return;}
+  va_list args;
+  va_start(args, formatString);
+  NSLogv(formatString, args);
+  va_end(args);
 }
 
 
-+(void)info:(NSString *)formatString, ... {
-    if (![[LPLog sharedLog] shouldLogAtLevel: LPLogLevelInfo]) {return;}
-    va_list args;
-    va_start(args, formatString);
-    NSLogv(formatString, args);
-    va_end(args);
-
++ (void) info:(NSString *) formatString, ... {
+  if (![[LPLog sharedLog] shouldLogAtLevel:LPLogLevelInfo]) {return;}
+  va_list args;
+  va_start(args, formatString);
+  NSLogv(formatString, args);
+  va_end(args);
 }
 
-+(void)error:(NSString *)formatString, ... {
-    if (![[LPLog sharedLog] shouldLogAtLevel: LPLogLevelError]) {return;}
-    va_list args;
-    va_start(args, formatString);
-    NSLogv(formatString, args);
-    va_end(args);
+
++ (void) error:(NSString *) formatString, ... {
+  if (![[LPLog sharedLog] shouldLogAtLevel:LPLogLevelError]) {return;}
+  va_list args;
+  va_start(args, formatString);
+  NSLogv(formatString, args);
+  va_end(args);
 }
 
 @end

--- a/calabash/Classes/Utils/LPReflectUtils.h
+++ b/calabash/Classes/Utils/LPReflectUtils.h
@@ -8,5 +8,6 @@
 
 @interface LPReflectUtils : NSObject
 
-+(id)invokeSpec:(id)object onTarget:(id)target withError:(NSError**)error;
++ (id) invokeSpec:(id) object onTarget:(id) target withError:(NSError **) error;
+
 @end

--- a/calabash/Classes/Utils/LPReflectUtils.m
+++ b/calabash/Classes/Utils/LPReflectUtils.m
@@ -5,223 +5,182 @@
 //
 
 #import "LPReflectUtils.h"
-#import "LPCJSONSerializer.h"
-#import "LPCJSONDeserializer.h"
 
 @implementation LPReflectUtils
 
-+(SEL)parseSpecFromArray:(NSArray *)arr withArgs:(NSMutableArray *)args
-{
-    NSMutableString *selStr = [NSMutableString stringWithCapacity:32];
-    for (id spec in arr)
-    {
-        NSString *key = nil;
-        id val = nil;
-        if ([spec isKindOfClass:[NSDictionary class]])
-        {
-            NSDictionary *specDict = (NSDictionary*)spec;
-            key = [[specDict keyEnumerator] nextObject];
-            val = [specDict objectForKey:key];
-        }
-        else if ([spec isKindOfClass:[NSArray class]])
-        {
-            NSArray *specArr = (NSArray*)spec;
-            key = (NSString*)[specArr objectAtIndex:0];
-            val = [specArr objectAtIndex:1];            
-        }
-        [selStr appendFormat:@"%@:",key];
-        [args addObject:val];
++ (SEL) parseSpecFromArray:(NSArray *) arr withArgs:(NSMutableArray *) args {
+  NSMutableString *selStr = [NSMutableString stringWithCapacity:32];
+  for (id spec in arr) {
+    NSString *key = nil;
+    id val = nil;
+    if ([spec isKindOfClass:[NSDictionary class]]) {
+      NSDictionary *specDict = (NSDictionary *) spec;
+      key = [[specDict keyEnumerator] nextObject];
+      val = [specDict objectForKey:key];
+    } else if ([spec isKindOfClass:[NSArray class]]) {
+      NSArray *specArr = (NSArray *) spec;
+      key = (NSString *) [specArr objectAtIndex:0];
+      val = [specArr objectAtIndex:1];
     }
-    return NSSelectorFromString(selStr);
+    [selStr appendFormat:@"%@:", key];
+    [args addObject:val];
+  }
+  return NSSelectorFromString(selStr);
 }
 
 
++ (id) invokeSpec:(id) object onTarget:(id) target withError:(NSError **) error {
+  id selObj = object;
+  id objValue;
+  int intValue;
+  long longValue;
+  char *charPtrValue;
+  char charValue;
+  short shortValue;
+  float floatValue;
+  double doubleValue;
+  SEL sel;
 
-+(id)invokeSpec:(id)object onTarget:(id)target withError:(NSError**)error
-{
-    id selObj = object;
-    id objValue;
-    int intValue;
-    long longValue;
-    char *charPtrValue;
-    char charValue;
-    short shortValue;
-    float floatValue;
-    double doubleValue;
-    SEL sel;
-    
-    NSMutableArray *args = [NSMutableArray array];
-    
-    if ([selObj isKindOfClass:[NSString class]])
-    {
-        sel = NSSelectorFromString(selObj);
-    }
-    else if ([selObj isKindOfClass:[NSDictionary class]])
-    {
-        sel = [self parseSpecFromArray:[NSArray arrayWithObject: selObj] withArgs:args];
-    }
-    else if ([selObj isKindOfClass:[NSArray class]])
-    {
-        sel = [self parseSpecFromArray:selObj withArgs:args];
-        
-    }
-    
-    NSMethodSignature *sig = [target methodSignatureForSelector:sel];
-    if (!sig || ![target respondsToSelector:sel])
-    {
-        *error = [NSError errorWithDomain:@"Calabash" code:2
-                                 userInfo:
-                  [NSDictionary dictionaryWithObjectsAndKeys:
-                   @"target does not respond to selector", @"reason",
-                   [NSString stringWithFormat:@"applied to selector %@",NSStringFromSelector(sel)],@"details"
-                   ,nil]];
-        return nil;
-        
-    }
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
-    
-    [invocation setSelector:sel];
-    for (NSInteger i =0, N=[args count]; i<N; i++)
-    {
-        id arg = [args objectAtIndex:i];
-        const char *cType = [sig getArgumentTypeAtIndex:i+2];
-        switch(*cType) {
-            case '@':
-                [invocation setArgument:&arg atIndex:i+2];
-                break;
-            case 'i':
-            {
-                NSInteger intVal = [arg integerValue];
-                [invocation setArgument:&intVal atIndex:i+2];
-                break;
-            }
-            case 's':
-            {
-                short shVal = [arg shortValue];
-                [invocation setArgument:&shVal atIndex:i+2];
-                break;
-            }
-            case 'd':
-            {
-                double dbVal = [arg doubleValue];
-                [invocation setArgument:&dbVal atIndex:i+2];
-                break;
-            }
-            case 'f':
-            {
-                float fltVal = [arg floatValue];
-                [invocation setArgument:&fltVal atIndex:i+2];
-                break;
-            }
-            case 'l':
-            {
-                long lngVal = [arg longValue];
-                [invocation setArgument:&lngVal atIndex:i+2];
-                break;
-            }
-            case '#':
-            {
-                Class cVal = NSClassFromString(arg);
-                [invocation setArgument:&cVal atIndex:i+2];
-                break;
-            }
-            case '*':
-                //not supported yet
-                @throw [NSString stringWithFormat: @"not yet support struct pointers: %@",sig];
-            case 'c':
-            {
-                char chVal =[arg charValue];
-                [invocation setArgument:&chVal atIndex:i+2];
-                break;
-            }
-            case '{': {
-                //not supported yet
-                @throw [NSString stringWithFormat: @"not yet support struct args: %@",sig];
-            }
-        }
-        
-    }
-    [invocation setTarget:target];
-    @try {
-        [invocation invoke];
-    }
-    @catch (NSException *exception) {
-        NSLog(@"Perform %@ with target %@ caught %@: %@", selObj, target, [exception name], [exception reason]);
-        NSLog(@"not supported");
-        return nil;
-    }
-    
-    
-    
-    
-    const char* type = [[invocation methodSignature] methodReturnType];
-    NSString *returnType = [NSString stringWithFormat:@"%s", type];
-    const char* trimmedType = [[returnType substringToIndex:1] cStringUsingEncoding:NSASCIIStringEncoding];
-    switch(*trimmedType) {
-        case '@':
-            [invocation getReturnValue:(void **)&objValue];
-            if (objValue == nil) {
-                return nil;
-            } else {
-                    return objValue;
-            }
-        case 'i':
-            [invocation getReturnValue:(void **)&intValue];
-            return [NSNumber numberWithInt: intValue];
-        case 's':
-            [invocation getReturnValue:(void **)&shortValue];
-            return [NSNumber numberWithShort:shortValue];
-        case 'd':
-            [invocation getReturnValue:(void **)&doubleValue];
-            return [NSNumber numberWithDouble: doubleValue];
-        case 'f':
-            [invocation getReturnValue:(void **)&floatValue];
-            return [NSNumber numberWithFloat:floatValue];
-        case 'l':
-            [invocation getReturnValue:(void **)&longValue];
-            return [NSNumber numberWithLong: longValue];
-        case '*':
-            [invocation getReturnValue:(void **)&charPtrValue];
-            return [NSString stringWithFormat:@"%s", charPtrValue];
-        case 'c':
-            [invocation getReturnValue:(void **)&charValue];
-            return [NSNumber numberWithChar:charValue];
-        case '{': {
-            unsigned int length = [[invocation methodSignature] methodReturnLength];
-            void *buffer = (void *)malloc(length);
-            [invocation getReturnValue:buffer];
-            NSValue *value = [[[NSValue alloc] initWithBytes:buffer objCType:type] autorelease];
-            
-            if ([returnType rangeOfString:@"{CGRect"].location == 0)
-            {
-                CGRect *rec = (CGRect*)buffer;
-                return [NSDictionary dictionaryWithObjectsAndKeys:
-                        [value description], @"description",
-                        [NSNumber numberWithFloat:rec->origin.x],@"x",
-                        [NSNumber numberWithFloat:rec->origin.y],@"y",
-                        [NSNumber numberWithFloat:rec->size.width],@"width",
-                        [NSNumber numberWithFloat:rec->size.height],@"height",
-                        nil];
-                
-            }
-            else if ([returnType rangeOfString:@"{CGPoint="].location == 0)
-            {
-                CGPoint *point = (CGPoint*)buffer;
-                return [NSDictionary dictionaryWithObjectsAndKeys:
-                        [value description], @"description",
-                        [NSNumber numberWithFloat:point->x],@"x",
-                        [NSNumber numberWithFloat:point->y],@"y",
-                        nil];
-                
-            }
-            else
-            {
-                return [value description];
-            }
-        }
-    }
-    
+  NSMutableArray *args = [NSMutableArray array];
 
+  if ([selObj isKindOfClass:[NSString class]]) {
+    sel = NSSelectorFromString(selObj);
+  } else if ([selObj isKindOfClass:[NSDictionary class]]) {
+    sel = [self parseSpecFromArray:[NSArray arrayWithObject:selObj]
+                          withArgs:args];
+  } else if ([selObj isKindOfClass:[NSArray class]]) {
+    sel = [self parseSpecFromArray:selObj withArgs:args];
+  }
+
+  NSMethodSignature *sig = [target methodSignatureForSelector:sel];
+  if (!sig || ![target respondsToSelector:sel]) {
+    *error = [NSError errorWithDomain:@"Calabash" code:2
+                             userInfo:[NSDictionary dictionaryWithObjectsAndKeys:@"target does not respond to selector", @"reason",
+                                                                                 [NSString stringWithFormat:@"applied to selector %@",
+                                                                                                            NSStringFromSelector(
+                                                                                                                    sel)], @"details",
+                                                                                 nil]];
+    return nil;
+  }
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
+
+  [invocation setSelector:sel];
+  for (NSInteger i = 0, N = [args count]; i < N; i++) {
+    id arg = [args objectAtIndex:i];
+    const char *cType = [sig getArgumentTypeAtIndex:i + 2];
+    switch (*cType) {
+      case '@':[invocation setArgument:&arg atIndex:i + 2];
+        break;
+      case 'i': {
+        NSInteger intVal = [arg integerValue];
+        [invocation setArgument:&intVal atIndex:i + 2];
+        break;
+      }
+      case 's': {
+        short shVal = [arg shortValue];
+        [invocation setArgument:&shVal atIndex:i + 2];
+        break;
+      }
+      case 'd': {
+        double dbVal = [arg doubleValue];
+        [invocation setArgument:&dbVal atIndex:i + 2];
+        break;
+      }
+      case 'f': {
+        float fltVal = [arg floatValue];
+        [invocation setArgument:&fltVal atIndex:i + 2];
+        break;
+      }
+      case 'l': {
+        long lngVal = [arg longValue];
+        [invocation setArgument:&lngVal atIndex:i + 2];
+        break;
+      }
+      case '#': {
+        Class cVal = NSClassFromString(arg);
+        [invocation setArgument:&cVal atIndex:i + 2];
+        break;
+      }
+      case '*':
+        //not supported yet
+        @throw [NSString stringWithFormat:@"not yet support struct pointers: %@",
+                                          sig];
+      case 'c': {
+        char chVal = [arg charValue];
+        [invocation setArgument:&chVal atIndex:i + 2];
+        break;
+      }
+      case '{': {
+        //not supported yet
+        @throw [NSString stringWithFormat:@"not yet support struct args: %@",
+                                          sig];
+      }
+    }
+  }
+  [invocation setTarget:target];
+  @try {
+    [invocation invoke];
+  }
+  @catch (NSException *exception) {
+    NSLog(@"Perform %@ with target %@ caught %@: %@", selObj, target,
+            [exception name], [exception reason]);
+    NSLog(@"not supported");
+    return nil;
+  }
+
+  const char *type = [[invocation methodSignature] methodReturnType];
+  NSString *returnType = [NSString stringWithFormat:@"%s", type];
+  const char *trimmedType = [[returnType substringToIndex:1]
+          cStringUsingEncoding:NSASCIIStringEncoding];
+  // TODO default switch statement is not handled in LPReflectUtils.m
+  switch (*trimmedType) {
+    case '@':[invocation getReturnValue:(void **) &objValue];
+      if (objValue == nil) {
+        return nil;
+      } else {
+        return objValue;
+      }
+    case 'i':[invocation getReturnValue:(void **) &intValue];
+      return [NSNumber numberWithInt:intValue];
+    case 's':[invocation getReturnValue:(void **) &shortValue];
+      return [NSNumber numberWithShort:shortValue];
+    case 'd':[invocation getReturnValue:(void **) &doubleValue];
+      return [NSNumber numberWithDouble:doubleValue];
+    case 'f':[invocation getReturnValue:(void **) &floatValue];
+      return [NSNumber numberWithFloat:floatValue];
+    case 'l':[invocation getReturnValue:(void **) &longValue];
+      return [NSNumber numberWithLong:longValue];
+    case '*':[invocation getReturnValue:(void **) &charPtrValue];
+      return [NSString stringWithFormat:@"%s", charPtrValue];
+    case 'c':[invocation getReturnValue:(void **) &charValue];
+      return [NSNumber numberWithChar:charValue];
+    case '{': {
+      unsigned int length = [[invocation methodSignature] methodReturnLength];
+      void *buffer = (void *) malloc(length);
+      [invocation getReturnValue:buffer];
+      NSValue *value = [[[NSValue alloc] initWithBytes:buffer objCType:type]
+              autorelease];
+
+      if ([returnType rangeOfString:@"{CGRect"].location == 0) {
+        CGRect *rec = (CGRect *) buffer;
+        return [NSDictionary dictionaryWithObjectsAndKeys:[value description], @"description",
+                                                          [NSNumber numberWithFloat:rec->origin.x], @"x",
+                                                          [NSNumber numberWithFloat:rec->origin.y], @"y",
+                                                          [NSNumber numberWithFloat:rec->size.width], @"width",
+                                                          [NSNumber numberWithFloat:rec->size.height], @"height",
+                                                          nil];
+      } else if ([returnType rangeOfString:@"{CGPoint="].location == 0) {
+        CGPoint *point = (CGPoint *) buffer;
+        return [NSDictionary dictionaryWithObjectsAndKeys:[value description], @"description",
+                                                          [NSNumber numberWithFloat:point->x], @"x",
+                                                          [NSNumber numberWithFloat:point->y], @"y",
+                                                          nil];
+      } else {
+        return [value description];
+      }
+    }
+  }
+  // TODO no return in LPReflectUtils.m invokeSpec:
 }
 
 @end

--- a/calabash/Classes/Utils/LPTouchUtils.h
+++ b/calabash/Classes/Utils/LPTouchUtils.h
@@ -8,23 +8,26 @@
 
 @interface LPTouchUtils : NSObject
 
-+(CGPoint) translateToScreenCoords:(CGPoint) point;
-+(CGPoint) centerOfView:(UIView *) view;
-+(CGPoint)centerOfFrame:(CGRect)frame;
-+(CGPoint)centerOfFrame:(CGRect)frame shouldTranslate:(BOOL)shouldTranslate;
-+(CGPoint) centerOfView:(id)view 
-          withSuperView:(UIView *)superView
-               inWindow:(id)window;
++ (CGPoint) translateToScreenCoords:(CGPoint) point;
 
-+(BOOL)is4InchDevice;
-+(NSArray*)applicationWindows;
++ (CGPoint) centerOfView:(UIView *) view;
 
-+(UIWindow*)windowForView:(UIView*)view;
++ (CGPoint) centerOfFrame:(CGRect) frame;
 
-+(UIWindow*)appDelegateWindow;
++ (CGPoint) centerOfFrame:(CGRect) frame shouldTranslate:(BOOL) shouldTranslate;
 
-+(BOOL)isViewVisible:(UIView *)view;
++ (CGPoint) centerOfView:(id) view withSuperView:(UIView *) superView inWindow:(id) window;
 
-+(void)flashView:(id) viewOrDom forDuration:(NSUInteger) duration;
++ (BOOL) is4InchDevice;
+
++ (NSArray *) applicationWindows;
+
++ (UIWindow *) windowForView:(UIView *) view;
+
++ (UIWindow *) appDelegateWindow;
+
++ (BOOL) isViewVisible:(UIView *) view;
+
++ (void) flashView:(id) viewOrDom forDuration:(NSUInteger) duration;
 
 @end

--- a/calabash/Classes/Utils/LPTouchUtils.m
+++ b/calabash/Classes/Utils/LPTouchUtils.m
@@ -4,7 +4,6 @@
 //  Copyright 2011 LessPainful. All rights reserved.
 //
 #import <sys/utsname.h>
-#import <QuartzCore/QuartzCore.h>
 
 #define LPiPHONE4INCHOFFSET 44
 
@@ -13,304 +12,285 @@
 
 @implementation LPTouchUtils
 
-+(BOOL)is4InchDevice {
-    UIDevice *device = [UIDevice currentDevice];
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    
-    NSString *system = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-    NSDictionary *env = [[NSProcessInfo processInfo]environment];
++ (BOOL) is4InchDevice {
+  UIDevice *device = [UIDevice currentDevice];
+  struct utsname systemInfo;
+  uname(&systemInfo);
 
-    
-    BOOL iphone5Like = NO;
-    if([@"iPhone Simulator" isEqualToString: [device model]])
-    {
-        
-        NSPredicate *inch5PhonePred = [NSPredicate predicateWithFormat:@"IPHONE_SIMULATOR_VERSIONS LIKE '*iPhone*Retina*4-inch*'"];
-        iphone5Like = [inch5PhonePred evaluateWithObject:env];
-    }
-    else if ([[device model] hasPrefix:@"iPhone"])
-    {
-        iphone5Like = [system hasPrefix:@"iPhone5"] || [system hasPrefix:@"iPhone6"];
-    }
-    else if ([[device model] hasPrefix:@"iPod"])
-    {
-        iphone5Like = [system hasPrefix:@"iPod5"];
-    }
-    
-    return iphone5Like;
+  NSString *system = [NSString stringWithCString:systemInfo.machine
+                                        encoding:NSUTF8StringEncoding];
+  NSDictionary *env = [[NSProcessInfo processInfo] environment];
+
+  BOOL iphone5Like = NO;
+  if ([@"iPhone Simulator" isEqualToString:[device model]]) {
+
+    NSPredicate *inch5PhonePred = [NSPredicate predicateWithFormat:@"IPHONE_SIMULATOR_VERSIONS LIKE '*iPhone*Retina*4-inch*'"];
+    iphone5Like = [inch5PhonePred evaluateWithObject:env];
+  } else if ([[device model] hasPrefix:@"iPhone"]) {
+    iphone5Like = [system hasPrefix:@"iPhone5"] || [system hasPrefix:@"iPhone6"];
+  } else if ([[device model] hasPrefix:@"iPod"]) {
+    iphone5Like = [system hasPrefix:@"iPod5"];
+  }
+
+  return iphone5Like;
 }
 
-+(CGPoint) translateToScreenCoords:(CGPoint) point {
-    UIScreen*  s = [UIScreen mainScreen];
-    
-    UIScreenMode* sm =[s currentMode];
-    CGRect b = [s bounds];
-    CGSize size = sm.size;
-    UIDeviceOrientation o = [[UIDevice currentDevice] orientation];
-    
-    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone){
-        if ([UIScreen mainScreen].scale == 2.0f) {
-            CGSize result = [[UIScreen mainScreen] bounds].size;
-            CGFloat scale = [UIScreen mainScreen].scale;
-            result = CGSizeMake(result.width * scale, result.height * scale);
-            
-            if(result.height == 960 && [LPTouchUtils is4InchDevice])
-            {//detect Letterbox
-                return CGPointMake(point.x, point.y + LPiPHONE4INCHOFFSET);
-            }
-            
-            if(result.height == 1136){
-                //NSLog(@"iPhone 5 Resolution");
-                //iPhone 5 full 
-                return point;
-            }
-        } 
-    }
-    
-    
-        
-    CGRect small_vert = CGRectMake(0, 0, 320, 480);
-    CGRect small_hori = CGRectMake(0, 0, 480, 320);
-    CGSize large_size_vert = CGSizeMake(768, 1024);
-    CGSize large_size_hori = CGSizeMake(1024, 768);
-    CGSize retina_ipad_vert = CGSizeMake(1536, 2048);
-    CGSize retina_ipad_hori = CGSizeMake(2048, 1536);
-    
-    
-    if ((CGRectEqualToRect(small_vert, b) || CGRectEqualToRect(small_hori, b))  &&
-        (CGSizeEqualToSize(large_size_hori, size) || CGSizeEqualToSize(large_size_vert, size) ||
-         CGSizeEqualToSize(retina_ipad_hori, size) || CGSizeEqualToSize(retina_ipad_vert, size))) {
-       
-        CGSize orientation_size =  UIDeviceOrientationIsPortrait(o) || UIDeviceOrientationFaceUp == o || UIDeviceOrientationUnknown == o ? large_size_vert : large_size_hori;
-        float x_offset = orientation_size.width/2.0f - b.size.width/2.0f;
-        float y_offset = orientation_size.height/2.0f - b.size.height/2.0f;
-        return CGPointMake(x_offset+point.x, y_offset+point.y);
-    } else {
+
++ (CGPoint) translateToScreenCoords:(CGPoint) point {
+  UIScreen *s = [UIScreen mainScreen];
+
+  UIScreenMode *sm = [s currentMode];
+  CGRect b = [s bounds];
+  CGSize size = sm.size;
+  UIDeviceOrientation o = [[UIDevice currentDevice] orientation];
+
+  if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+    if ([UIScreen mainScreen].scale == 2.0f) {
+      CGSize result = [[UIScreen mainScreen] bounds].size;
+      CGFloat scale = [UIScreen mainScreen].scale;
+      result = CGSizeMake(result.width * scale, result.height * scale);
+
+      if (result.height == 960 && [LPTouchUtils is4InchDevice]) {//detect Letterbox
+        return CGPointMake(point.x, point.y + LPiPHONE4INCHOFFSET);
+      }
+
+      if (result.height == 1136) {
+        //NSLog(@"iPhone 5 Resolution");
+        //iPhone 5 full
         return point;
+      }
     }
+  }
+
+
+  CGRect small_vert = CGRectMake(0, 0, 320, 480);
+  CGRect small_hori = CGRectMake(0, 0, 480, 320);
+  CGSize large_size_vert = CGSizeMake(768, 1024);
+  CGSize large_size_hori = CGSizeMake(1024, 768);
+  CGSize retina_ipad_vert = CGSizeMake(1536, 2048);
+  CGSize retina_ipad_hori = CGSizeMake(2048, 1536);
+
+
+  if ((CGRectEqualToRect(small_vert, b) || CGRectEqualToRect(small_hori,
+          b)) && (CGSizeEqualToSize(large_size_hori, size) || CGSizeEqualToSize(
+          large_size_vert, size) || CGSizeEqualToSize(retina_ipad_hori,
+          size) || CGSizeEqualToSize(retina_ipad_vert, size))) {
+
+    CGSize orientation_size = UIDeviceOrientationIsPortrait(o) || UIDeviceOrientationFaceUp == o || UIDeviceOrientationUnknown == o ? large_size_vert : large_size_hori;
+    float x_offset = orientation_size.width / 2.0f - b.size.width / 2.0f;
+    float y_offset = orientation_size.height / 2.0f - b.size.height / 2.0f;
+    return CGPointMake(x_offset + point.x, y_offset + point.y);
+  } else {
+    return point;
+  }
 }
 
-+(NSArray*)applicationWindows {
-    // iOS flatdacted apparenlty doesn't list the "real" window containing alerts in the windows list, but stores it
-    // instead in the -keyWindow property. To fix that, check if the array of windows contains the key window, and
-    // explicitly add it if needed.
-    //
-    NSMutableArray *allWindows = [[[[UIApplication sharedApplication] windows] mutableCopy] autorelease];
-    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-    if(keyWindow && ![allWindows containsObject: keyWindow]) {
-        [allWindows addObject: keyWindow];
-    }
-    
-    return allWindows;
+
++ (NSArray *) applicationWindows {
+  // iOS flatdacted apparently doesn't list the "real" window containing alerts in the windows list, but stores it
+  // instead in the -keyWindow property. To fix that, check if the array of windows contains the key window, and
+  // explicitly add it if needed.
+  //
+  NSMutableArray *allWindows = [[[[UIApplication sharedApplication] windows]
+          mutableCopy] autorelease];
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  if (keyWindow && ![allWindows containsObject:keyWindow]) {
+    [allWindows addObject:keyWindow];
+  }
+
+  return allWindows;
 }
 
-+(UIWindow*)windowForView:(UIView*)view
-{
-    id v = view;
-    while (v && ![v isKindOfClass:[UIWindow class]])
+
++ (UIWindow *) windowForView:(UIView *) view {
+  id v = view;
+  while (v && ![v isKindOfClass:[UIWindow class]]) {
+    v = [v superview];
+  }
+  return v;
+}
+
+
++ (NSInteger) indexOfView:(UIView *) viewToFind asSubViewInView:(UIView *) viewToSearch {
+  //Assume viewToFind != viewToSearch
+  if (viewToFind == nil || viewToSearch == nil) {return -1;}
+  NSArray *subViews = [viewToSearch subviews];
+  for (NSInteger i = 0; i < [subViews count]; i++) {
+    UIView *subView = [subViews objectAtIndex:i];
+    if ([self canFindView:viewToFind asSubViewInView:subView]) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+
++ (BOOL) canFindView:(UIView *) viewToFind asSubViewInView:(UIView *) viewToSearch {
+  if (viewToFind == viewToSearch) {return YES;}
+  if (viewToFind == nil || viewToSearch == nil) {return NO;}
+  NSInteger index = [self indexOfView:viewToFind asSubViewInView:viewToSearch];
+  return index != -1;
+}
+
+
++ (BOOL) isViewOrParentsHidden:(UIView *) view {
+  if ([view alpha] <= 0.05) {
+    return YES;
+  }
+  UIView *superView = view;
+  while (superView) {
+    if ([superView isHidden]) {
+      return YES;
+    }
+    superView = [superView superview];
+  }
+  return NO;
+}
+
+
++ (UIView *) findCommonAncestorForView:(UIView *) viewToCheck andView:(UIView *) otherView firstIndex:(NSInteger *) firstIndexPtr secondIndex:(NSInteger *) secondIndexPtr {
+  UIView *parent = [otherView superview];
+  NSInteger parentIndex = [[parent subviews] indexOfObject:otherView];
+  NSInteger viewToCheckIndex = [self indexOfView:viewToCheck
+                                 asSubViewInView:parent];
+  while (parent && (viewToCheckIndex == -1)) {
+    UIView *nextParent = [parent superview];
+    parentIndex = [[nextParent subviews] indexOfObject:parent];
+    parent = nextParent;
+    viewToCheckIndex = [self indexOfView:viewToCheck asSubViewInView:parent];
+  }
+  if (viewToCheckIndex && parent) {
+    *firstIndexPtr = viewToCheckIndex;
+    *secondIndexPtr = parentIndex;
+    return parent;
+  }
+  return nil;
+}
+
+
++ (BOOL) isView:(UIView *) viewToCheck zIndexAboveView:(UIView *) otherView {
+  NSInteger firstIndex = -1;
+  NSInteger secondIndex = -1;
+
+  UIView *commonAncestor = [self findCommonAncestorForView:viewToCheck
+                                                   andView:otherView
+                                                firstIndex:&firstIndex
+                                               secondIndex:&secondIndex];
+  if (!commonAncestor || firstIndex == -1 || secondIndex == -1) {return NO;}
+  return firstIndex > secondIndex;
+}
+
+
++ (BOOL) isViewVisible:(UIView *) view {
+  if (![view isKindOfClass:[UIView class]] || [self isViewOrParentsHidden:view]) {return NO;}
+  UIWindow *windowForView = [self windowForView:view];
+  if (!windowForView) {return YES;/* what can I do?*/}
+
+  CGPoint center = [self centerOfView:view inWindow:windowForView];
+
+  UIView *hitView = [windowForView hitTest:center withEvent:nil];
+  if ([self canFindView:view asSubViewInView:hitView]) {
+    return YES;
+  }
+  UIView *hitSuperView = hitView;
+
+  while (hitSuperView && hitSuperView != view) {
+    hitSuperView = [hitSuperView superview];
+  }
+  if (hitSuperView == view) {
+    return YES;
+  }
+
+  if (![view isKindOfClass:[UIControl class]]) {
+    //there may be a case with a non-control (e.g., label)
+    //on top of a control visually but not logically
+    UIWindow *viewWin = [self windowForView:view];
+    UIWindow *hitWin = [self windowForView:hitView];
+    if (viewWin == hitWin)//common window
     {
-        v = [v superview];
+
+      CGRect hitViewBounds = [viewWin convertRect:hitView.bounds
+                                         fromView:hitView];
+      CGRect viewBounds = [viewWin convertRect:view.bounds fromView:view];
+
+      if (CGRectContainsRect(hitViewBounds, viewBounds) && [self isView:hitView
+                                                        zIndexAboveView:view]) {
+        //In this case the hitView (which we're not asking about)
+        //is completely overlapping the view and "above" it in the container.
+        return NO;
+      }
+
+
+      CGRect ctrlRect = [viewWin convertRect:hitView.frame
+                                    fromView:hitView.superview];
+      return CGRectContainsPoint(ctrlRect, center);
     }
-    return v;
+  }
+  return NO;
 }
 
-+(NSInteger)indexOfView:(UIView *)viewToFind asSubViewInView:(UIView *)viewToSearch
-{
-    //Assume viewToFind != viewToSearch
-    if (viewToFind == nil || viewToSearch == nil) {return  -1;}
-    NSArray *subViews = [viewToSearch subviews];
-    for (NSInteger i=0;i<[subViews count];i++)
-    {
-        UIView *subView = [subViews objectAtIndex:i];
-        if ([self canFindView:viewToFind asSubViewInView:subView])
-        {
-            return i;
-        }
+
++ (CGPoint) centerOfFrame:(CGRect) frame shouldTranslate:(BOOL) shouldTranslate {
+  CGPoint translated = shouldTranslate ? [self translateToScreenCoords:frame.origin] : frame.origin;
+  return CGPointMake(translated.x + 0.5 * frame.size.width,
+          translated.y + 0.5 * frame.size.height);
+}
+
+
++ (CGPoint) centerOfFrame:(CGRect) frame {
+  return [self centerOfFrame:frame shouldTranslate:YES];
+}
+
+
++ (CGPoint) centerOfView:(UIView *) view shouldTranslate:(BOOL) shouldTranslate {
+
+  UIWindow *delegateWindow = [LPTouchUtils appDelegateWindow];
+  UIWindow *viewWindow = [self windowForView:view];
+  CGRect bounds = [viewWindow convertRect:view.bounds fromView:view];
+  bounds = [delegateWindow convertRect:bounds fromWindow:viewWindow];
+  return [self centerOfFrame:bounds shouldTranslate:shouldTranslate];
+}
+
+
++ (CGPoint) centerOfView:(UIView *) view inWindow:(UIWindow *) windowForView {
+  CGRect bounds = [windowForView convertRect:view.bounds fromView:view];
+  return [self centerOfFrame:bounds shouldTranslate:NO];
+}
+
+
++ (UIWindow *) appDelegateWindow {
+  UIWindow *delegateWindow = nil;
+  NSString *iosVersion = [UIDevice currentDevice].systemVersion;
+  id <UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
+
+  if ([[iosVersion substringToIndex:1]
+          isEqualToString:@"4"] || !([appDelegate respondsToSelector:@selector(window)])) {
+
+    if ([appDelegate respondsToSelector:@selector(window)]) {
+      delegateWindow = [appDelegate window];
     }
-    return -1;
-}
 
-+(BOOL)canFindView:(UIView *)viewToFind asSubViewInView:(UIView *)viewToSearch
-{
-    if (viewToFind == viewToSearch) { return YES; }
-    if (viewToFind == nil || viewToSearch == nil) {return  NO; }
-    NSInteger index = [self indexOfView:viewToFind asSubViewInView:viewToSearch];
-    return index != -1;    
-}
-
-+(BOOL)isViewOrParentsHidden:(UIView*)view
-{
-    if ([view alpha] <= 0.05) {
-        return YES;
+    if (!delegateWindow) {
+      NSArray *allWindows = [LPTouchUtils applicationWindows];
+      delegateWindow = [allWindows objectAtIndex:0];
     }
-    UIView* superView = view;
-    while (superView)
-    {
-        if ([superView isHidden]) {
-            return YES;
-        }
-        superView = [superView superview];
-    }
-    return NO;    
-}
-
-+(UIView*) findCommonAncestorForView:(UIView*)viewToCheck andView:(UIView*)otherView firstIndex:(NSInteger*)firstIndexPtr secondIndex:(NSInteger*)secondIndexPtr
-{
-    UIView *parent = [otherView superview];
-    NSInteger parentIndex = [[parent subviews] indexOfObject:otherView];
-    NSInteger viewToCheckIndex = [self indexOfView:viewToCheck asSubViewInView:parent];
-    while (parent && (viewToCheckIndex == -1))
-    {
-        UIView *nextParent = [parent superview];
-        parentIndex = [[nextParent subviews] indexOfObject:parent];
-        parent = nextParent;
-        viewToCheckIndex = [self indexOfView:viewToCheck asSubViewInView:parent];
-    }
-    if (viewToCheckIndex && parent)
-    {
-        *firstIndexPtr = viewToCheckIndex;
-        *secondIndexPtr = parentIndex;        
-        return parent;
-    }
-    return nil;
-}
-                                      
-                                      
-+(BOOL)isView:(UIView*)viewToCheck zIndexAboveView:(UIView*)otherView
-{
-    NSInteger firstIndex = -1;
-    NSInteger secondIndex = -1;
-    
-    UIView *commonAncestor = [self findCommonAncestorForView: viewToCheck andView:otherView firstIndex:&firstIndex secondIndex:&secondIndex];
-    if (!commonAncestor || firstIndex == -1 || secondIndex == -1) {return NO;}
-    return firstIndex > secondIndex;    
-}
-
-+(BOOL)isViewVisible:(UIView *)view
-{
-    if (![view isKindOfClass:[UIView class]] || [self isViewOrParentsHidden:view]) {return NO;}
-    UIWindow *windowForView = [self windowForView:view];
-    if (!windowForView) {return YES;/* what can I do?*/}
-
-    CGPoint center = [self centerOfView:view inWindow:windowForView];    
-
-    UIView *hitView = [windowForView hitTest:center withEvent:nil];
-    if ([self canFindView: view asSubViewInView:hitView])
-    {
-        return YES;
-    } 
-    UIView *hitSuperView = hitView;
-    
-    while (hitSuperView && hitSuperView != view)
-    {
-        hitSuperView = [hitSuperView superview];
-    }
-    if (hitSuperView == view)
-    {
-        return YES;
-    }
-    
-    
-    if (![view isKindOfClass:[UIControl class]])
-    {
-        //there may be a case with a non-control (e.g., label)
-        //on top of a control visually but not logically
-        UIWindow *viewWin = [self windowForView:view];
-        UIWindow *hitWin = [self windowForView:hitView];
-        if (viewWin == hitWin)//common window
-        {
-            
-            CGRect hitViewBounds = [viewWin convertRect:hitView.bounds fromView:hitView];
-            CGRect viewBounds = [viewWin convertRect:view.bounds fromView:view];
-            
-            if (CGRectContainsRect(hitViewBounds, viewBounds) && [self isView:hitView zIndexAboveView:view])
-            {
-                //In this case the hitView (which we're not asking about)
-                //is completely overlapping the view and "above" it in the container.
-                return NO;
-            }
-            
-                                    
-            CGRect ctrlRect = [viewWin convertRect:hitView.frame fromView:hitView.superview];            
-            return CGRectContainsPoint(ctrlRect, center);
-            //
-            
-        }
-    }
-    return NO;
-}
-
-+(CGPoint)centerOfFrame:(CGRect)frame shouldTranslate:(BOOL)shouldTranslate
-{
-    CGPoint translated =  shouldTranslate ? [self translateToScreenCoords:frame.origin] : frame.origin;
-    
-    
-    return CGPointMake(translated.x + 0.5 * frame.size.width,
-                       translated.y + 0.5 * frame.size.height);
+  } else {
+    delegateWindow = appDelegate.window;
+  }
+  return delegateWindow;
 }
 
 
-+(CGPoint)centerOfFrame:(CGRect)frame
-{
-    return [self centerOfFrame:frame shouldTranslate:YES];
++ (CGPoint) centerOfView:(UIView *) view {
+  return [self centerOfView:view shouldTranslate:YES];
 }
 
-+(CGPoint)centerOfView:(UIView *)view shouldTranslate:(BOOL)shouldTranslate
-{
- 
-    UIWindow *delegateWindow = [LPTouchUtils appDelegateWindow];
-    UIWindow *viewWindow = [self windowForView:view];
-    CGRect bounds = [viewWindow convertRect:view.bounds fromView:view];
-    bounds = [delegateWindow convertRect:bounds fromWindow:viewWindow];
-    return [self centerOfFrame:bounds shouldTranslate:shouldTranslate];
-}
 
-+(CGPoint)centerOfView:(UIView*)view inWindow:(UIWindow*)windowForView
-{
-    CGRect bounds = [windowForView convertRect:view.bounds fromView:view];
-    return [self centerOfFrame:bounds shouldTranslate:NO];
-}
++ (CGPoint) centerOfView:(id) view withSuperView:(UIView *) superView inWindow:(id) window {
 
-+(UIWindow*)appDelegateWindow
-{
-    UIWindow *delegateWindow = nil;
-    NSString *iosVersion = [UIDevice currentDevice].systemVersion;
-    id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
-    
-    if ([[iosVersion substringToIndex:1] isEqualToString:@"4"] || !([appDelegate respondsToSelector:@selector(window)]))
-    {
-        
-        if ([appDelegate respondsToSelector:@selector(window)]) {
-            delegateWindow = [appDelegate window];
-        }
-        
-        if (!delegateWindow)
-        {
-            NSArray *allWindows = [LPTouchUtils applicationWindows];
-            delegateWindow = [allWindows objectAtIndex:0];
-        }
-    }
-    else
-    {
-        delegateWindow = appDelegate.window;
-    }
-    return delegateWindow;
+  CGRect frameInWindow = [window convertRect:[view frame] fromView:superView];
+  return [self centerOfFrame:frameInWindow shouldTranslate:YES];
 }
-
-+(CGPoint) centerOfView:(UIView *) view 
-{
-    return [self centerOfView:view shouldTranslate:YES];
-}
-+(CGPoint) centerOfView:(id)view 
-          withSuperView:(UIView *)superView
-               inWindow:(id)window
-{
-        
-        CGRect frameInWindow = [window convertRect:[view frame] fromView:superView];
-    return [self centerOfFrame:frameInWindow shouldTranslate:YES];
-}
-
 
 //  Created by Olivier Larivain on 3/6/13.
 //  Copyright (c) 2013 LessPainful. All rights reserved.
@@ -319,35 +299,30 @@
 //      refactor from category method
 //
 
-+(void)flashView:(id) viewOrDom forDuration:(NSUInteger) duration
-{
-    if ([viewOrDom isKindOfClass: [UIView class]])
-    {
-        UIView *view = (UIView*) viewOrDom;
-        
-        UIColor *originalBackgroundColor = [view.backgroundColor retain];
-        CGFloat orginalAlpha = view.alpha;
-        for (NSUInteger i = 0; i < 5; i++) {
-            view.backgroundColor = [UIColor yellowColor];
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
-            view.alpha = 0;
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
-            
-            view.backgroundColor = [UIColor blueColor];
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
-            
-            view.alpha = 1;
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
-        }
-        view.alpha = orginalAlpha;
-        view.backgroundColor = originalBackgroundColor;
-        [originalBackgroundColor release];
-    }
-    else
-    {
-        //TODO implement flash in JavaScript
-    }
++ (void) flashView:(id) viewOrDom forDuration:(NSUInteger) duration {
+  if ([viewOrDom isKindOfClass:[UIView class]]) {
+    UIView *view = (UIView *) viewOrDom;
 
+    UIColor *originalBackgroundColor = [view.backgroundColor retain];
+    CGFloat originalAlpha = view.alpha;
+    for (NSUInteger i = 0; i < 5; i++) {
+      view.backgroundColor = [UIColor yellowColor];
+      CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
+      view.alpha = 0;
+      CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
+
+      view.backgroundColor = [UIColor blueColor];
+      CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
+
+      view.alpha = 1;
+      CFRunLoopRunInMode(kCFRunLoopDefaultMode, .05, false);
+    }
+    view.alpha = originalAlpha;
+    view.backgroundColor = originalBackgroundColor;
+    [originalBackgroundColor release];
+  } else {
+    //TODO implement flash in JavaScript
+  }
 }
 
 @end

--- a/calabash/Classes/Utils/LPUIAChannel.h
+++ b/calabash/Classes/Utils/LPUIAChannel.h
@@ -9,12 +9,12 @@
 
 @interface LPUIAChannel : NSObject
 
-+ (LPUIAChannel *)sharedChannel;
++ (LPUIAChannel *) sharedChannel;
 
-+(void)runAutomationCommand:(NSString*)command
-                       then:(void(^)(NSDictionary *result))resultHandler;
++ (void) runAutomationCommand:(NSString *) command then:(void (^)(
+        NSDictionary *result)) resultHandler;
 
--(void)runAutomationCommand:(NSString*)command
-                       then:(void(^)(NSDictionary *result))resultHandler;
+- (void) runAutomationCommand:(NSString *) command then:(void (^)(
+        NSDictionary *result)) resultHandler;
 
 @end

--- a/calabash/Classes/Utils/LPUIAChannel.m
+++ b/calabash/Classes/Utils/LPUIAChannel.m
@@ -26,107 +26,112 @@
 //  by Karl Krukow <karl.krukow@xamarin.com>
 
 #import "LPUIAChannel.h"
+
 #define MAX_LOOP_COUNT 1200
 
-const static NSString *LPUIAChannelUIAPrefsRequestKey               = @"__calabashRequest";
-const static NSString *LPUIAChannelUIAPrefsResponseKey              = @"__calabashResponse";
-const static NSString *LPUIAChannelUIAPrefsIndexKey                 = @"index";
-const static NSString *LPUIAChannelUIAPrefsCommandKey               = @"command";
-const static NSTimeInterval LPUIAChannelUIADelay                    = 0.1;
+const static NSString *LPUIAChannelUIAPrefsRequestKey = @"__calabashRequest";
+const static NSString *LPUIAChannelUIAPrefsResponseKey = @"__calabashResponse";
+const static NSString *LPUIAChannelUIAPrefsIndexKey = @"index";
+const static NSString *LPUIAChannelUIAPrefsCommandKey = @"command";
+const static NSTimeInterval LPUIAChannelUIADelay = 0.1;
 
-    
 @implementation LPUIAChannel {
-    dispatch_queue_t _uiaQueue;
-    NSUInteger _scriptIndex;
-    BOOL _scriptLoggingEnabled;
+  dispatch_queue_t _uiaQueue;
+  NSUInteger _scriptIndex;
+  BOOL _scriptLoggingEnabled;
 }
 
-+(LPUIAChannel *)sharedChannel {
-    static LPUIAChannel *sharedChannel = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedChannel = [[LPUIAChannel alloc] init];
-    });
-    return sharedChannel;
-}
-
--(id)init {
-    self = [super init];
-    if (self) {
-        _uiaQueue = dispatch_queue_create("calabash.uia_queue", DISPATCH_QUEUE_SERIAL);
-    }
-    return self;
-}
-
--(void)dealloc {
-    [super dealloc];
-    dispatch_release(_uiaQueue);
++ (LPUIAChannel *) sharedChannel {
+  static LPUIAChannel *sharedChannel = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedChannel = [[LPUIAChannel alloc] init];
+  });
+  return sharedChannel;
 }
 
 
-
-+(void)runAutomationCommand:(NSString*)command
-                       then:(void(^)(NSDictionary *result))resultHandler {
-    
-    [[LPUIAChannel sharedChannel] runAutomationCommand:command
-                                                  then:resultHandler];
+- (id) init {
+  self = [super init];
+  if (self) {
+    _uiaQueue = dispatch_queue_create(
+            "calabash.uia_queue", DISPATCH_QUEUE_SERIAL);
+  }
+  return self;
 }
 
--(void)runAutomationCommand:(NSString*)command
-                       then:(void(^)(NSDictionary *))resultHandler {
-    
-    dispatch_async(_uiaQueue, ^{
-        [self requestExecutionOf:command];
-        
-        NSDictionary *result = nil;
-        NSUInteger loopCount = 0;
-        while (1) {//Loop waiting for response
-            NSDictionary *resultPrefs = [self userPreferences];
-            NSDictionary *currentResponse = [resultPrefs objectForKey: LPUIAChannelUIAPrefsResponseKey];
-            
-            if (currentResponse) {
-                NSUInteger responseIndex = [(NSNumber*)[currentResponse objectForKey: LPUIAChannelUIAPrefsIndexKey ]
-                                                        unsignedIntegerValue];
-                if (responseIndex == _scriptIndex) {
-                    result = currentResponse;
-                    break;
-                }
-            }
-            [NSThread sleepForTimeInterval: LPUIAChannelUIADelay];
-            loopCount++;
-            if (loopCount >= MAX_LOOP_COUNT) {
-                result = nil;
-                break;
-            }
+
+// todo LPUIAChannel.m [super dealloc] should be called _last_
+- (void) dealloc {
+  [super dealloc];
+  dispatch_release(_uiaQueue);
+}
+
+
++ (void) runAutomationCommand:(NSString *) command then:(void (^)(
+        NSDictionary *result)) resultHandler {
+
+  [[LPUIAChannel sharedChannel]
+          runAutomationCommand:command then:resultHandler];
+}
+
+
+- (void) runAutomationCommand:(NSString *) command then:(void (^)(
+        NSDictionary *)) resultHandler {
+
+  dispatch_async(_uiaQueue, ^{
+    [self requestExecutionOf:command];
+
+    NSDictionary *result = nil;
+    NSUInteger loopCount = 0;
+    while (1) {//Loop waiting for response
+      NSDictionary *resultPrefs = [self userPreferences];
+      NSDictionary *currentResponse = [resultPrefs objectForKey:LPUIAChannelUIAPrefsResponseKey];
+
+      if (currentResponse) {
+        NSUInteger responseIndex = [(NSNumber *) [currentResponse objectForKey:LPUIAChannelUIAPrefsIndexKey] unsignedIntegerValue];
+        if (responseIndex == _scriptIndex) {
+          result = currentResponse;
+          break;
         }
-        _scriptIndex++;
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            resultHandler(result);
-        });
-        
+      }
+      [NSThread sleepForTimeInterval:LPUIAChannelUIADelay];
+      loopCount++;
+      if (loopCount >= MAX_LOOP_COUNT) {
+        result = nil;
+        break;
+      }
+    }
+    _scriptIndex++;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      resultHandler(result);
     });
+  });
 }
 
--(void)requestExecutionOf:(NSString *)command {
+
+- (void) requestExecutionOf:(NSString *) command {
 #if TARGET_IPHONE_SIMULATOR
     [self simulatorRequestExecutionOf:command];
 #else
-    [self deviceRequestExecutionOf:command];
+  [self deviceRequestExecutionOf:command];
 #endif
 }
 
--(NSDictionary *)userPreferences {
-    NSDictionary *prefs = nil;
+
+- (NSDictionary *) userPreferences {
+  NSDictionary *prefs = nil;
 #if TARGET_IPHONE_SIMULATOR
     prefs = [NSDictionary dictionaryWithContentsOfFile:[self simulatorPreferencesPath]];
 #else
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults synchronize];
-    prefs = [defaults dictionaryRepresentation];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults synchronize];
+  prefs = [defaults dictionaryRepresentation];
 #endif
-    return prefs;
+  return prefs;
 }
+
 
 #if TARGET_IPHONE_SIMULATOR
 -(void)simulatorRequestExecutionOf:(NSString *)command {
@@ -135,28 +140,27 @@ const static NSTimeInterval LPUIAChannelUIADelay                    = 0.1;
         prefs = [NSMutableDictionary dictionary];
     }
     NSDictionary *uiaRequest   = [self requestForCommand:command];
-    
+
     [prefs setObject:uiaRequest forKey:LPUIAChannelUIAPrefsRequestKey];
     [prefs writeToFile:[self simulatorPreferencesPath] atomically:YES];
-
-    
-    
 }
 #endif // TARGET_IPHONE_SIMULATOR
 
--(void)deviceRequestExecutionOf:(NSString*)command {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSDictionary *uiaRequest   = [self requestForCommand:command];
-    
-    [defaults setObject:uiaRequest forKey:(NSString*)LPUIAChannelUIAPrefsRequestKey];
-    [defaults synchronize];
+
+- (void) deviceRequestExecutionOf:(NSString *) command {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  NSDictionary *uiaRequest = [self requestForCommand:command];
+
+  [defaults setObject:uiaRequest
+               forKey:(NSString *) LPUIAChannelUIAPrefsRequestKey];
+  [defaults synchronize];
 }
 
--(NSDictionary*)requestForCommand:(NSString*)command {
-    return [NSDictionary dictionaryWithObjectsAndKeys:
-                @(_scriptIndex), LPUIAChannelUIAPrefsIndexKey,
-                command, LPUIAChannelUIAPrefsCommandKey,
-            nil];
+
+- (NSDictionary *) requestForCommand:(NSString *) command {
+  return [NSDictionary dictionaryWithObjectsAndKeys:@(_scriptIndex), LPUIAChannelUIAPrefsIndexKey,
+                                                    command, LPUIAChannelUIAPrefsCommandKey,
+                                                    nil];
 }
 
 #pragma mark - Communication
@@ -171,15 +175,15 @@ const static NSTimeInterval LPUIAChannelUIADelay                    = 0.1;
     dispatch_once(&onceToken, ^{
         NSString *plistRootPath = nil, *relativePlistPath = nil;
         NSString *plistName = [NSString stringWithFormat:@"%@.plist", [[NSBundle mainBundle] bundleIdentifier]];
-        
+
         // 1. get into the simulator's app support directory by fetching the sandboxed Library's path
         NSString *userDirectoryPath = [[[[NSFileManager defaultManager] URLsForDirectory:NSLibraryDirectory inDomains:NSUserDomainMask] lastObject] path];
         // 2. get out of our application directory, back to the root support directory for this system version
         plistRootPath = [userDirectoryPath substringToIndex:([userDirectoryPath rangeOfString:@"Applications"].location)];
-        
+
         // 3. locate, relative to here, /Library/Preferences/[bundle ID].plist
         relativePlistPath = [NSString stringWithFormat:@"Library/Preferences/%@", plistName];
-        
+
         // 4. and unescape spaces, if necessary (i.e. in the simulator)
         NSString *unsanitizedPlistPath = [plistRootPath stringByAppendingPathComponent:relativePlistPath];
         path = [[unsanitizedPlistPath stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding] copy];

--- a/calabash/Classes/Utils/UIAutomation.h
+++ b/calabash/Classes/Utils/UIAutomation.h
@@ -9,1054 +9,1014 @@
 
 
 @protocol UIAXElement
-+ (id)uiaxElementAtPosition:(struct CGPoint)arg1;
-+ (id)uiaxSystemWideElement;
-+ (id)uiaxFocusedApplicationElement;
-+ (id)stringForAXError:(long)arg1;
-+ (id)stringForAXNotification:(int)arg1;
-+ (id)stringForTraits:(unsigned long long)arg1;
-- (struct __AXUIElement *)axuiElementRef;
-- (id)valueForAttribute:(int)arg1;
-- (BOOL)setValue:(id)arg1 forAttribute:(int)arg2;
-- (id)valuesForAttributes:(id)arg1;
-- (id)valueForAttribute:(int)arg1 parameter:(id)arg2;
-- (BOOL)performAXAction:(int)arg1;
-- (BOOL)performAXAction:(int)arg1 withValue:(id)arg2;
-- (int)pid;
-- (long)axError;
-- (BOOL)isValid;
-- (BOOL)checkIsValid;
-- (id)valuesForAllKnownAttributes;
-- (id)stringForAttributes:(id)arg1;
-- (id)stringForAllKnownAttributes;
-- (id)traitsNumber;
-- (unsigned long long)traits;
-- (id)rect;
-- (id)centerPoint;
-- (id)description;
-- (id)firstElementOfAttribute:(int)arg1 withValue:(id)arg2 forAttribute:(int)arg3;
-- (id)parent;
-- (id)children;
-- (id)childWithTestingTrait:(id)arg1;
-- (id)ancestry;
++ (id) uiaxElementAtPosition:(struct CGPoint) arg1;
++ (id) uiaxSystemWideElement;
++ (id) uiaxFocusedApplicationElement;
++ (id) stringForAXError:(long) arg1;
++ (id) stringForAXNotification:(int) arg1;
++ (id) stringForTraits:(unsigned long long) arg1;
+- (struct __AXUIElement *) axuiElementRef;
+- (id) valueForAttribute:(int) arg1;
+- (BOOL) setValue:(id) arg1 forAttribute:(int) arg2;
+- (id) valuesForAttributes:(id) arg1;
+- (id) valueForAttribute:(int) arg1 parameter:(id) arg2;
+- (BOOL) performAXAction:(int) arg1;
+- (BOOL) performAXAction:(int) arg1 withValue:(id) arg2;
+- (int) pid;
+- (long) axError;
+- (BOOL) isValid;
+- (BOOL) checkIsValid;
+- (id) valuesForAllKnownAttributes;
+- (id) stringForAttributes:(id) arg1;
+- (id) stringForAllKnownAttributes;
+- (id) traitsNumber;
+- (unsigned long long) traits;
+- (id) rect;
+- (id) centerPoint;
+- (id) description;
+- (id) firstElementOfAttribute:(int) arg1 withValue:(id) arg2 forAttribute:(int) arg3;
+- (id) parent;
+- (id) children;
+- (id) childWithTestingTrait:(id) arg1;
+- (id) ancestry;
 @end
 
-@interface UIAXElement : NSObject <UIAXElement>
-{
-    struct __AXUIElement *_axuiElementRef;
-    double _creationTime;
-    double _lastAccessedTime;
-    BOOL _isValid;
-    int _axError;
+@interface UIAXElement : NSObject <UIAXElement> {
+  struct __AXUIElement *_axuiElementRef;
+  double _creationTime;
+  double _lastAccessedTime;
+  BOOL _isValid;
+  int _axError;
 }
 
-+ (void)initialize;
-+ (void)_raiseAXErrorAPIDisabled;
-+ (void)_raiseIfAXErrorAPIDisabled:(long)arg1;
-+ (id)uiaxElementWithAXUIElementRef:(struct __AXUIElement *)arg1;
-+ (id)_regularAttributeNumbers;
-+ (id)_regularAttributeStrings;
-+ (id)_parameterizedAttributeNumbers;
-+ (id)_parameterizedAttributeStrings;
-+ (id)_traitNumbers;
-+ (id)_traitStrings;
-+ (id)_stringsForRegularAttributesDictionary;
-+ (id)_regularAttributesForStringsDictionary;
-+ (id)_stringsForParameterizedAttributesDictionary;
-+ (id)_parameterizedAttributesForStringsDictionary;
-+ (id)_stringsForTraitsDictionary;
-+ (id)_stringForAttribute:(int)arg1;
-+ (int)_attributeForString:(id)arg1;
-+ (id)_stringForParameterizedAttribute:(int)arg1;
-+ (int)_parameterizedAttributeForString:(id)arg1;
-+ (id)_objectForCFTypeRef:(void *)arg1;
-+ (id)uiaxElementAtPosition:(struct CGPoint)arg1;
-+ (id)uiaxSystemWideElement;
-+ (id)uiaxFocusedApplicationElement;
-+ (id)stringForAXError:(long)arg1;
-+ (id)stringForAXNotification:(int)arg1;
-+ (id)stringForTraits:(unsigned long long)arg1;
-- (void)_invalidate;
-- (void)_setValidForAXError:(long)arg1;
-- (id)_initWithAXUIElementRef:(struct __AXUIElement *)arg1;
-- (double)_creationTime;
-- (double)_lastAccessedTime;
-- (void)_setLastAccessedTime:(double)arg1;
-- (void)dealloc;
-- (void)finalize;
-- (BOOL)isEqual:(id)arg1;
-- (unsigned int)hash;
-- (struct __AXUIElement *)axuiElementRef;
-- (id)valueForAttribute:(int)arg1;
-- (BOOL)setValue:(id)arg1 forAttribute:(int)arg2;
-- (id)valuesForAttributes:(id)arg1;
-- (id)valueForAttribute:(int)arg1 parameter:(id)arg2;
-- (id)valueForKey:(id)arg1;
-- (id)valueForUndefinedKey:(id)arg1;
-- (BOOL)performAXAction:(int)arg1;
-- (BOOL)performAXAction:(int)arg1 withValue:(id)arg2;
-- (int)pid;
-- (long)axError;
-- (BOOL)isValid;
-- (BOOL)checkIsValid;
-- (id)valuesForAllKnownAttributes;
-- (id)stringForAttributes:(id)arg1;
-- (id)stringForAllKnownAttributes;
-- (id)_copyTraitsNumber;
-- (id)traitsNumber;
-- (unsigned long long)traits;
-- (id)description;
-- (id)rect;
-- (id)centerPoint;
-- (id)uiaxElementAtCenterPoint;
-- (id)firstElementOfAttribute:(int)arg1 withValue:(id)arg2 forAttribute:(int)arg3;
-- (id)parent;
-- (id)children;
-- (id)childWithTestingTrait:(id)arg1;
-- (id)ancestry;
-- (BOOL)_hasNonzeroSize;
-- (void)logAXInfo;
-- (void)logAXAncestry;
-- (void)logAXTree;
-
-@end
-
-@interface UIAElement : NSObject <NSCopying>
-{
-    UIAXElement *_uiaxElement;
-    UIAElement *_parentElement;
-    NSInvocation *_selfPatienceInvocation;
-    double _createdTime;
-    double _lastAccessedTime;
-    BOOL _isValid;
-    NSDictionary *_elementClassIndexSets;
-}
-
-+ (void)initialize;
-+ (BOOL)_delayForTimeInterval:(double)arg1;
-+ (void)_logVerbosity:(unsigned int)arg1 format:(id)arg2;
-+ (int)_liveCount;
-+ (int)_maxCount;
-+ (id)_countsString;
-+ (id)_elementWithUIAXElement:(id)arg1 parent:(id)arg2;
-+ (id)attributeKeys;
-+ (id)toOneRelationshipKeys;
-+ (id)toManyRelationshipKeys;
-+ (id)allKeys;
-+ (struct CGAffineTransform)_transformToRotateFromInterfaceOrientation:(int)arg1;
-+ (struct CGAffineTransform)_transformToRotateToInterfaceOrientation:(int)arg1;
-+ (struct CGRect)_convertRectToCurrentInterfaceOrientation:(struct CGRect)arg1;
-+ (struct CGRect)_convertRectFromCurrentInterfaceOrientation:(struct CGRect)arg1;
-+ (struct CGPoint)_convertPointFromCurrentInterfaceOrientation:(struct CGPoint)arg1;
-+ (struct CGPoint)_convertPointToCurrentInterfaceOrientation:(struct CGPoint)arg1;
-+ (id)_nameForAXElement:(id)arg1;
-+ (id)_valueForAXElement:(id)arg1;
-+ (id)_hitPointFromDictionary:(id)arg1;
-+ (id)_hitPointForObject:(id)arg1;
-+ (id)_rectFromDictionary:(id)arg1;
-+ (double)_patienceRetryInterval;
-+ (void)_setPatienceRetryInterval:(double)arg1;
-+ (double)patience;
-+ (void)setPatience:(double)arg1;
-+ (void)pushPatience:(double)arg1;
-+ (double)popPatience;
-+ (id)_invocationForInvoker:(id)arg1 selector:(SEL)arg2 arguments:(void *)arg3;
-+ (id)_patienceInvocationPathForUIAObject:(id)arg1;
-+ (id)_performInvocationPath:(id)arg1;
-+ (id)_waitForInvocationPath:(id)arg1;
-+ (id)_setPatienceInvocation:(id)arg1 forUIAObject:(id)arg2;
-+ (id)_jsMethodNameForSelector:(SEL)arg1;
-+ (id)_jsEscapedStringForString:(id)arg1;
-+ (id)_jsStringForString:(id)arg1;
-+ (id)_jsStringForDictionary:(id)arg1;
-+ (id)_jsStringForObject:(id)arg1;
-+ (id)_jsStringForRect:(struct CGRect)arg1;
-+ (id)_jsStringForInvocation:(id)arg1;
-+ (id)_jsMethodCallStringForInvoker:(id)arg1 selector:(SEL)arg2;
-+ (id)_jsStringForInvocationPath:(id)arg1;
-+ (id)_jsStringForUIAElement:(id)arg1;
-+ (Class)_uiaClassForClass:(Class)arg1;
-+ (Class)_classForSimpleUIAXElement:(id)arg1;
-+ (id)elementForUIAXElement:(id)arg1;
-+ (id)elementAtPosition:(struct CGPoint)arg1;
-+ (id)_predicateForPredicateOrString:(id)arg1;
-- (id)init;
-- (id)_initWithUIAXElement:(id)arg1 parent:(id)arg2;
-- (void)dealloc;
-- (void)_emptyCaches;
-- (void)_invalidate;
-- (BOOL)isEqual:(id)arg1;
-- (unsigned int)hash;
-- (id)description;
-- (id)copyWithZone:(struct _NSZone *)arg1;
-- (double)_createdTime;
-- (double)_lastAccessedTime;
-- (void)_setLastAccessedTime:(double)arg1;
-- (BOOL)isValid;
-- (BOOL)checkIsValid;
-- (BOOL)waitForInvalid;
-- (id)attributeKeys;
-- (id)toOneRelationshipKeys;
-- (id)toManyRelationshipKeys;
-- (id)allKeys;
-- (id)_synonymToManyRelationshipKeys;
-- (id)valueForUndefinedKey:(id)arg1;
-- (id)attributes;
-- (id)toOneRelationships;
-- (id)toManyRelationships;
-- (id)uiaxElement;
-- (id)parentElement;
-- (id)ancestry;
-- (id)_logInfo;
-- (id)_logInfoWithChildren;
-- (void)logElement;
-- (void)logElementTree;
-- (void)logAXInfo;
-- (void)logAXTree;
-- (id)pid;
-- (id)hint;
-- (id)label;
-- (id)rect;
-- (id)_uiaRect;
-- (id)_tryHitpoint:(struct CGPoint)arg1;
-- (id)_hitpoint;
-- (id)hitpoint;
-- (id)_uiaHitpoint;
-- (id)isEnabled;
-- (id)hasKeyboardFocus;
-- (id)isVisible;
-- (id)target;
-- (id)name;
-- (id)value;
-- (BOOL)_shouldAllowSettingValue;
-- (void)setValue:(id)arg1;
-- (id)url;
-- (id)dom;
-- (id)className;
-- (id)type;
-- (void)undo;
-- (void)redo;
-- (void)_delayForAnimationsInProgress;
-- (void)_prepareForAction:(SEL)arg1;
-- (void)tap;
-- (void)doubleTap;
-- (void)twoFingerTap;
-- (void)tapWithOptions:(id)arg1;
-- (void)touchAndHold:(id)arg1;
-- (void)_dragInsideWithOptions:(id)arg1 withFlick:(BOOL)arg2;
-- (void)dragInsideWithOptions:(id)arg1;
-- (void)flickInsideWithOptions:(id)arg1;
-- (void)_rotateWithOptions:(id)arg1;
-- (void)rotateWithOptions:(id)arg1;
-- (void)activate;
-- (void)scrollUp;
-- (void)scrollDown;
-- (void)scrollLeft;
-- (void)scrollRight;
-- (id)scrollToVisible;
-- (id)scrollToElementWithName:(id)arg1;
-- (id)scrollToElementWithPredicate:(id)arg1;
-- (id)scrollToElementWithValue:(id)arg1 forKey:(id)arg2;
-- (id)_selfPatienceInvocation;
-- (void)_setSelfPatienceInvocation:(id)arg1;
-- (void)chopPatience;
-- (id)_objectWithPatienceInvocationFromUIAObject:(id)arg1 selector:(SEL)arg2;
-- (id)_patienceForAttribute:(SEL)arg1 value:(id)arg2;
-- (id)scriptingActionExpressionShouldFavorTapOffset;
-- (id)scriptingInvocationString;
-- (id)scriptingInvocationFullExpressionString;
-- (id)_scriptingSynonymsForSubElement:(id)arg1 maxCount:(unsigned int)arg2;
-- (id)scriptingFavoredSynonymString;
-- (id)scriptingSynonymStrings;
-- (id)scriptingSynonymFullExpressionString;
-- (id)_elementForSimpleUIAXElement:(id)arg1;
-- (id)_elementsForUIAXElements:(id)arg1 axFilter:(SEL)arg2;
-- (id)_elementsForUIAXElements:(id)arg1;
-- (BOOL)_inspectConfirmElement:(id)arg1 forAXAncestry:(id)arg2 index:(unsigned int *)arg3;
-- (id)_inspectedToOneRelationship:(id)arg1 forAXAncestry:(id)arg2 index:(unsigned int *)arg3;
-- (id)_inspectedToManyRelationship:(id)arg1 forAXAncestry:(id)arg2 index:(unsigned int *)arg3;
-- (id)_inspectedElementForAXAncestry:(id)arg1 index:(unsigned int *)arg2 triedKeys:(id)arg3;
-- (id)_elementForUIAXElement:(id)arg1;
-- (id)_elementAtPosition:(struct CGPoint)arg1;
-- (id)elementAtPoint:(id)arg1;
-- (id)withName:(id)arg1;
-- (id)withValue:(id)arg1 forKey:(id)arg2;
-- (id)withPredicate:(id)arg1;
-- (id)elements;
-- (id)_elementsOfClass:(Class)arg1 forSelector:(SEL)arg2;
-- (id)actionSheets;
-- (id)actionSheet;
-- (id)activityIndicators;
-- (id)buttons;
-- (id)editingMenus;
-- (id)images;
-- (id)keyboards;
-- (id)keyboard;
-- (id)keys;
-- (id)links;
-- (id)navigationBars;
-- (id)navigationBar;
-- (id)pageIndicators;
-- (id)pickers;
-- (id)popovers;
-- (id)popover;
-- (id)progressIndicators;
-- (id)scrollViews;
-- (id)segmentedControls;
-- (id)sliders;
-- (id)switches;
-- (id)staticTexts;
-- (id)tableViews;
-- (id)textFields;
-- (id)secureTextFields;
-- (id)searchBars;
-- (id)tabBars;
-- (id)tabBar;
-- (id)toolbars;
-- (id)toolbar;
-- (id)textViews;
-- (id)webViews;
++ (void) initialize;
++ (void) _raiseAXErrorAPIDisabled;
++ (void) _raiseIfAXErrorAPIDisabled:(long) arg1;
++ (id) uiaxElementWithAXUIElementRef:(struct __AXUIElement *) arg1;
++ (id) _regularAttributeNumbers;
++ (id) _regularAttributeStrings;
++ (id) _parameterizedAttributeNumbers;
++ (id) _parameterizedAttributeStrings;
++ (id) _traitNumbers;
++ (id) _traitStrings;
++ (id) _stringsForRegularAttributesDictionary;
++ (id) _regularAttributesForStringsDictionary;
++ (id) _stringsForParameterizedAttributesDictionary;
++ (id) _parameterizedAttributesForStringsDictionary;
++ (id) _stringsForTraitsDictionary;
++ (id) _stringForAttribute:(int) arg1;
++ (int) _attributeForString:(id) arg1;
++ (id) _stringForParameterizedAttribute:(int) arg1;
++ (int) _parameterizedAttributeForString:(id) arg1;
++ (id) _objectForCFTypeRef:(void *) arg1;
++ (id) uiaxElementAtPosition:(struct CGPoint) arg1;
++ (id) uiaxSystemWideElement;
++ (id) uiaxFocusedApplicationElement;
++ (id) stringForAXError:(long) arg1;
++ (id) stringForAXNotification:(int) arg1;
++ (id) stringForTraits:(unsigned long long) arg1;
+- (void) _invalidate;
+- (void) _setValidForAXError:(long) arg1;
+- (id) _initWithAXUIElementRef:(struct __AXUIElement *) arg1;
+- (double) _creationTime;
+- (double) _lastAccessedTime;
+- (void) _setLastAccessedTime:(double) arg1;
+- (void) dealloc;
+- (void) finalize;
+- (BOOL) isEqual:(id) arg1;
+- (unsigned int) hash;
+- (struct __AXUIElement *) axuiElementRef;
+- (id) valueForAttribute:(int) arg1;
+- (BOOL) setValue:(id) arg1 forAttribute:(int) arg2;
+- (id) valuesForAttributes:(id) arg1;
+- (id) valueForAttribute:(int) arg1 parameter:(id) arg2;
+- (id) valueForKey:(id) arg1;
+- (id) valueForUndefinedKey:(id) arg1;
+- (BOOL) performAXAction:(int) arg1;
+- (BOOL) performAXAction:(int) arg1 withValue:(id) arg2;
+- (int) pid;
+- (long) axError;
+- (BOOL) isValid;
+- (BOOL) checkIsValid;
+- (id) valuesForAllKnownAttributes;
+- (id) stringForAttributes:(id) arg1;
+- (id) stringForAllKnownAttributes;
+- (id) _copyTraitsNumber;
+- (id) traitsNumber;
+- (unsigned long long) traits;
+- (id) description;
+- (id) rect;
+- (id) centerPoint;
+- (id) uiaxElementAtCenterPoint;
+- (id) firstElementOfAttribute:(int) arg1 withValue:(id) arg2 forAttribute:(int) arg3;
+- (id) parent;
+- (id) children;
+- (id) childWithTestingTrait:(id) arg1;
+- (id) ancestry;
+- (BOOL) _hasNonzeroSize;
+- (void) logAXInfo;
+- (void) logAXAncestry;
+- (void) logAXTree;
 
 @end
 
-@interface UIAElementArray : NSArray
-{
-    NSArray *_array;
-    NSInvocation *_selfPatienceInvocation;
-    double _refreshedTime;
-    double _lastAccessedTime;
+@interface UIAElement : NSObject <NSCopying> {
+  UIAXElement *_uiaxElement;
+  UIAElement *_parentElement;
+  NSInvocation *_selfPatienceInvocation;
+  double _createdTime;
+  double _lastAccessedTime;
+  BOOL _isValid;
+  NSDictionary *_elementClassIndexSets;
 }
 
-+ (void)initialize;
-+ (int)_liveCount;
-+ (int)_maxCount;
-+ (id)_arrayWithArray:(id)arg1;
-+ (id)_cachedArrayAtPtr:(const id *)arg1;
-+ (void)_cacheArray:(id)arg1 atPtr:(const id *)arg2;
-+ (void)_removeCachedArrayAtPtr:(const id *)arg1;
-- (id)_initWithArray:(id)arg1;
-- (void)dealloc;
-- (unsigned int)count;
-- (id)objectAtIndex:(unsigned int)arg1;
-- (BOOL)isEqualToArray:(id)arg1;
-- (BOOL)isEqual:(id)arg1;
-- (unsigned int)hash;
-- (id)description;
-- (id)_selfPatienceInvocation;
-- (void)_setSelfPatienceInvocation:(id)arg1;
-- (id)_objectWithPatienceInvocationFromUIAObject:(id)arg1 selector:(SEL)arg2;
-- (id)nsArray;
-- (void)_setArray:(id)arg1;
-- (double)_refreshedTime;
-- (double)_lastAccessedTime;
-- (void)_setLastAccessedTime:(double)arg1;
-- (BOOL)_isStillFreshAtTime:(double)arg1;
-- (id)_withClass:(Class)arg1;
-- (id)_withName:(id)arg1;
-- (id)_withValue:(id)arg1 forKey:(id)arg2;
-- (id)_withPredicate:(id)arg1;
-- (id)withClass:(Class)arg1;
-- (id)withName:(id)arg1;
-- (id)withValue:(id)arg1 forKey:(id)arg2;
-- (id)withPredicate:(id)arg1;
-- (id)firstWithName:(id)arg1;
-- (id)firstWithValue:(id)arg1 forKey:(id)arg2;
-- (id)firstWithPredicate:(id)arg1;
-- (void)logElements;
-- (void)logElementTrees;
-- (id)elementOfClass:(Class)arg1 atIndex:(unsigned int)arg2;
-- (id)_scriptingIndexSynonymsForElement:(id)arg1 maxCount:(unsigned int)arg2;
-- (id)scriptingFavoredIndexSynonymForElement:(id)arg1;
-- (id)scriptingIndexSynonymsForElement:(id)arg1;
-- (id)scriptingInvocationString;
-- (id)scriptingInvocationFullExpressionString;
-- (BOOL)isValid;
++ (void) initialize;
++ (BOOL) _delayForTimeInterval:(double) arg1;
++ (void) _logVerbosity:(unsigned int) arg1 format:(id) arg2;
++ (int) _liveCount;
++ (int) _maxCount;
++ (id) _countsString;
++ (id) _elementWithUIAXElement:(id) arg1 parent:(id) arg2;
++ (id) attributeKeys;
++ (id) toOneRelationshipKeys;
++ (id) toManyRelationshipKeys;
++ (id) allKeys;
++ (struct CGAffineTransform) _transformToRotateFromInterfaceOrientation:(int) arg1;
++ (struct CGAffineTransform) _transformToRotateToInterfaceOrientation:(int) arg1;
++ (struct CGRect) _convertRectToCurrentInterfaceOrientation:(struct CGRect) arg1;
++ (struct CGRect) _convertRectFromCurrentInterfaceOrientation:(struct CGRect) arg1;
++ (struct CGPoint) _convertPointFromCurrentInterfaceOrientation:(struct CGPoint) arg1;
++ (struct CGPoint) _convertPointToCurrentInterfaceOrientation:(struct CGPoint) arg1;
++ (id) _nameForAXElement:(id) arg1;
++ (id) _valueForAXElement:(id) arg1;
++ (id) _hitPointFromDictionary:(id) arg1;
++ (id) _hitPointForObject:(id) arg1;
++ (id) _rectFromDictionary:(id) arg1;
++ (double) _patienceRetryInterval;
++ (void) _setPatienceRetryInterval:(double) arg1;
++ (double) patience;
++ (void) setPatience:(double) arg1;
++ (void) pushPatience:(double) arg1;
++ (double) popPatience;
++ (id) _invocationForInvoker:(id) arg1 selector:(SEL) arg2 arguments:(void *) arg3;
++ (id) _patienceInvocationPathForUIAObject:(id) arg1;
++ (id) _performInvocationPath:(id) arg1;
++ (id) _waitForInvocationPath:(id) arg1;
++ (id) _setPatienceInvocation:(id) arg1 forUIAObject:(id) arg2;
++ (id) _jsMethodNameForSelector:(SEL) arg1;
++ (id) _jsEscapedStringForString:(id) arg1;
++ (id) _jsStringForString:(id) arg1;
++ (id) _jsStringForDictionary:(id) arg1;
++ (id) _jsStringForObject:(id) arg1;
++ (id) _jsStringForRect:(struct CGRect) arg1;
++ (id) _jsStringForInvocation:(id) arg1;
++ (id) _jsMethodCallStringForInvoker:(id) arg1 selector:(SEL) arg2;
++ (id) _jsStringForInvocationPath:(id) arg1;
++ (id) _jsStringForUIAElement:(id) arg1;
++ (Class) _uiaClassForClass:(Class) arg1;
++ (Class) _classForSimpleUIAXElement:(id) arg1;
++ (id) elementForUIAXElement:(id) arg1;
++ (id) elementAtPosition:(struct CGPoint) arg1;
++ (id) _predicateForPredicateOrString:(id) arg1;
+- (id) init;
+- (id) _initWithUIAXElement:(id) arg1 parent:(id) arg2;
+- (void) dealloc;
+- (void) _emptyCaches;
+- (void) _invalidate;
+- (BOOL) isEqual:(id) arg1;
+- (unsigned int) hash;
+- (id) description;
+- (id) copyWithZone:(struct _NSZone *) arg1;
+- (double) _createdTime;
+- (double) _lastAccessedTime;
+- (void) _setLastAccessedTime:(double) arg1;
+- (BOOL) isValid;
+- (BOOL) checkIsValid;
+- (BOOL) waitForInvalid;
+- (id) attributeKeys;
+- (id) toOneRelationshipKeys;
+- (id) toManyRelationshipKeys;
+- (id) allKeys;
+- (id) _synonymToManyRelationshipKeys;
+- (id) valueForUndefinedKey:(id) arg1;
+- (id) attributes;
+- (id) toOneRelationships;
+- (id) toManyRelationships;
+- (id) uiaxElement;
+- (id) parentElement;
+- (id) ancestry;
+- (id) _logInfo;
+- (id) _logInfoWithChildren;
+- (void) logElement;
+- (void) logElementTree;
+- (void) logAXInfo;
+- (void) logAXTree;
+- (id) pid;
+- (id) hint;
+- (id) label;
+- (id) rect;
+- (id) _uiaRect;
+- (id) _tryHitpoint:(struct CGPoint) arg1;
+- (id) _hitpoint;
+- (id) hitpoint;
+- (id) _uiaHitpoint;
+- (id) isEnabled;
+- (id) hasKeyboardFocus;
+- (id) isVisible;
+- (id) target;
+- (id) name;
+- (id) value;
+- (BOOL) _shouldAllowSettingValue;
+- (void) setValue:(id) arg1;
+- (id) url;
+- (id) dom;
+- (id) className;
+- (id) type;
+- (void) undo;
+- (void) redo;
+- (void) _delayForAnimationsInProgress;
+- (void) _prepareForAction:(SEL) arg1;
+- (void) tap;
+- (void) doubleTap;
+- (void) twoFingerTap;
+- (void) tapWithOptions:(id) arg1;
+- (void) touchAndHold:(id) arg1;
+- (void) _dragInsideWithOptions:(id) arg1 withFlick:(BOOL) arg2;
+- (void) dragInsideWithOptions:(id) arg1;
+- (void) flickInsideWithOptions:(id) arg1;
+- (void) _rotateWithOptions:(id) arg1;
+- (void) rotateWithOptions:(id) arg1;
+- (void) activate;
+- (void) scrollUp;
+- (void) scrollDown;
+- (void) scrollLeft;
+- (void) scrollRight;
+- (id) scrollToVisible;
+- (id) scrollToElementWithName:(id) arg1;
+- (id) scrollToElementWithPredicate:(id) arg1;
+- (id) scrollToElementWithValue:(id) arg1 forKey:(id) arg2;
+- (id) _selfPatienceInvocation;
+- (void) _setSelfPatienceInvocation:(id) arg1;
+- (void) chopPatience;
+- (id) _objectWithPatienceInvocationFromUIAObject:(id) arg1 selector:(SEL) arg2;
+- (id) _patienceForAttribute:(SEL) arg1 value:(id) arg2;
+- (id) scriptingActionExpressionShouldFavorTapOffset;
+- (id) scriptingInvocationString;
+- (id) scriptingInvocationFullExpressionString;
+- (id) _scriptingSynonymsForSubElement:(id) arg1 maxCount:(unsigned int) arg2;
+- (id) scriptingFavoredSynonymString;
+- (id) scriptingSynonymStrings;
+- (id) scriptingSynonymFullExpressionString;
+- (id) _elementForSimpleUIAXElement:(id) arg1;
+- (id) _elementsForUIAXElements:(id) arg1 axFilter:(SEL) arg2;
+- (id) _elementsForUIAXElements:(id) arg1;
+- (BOOL) _inspectConfirmElement:(id) arg1 forAXAncestry:(id) arg2 index:(unsigned int *) arg3;
+- (id) _inspectedToOneRelationship:(id) arg1 forAXAncestry:(id) arg2 index:(unsigned int *) arg3;
+- (id) _inspectedToManyRelationship:(id) arg1 forAXAncestry:(id) arg2 index:(unsigned int *) arg3;
+- (id) _inspectedElementForAXAncestry:(id) arg1 index:(unsigned int *) arg2 triedKeys:(id) arg3;
+- (id) _elementForUIAXElement:(id) arg1;
+- (id) _elementAtPosition:(struct CGPoint) arg1;
+- (id) elementAtPoint:(id) arg1;
+- (id) withName:(id) arg1;
+- (id) withValue:(id) arg1 forKey:(id) arg2;
+- (id) withPredicate:(id) arg1;
+- (id) elements;
+- (id) _elementsOfClass:(Class) arg1 forSelector:(SEL) arg2;
+- (id) actionSheets;
+- (id) actionSheet;
+- (id) activityIndicators;
+- (id) buttons;
+- (id) editingMenus;
+- (id) images;
+- (id) keyboards;
+- (id) keyboard;
+- (id) keys;
+- (id) links;
+- (id) navigationBars;
+- (id) navigationBar;
+- (id) pageIndicators;
+- (id) pickers;
+- (id) popovers;
+- (id) popover;
+- (id) progressIndicators;
+- (id) scrollViews;
+- (id) segmentedControls;
+- (id) sliders;
+- (id) switches;
+- (id) staticTexts;
+- (id) tableViews;
+- (id) textFields;
+- (id) secureTextFields;
+- (id) searchBars;
+- (id) tabBars;
+- (id) tabBar;
+- (id) toolbars;
+- (id) toolbar;
+- (id) textViews;
+- (id) webViews;
 
 @end
 
-@interface UIAElementNil : NSObject <NSFastEnumeration>
-{
-    NSInvocation *_selfPatienceInvocation;
-    double _refreshedTime;
-    double _lastAccessedTime;
+@interface UIAElementArray : NSArray {
+  NSArray *_array;
+  NSInvocation *_selfPatienceInvocation;
+  double _refreshedTime;
+  double _lastAccessedTime;
 }
 
-+ (int)_liveCount;
-+ (int)_maxCount;
-+ (id)_elementNilWithInvocation:(id)arg1;
-- (id)_selfPatienceInvocation;
-- (void)_setSelfPatienceInvocation:(id)arg1;
-- (id)_objectWithPatienceInvocationFromUIAObject:(id)arg1 selector:(SEL)arg2;
-- (id)_initWithInvocation:(id)arg1;
-- (void)dealloc;
-- (double)_refreshedTime;
-- (double)_lastAccessedTime;
-- (void)_setLastAccessedTime:(double)arg1;
-- (BOOL)_isStillFreshAtTime:(double)arg1;
-- (id)_elementNilWithPatienceInvocation:(SEL)arg1;
-- (id)scriptingInvocationString;
-- (id)scriptingInvocationFullExpressionString;
-- (BOOL)isValid;
-- (BOOL)checkIsValid;
-- (BOOL)waitForInvalid;
-- (id)withName:(id)arg1;
-- (id)withValue:(id)arg1 forKey:(id)arg2;
-- (id)withPredicate:(id)arg1;
-- (unsigned int)count;
-- (id)objectAtIndex:(unsigned int)arg1;
-- (id)nsArray;
-- (BOOL)containsObject:(id)arg1;
-- (unsigned int)indexOfObject:(id)arg1;
-- (id)objectEnumerator;
-- (id)reverseObjectEnumerator;
-- (id)firstWithName:(id)arg1;
-- (id)firstWithValue:(id)arg1 forKey:(id)arg2;
-- (id)firstWithPredicate:(id)arg1;
-- (id)elementOfClass:(Class)arg1 atIndex:(unsigned int)arg2;
-- (void)_raiseInvalidElementAction;
-- (void)tap;
-- (void)doubleTap;
-- (void)twoFingerTap;
-- (void)tapWithOptions:(id)arg1;
-- (void)touchAndHold:(id)arg1;
-- (void)choose;
-- (void)dragToValue:(id)arg1;
-- (void)selectValue:(id)arg1;
-- (void)dismiss;
-- (void)goToNextPage;
-- (void)goToPreviousPage;
-- (void)selectPage:(id)arg1;
-- (void)dragInsideWithOptions:(id)arg1;
-- (void)flickInsideWithOptions:(id)arg1;
-- (void)rotateWithOptions:(id)arg1;
-- (void)activate;
-- (void)scrollUp;
-- (void)scrollDown;
-- (void)scrollLeft;
-- (void)scrollRight;
-- (void)scrollToVisible;
-- (id)scrollToElementWithName:(id)arg1;
-- (id)scrollToElementWithPredicate:(id)arg1;
-- (id)scrollToElementWithValue:(id)arg1 forKey:(id)arg2;
-- (id)elements;
-- (id)activityIndicators;
-- (id)buttons;
-- (id)editingMenus;
-- (id)images;
-- (id)keyboards;
-- (id)keys;
-- (id)links;
-- (id)pageIndicators;
-- (id)pickers;
-- (id)popover;
-- (id)progressIndicators;
-- (id)scrollViews;
-- (id)segmentedControls;
-- (id)staticTexts;
-- (id)switches;
-- (id)sliders;
-- (id)textFields;
-- (id)secureTextFields;
-- (id)tableViews;
-- (id)searchBars;
-- (id)textViews;
-- (id)webViews;
-- (id)parentElement;
-- (id)ancestry;
-- (id)windows;
-- (id)keyWindow;
-- (id)mainWindow;
-- (id)actionSheets;
-- (id)actionSheet;
-- (id)alert;
-- (id)editingMenu;
-- (id)switcherScrollView;
-- (id)keyboard;
-- (id)statusBar;
-- (id)navigationBars;
-- (id)navigationBar;
-- (id)tabBars;
-- (id)tabBar;
-- (id)toolbars;
-- (id)toolbar;
-- (id)leftButton;
-- (id)rightButton;
-- (id)selectedButton;
-- (id)wheels;
-- (id)headers;
-- (id)cells;
-- (id)visibleCells;
-- (id)groups;
-- (id)visibleGroups;
-- (id)rect;
-- (id)hitpoint;
-- (id)name;
-- (id)label;
-- (id)hint;
-- (id)value;
-- (id)url;
-- (id)dom;
-- (void)setValue:(id)arg1;
-- (id)pid;
-- (id)helpTag;
-- (id)isEnabled;
-- (id)isVisible;
-- (id)isCameraIrisOpen;
-- (id)hasKeyboardFocus;
-- (id)hasOpenMenu;
-- (id)target;
-- (id)depth;
-- (id)visibleFrame;
-- (id)bundlePath;
-- (id)version;
-- (id)bundleID;
-- (id)bundleVersion;
-- (id)localizedStringForKey:(id)arg1 value:(id)arg2 table:(id)arg3;
-- (id)localizations;
-- (id)stateDescription;
-- (id)architecture;
-- (id)isFront;
-- (id)isBackgroundApp;
-- (id)cancelButton;
-- (id)defaultButton;
-- (id)isSeparatorItem;
-- (id)keyEquivalent;
-- (id)keyEquivalentModifiers;
-- (id)contentArea;
-- (id)orientation;
-- (id)minValue;
-- (id)maxValue;
-- (id)textLength;
-- (id)numberOfCells;
-- (id)values;
-- (id)selectedValue;
-- (id)pageCount;
-- (id)pageIndex;
-- (id)_logInfoWithChildren;
-- (void)logElement;
-- (void)logElementTree;
-- (void)logAXInfo;
-- (void)logAXTree;
++ (void) initialize;
++ (int) _liveCount;
++ (int) _maxCount;
++ (id) _arrayWithArray:(id) arg1;
++ (id) _cachedArrayAtPtr:(const id *) arg1;
++ (void) _cacheArray:(id) arg1 atPtr:(const id *) arg2;
++ (void) _removeCachedArrayAtPtr:(const id *) arg1;
+- (id) _initWithArray:(id) arg1;
+- (void) dealloc;
+- (unsigned int) count;
+- (id) objectAtIndex:(unsigned int) arg1;
+- (BOOL) isEqualToArray:(id) arg1;
+- (BOOL) isEqual:(id) arg1;
+- (unsigned int) hash;
+- (id) description;
+- (id) _selfPatienceInvocation;
+- (void) _setSelfPatienceInvocation:(id) arg1;
+- (id) _objectWithPatienceInvocationFromUIAObject:(id) arg1 selector:(SEL) arg2;
+- (id) nsArray;
+- (void) _setArray:(id) arg1;
+- (double) _refreshedTime;
+- (double) _lastAccessedTime;
+- (void) _setLastAccessedTime:(double) arg1;
+- (BOOL) _isStillFreshAtTime:(double) arg1;
+- (id) _withClass:(Class) arg1;
+- (id) _withName:(id) arg1;
+- (id) _withValue:(id) arg1 forKey:(id) arg2;
+- (id) _withPredicate:(id) arg1;
+- (id) withClass:(Class) arg1;
+- (id) withName:(id) arg1;
+- (id) withValue:(id) arg1 forKey:(id) arg2;
+- (id) withPredicate:(id) arg1;
+- (id) firstWithName:(id) arg1;
+- (id) firstWithValue:(id) arg1 forKey:(id) arg2;
+- (id) firstWithPredicate:(id) arg1;
+- (void) logElements;
+- (void) logElementTrees;
+- (id) elementOfClass:(Class) arg1 atIndex:(unsigned int) arg2;
+- (id) _scriptingIndexSynonymsForElement:(id) arg1 maxCount:(unsigned int) arg2;
+- (id) scriptingFavoredIndexSynonymForElement:(id) arg1;
+- (id) scriptingIndexSynonymsForElement:(id) arg1;
+- (id) scriptingInvocationString;
+- (id) scriptingInvocationFullExpressionString;
+- (BOOL) isValid;
 
 @end
 
-@interface UIAScreen : UIAElement
-{
-    UIScreen *_uiScreen;
+@interface UIAElementNil : NSObject <NSFastEnumeration> {
+  NSInvocation *_selfPatienceInvocation;
+  double _refreshedTime;
+  double _lastAccessedTime;
 }
 
-+ (id)attributeKeys;
-- (id)_initWithUIScreen:(id)arg1 parent:(id)arg2;
-- (void)dealloc;
-- (id)_uiScreen;
-- (id)description;
-- (id)copyWithZone:(struct _NSZone *)arg1;
-- (id)bounds;
-- (id)scale;
-- (id)applicationFrame;
-- (id)_uiaApplicationFrame;
-- (id)uiScreen;
++ (int) _liveCount;
++ (int) _maxCount;
++ (id) _elementNilWithInvocation:(id) arg1;
+- (id) _selfPatienceInvocation;
+- (void) _setSelfPatienceInvocation:(id) arg1;
+- (id) _objectWithPatienceInvocationFromUIAObject:(id) arg1 selector:(SEL) arg2;
+- (id) _initWithInvocation:(id) arg1;
+- (void) dealloc;
+- (double) _refreshedTime;
+- (double) _lastAccessedTime;
+- (void) _setLastAccessedTime:(double) arg1;
+- (BOOL) _isStillFreshAtTime:(double) arg1;
+- (id) _elementNilWithPatienceInvocation:(SEL) arg1;
+- (id) scriptingInvocationString;
+- (id) scriptingInvocationFullExpressionString;
+- (BOOL) isValid;
+- (BOOL) checkIsValid;
+- (BOOL) waitForInvalid;
+- (id) withName:(id) arg1;
+- (id) withValue:(id) arg1 forKey:(id) arg2;
+- (id) withPredicate:(id) arg1;
+- (unsigned int) count;
+- (id) objectAtIndex:(unsigned int) arg1;
+- (id) nsArray;
+- (BOOL) containsObject:(id) arg1;
+- (unsigned int) indexOfObject:(id) arg1;
+- (id) objectEnumerator;
+- (id) reverseObjectEnumerator;
+- (id) firstWithName:(id) arg1;
+- (id) firstWithValue:(id) arg1 forKey:(id) arg2;
+- (id) firstWithPredicate:(id) arg1;
+- (id) elementOfClass:(Class) arg1 atIndex:(unsigned int) arg2;
+- (void) _raiseInvalidElementAction;
+- (void) tap;
+- (void) doubleTap;
+- (void) twoFingerTap;
+- (void) tapWithOptions:(id) arg1;
+- (void) touchAndHold:(id) arg1;
+- (void) choose;
+- (void) dragToValue:(id) arg1;
+- (void) selectValue:(id) arg1;
+- (void) dismiss;
+- (void) goToNextPage;
+- (void) goToPreviousPage;
+- (void) selectPage:(id) arg1;
+- (void) dragInsideWithOptions:(id) arg1;
+- (void) flickInsideWithOptions:(id) arg1;
+- (void) rotateWithOptions:(id) arg1;
+- (void) activate;
+- (void) scrollUp;
+- (void) scrollDown;
+- (void) scrollLeft;
+- (void) scrollRight;
+- (void) scrollToVisible;
+- (id) scrollToElementWithName:(id) arg1;
+- (id) scrollToElementWithPredicate:(id) arg1;
+- (id) scrollToElementWithValue:(id) arg1 forKey:(id) arg2;
+- (id) elements;
+- (id) activityIndicators;
+- (id) buttons;
+- (id) editingMenus;
+- (id) images;
+- (id) keyboards;
+- (id) keys;
+- (id) links;
+- (id) pageIndicators;
+- (id) pickers;
+- (id) popover;
+- (id) progressIndicators;
+- (id) scrollViews;
+- (id) segmentedControls;
+- (id) staticTexts;
+- (id) switches;
+- (id) sliders;
+- (id) textFields;
+- (id) secureTextFields;
+- (id) tableViews;
+- (id) searchBars;
+- (id) textViews;
+- (id) webViews;
+- (id) parentElement;
+- (id) ancestry;
+- (id) windows;
+- (id) keyWindow;
+- (id) mainWindow;
+- (id) actionSheets;
+- (id) actionSheet;
+- (id) alert;
+- (id) editingMenu;
+- (id) switcherScrollView;
+- (id) keyboard;
+- (id) statusBar;
+- (id) navigationBars;
+- (id) navigationBar;
+- (id) tabBars;
+- (id) tabBar;
+- (id) toolbars;
+- (id) toolbar;
+- (id) leftButton;
+- (id) rightButton;
+- (id) selectedButton;
+- (id) wheels;
+- (id) headers;
+- (id) cells;
+- (id) visibleCells;
+- (id) groups;
+- (id) visibleGroups;
+- (id) rect;
+- (id) hitpoint;
+- (id) name;
+- (id) label;
+- (id) hint;
+- (id) value;
+- (id) url;
+- (id) dom;
+- (void) setValue:(id) arg1;
+- (id) pid;
+- (id) helpTag;
+- (id) isEnabled;
+- (id) isVisible;
+- (id) isCameraIrisOpen;
+- (id) hasKeyboardFocus;
+- (id) hasOpenMenu;
+- (id) target;
+- (id) depth;
+- (id) visibleFrame;
+- (id) bundlePath;
+- (id) version;
+- (id) bundleID;
+- (id) bundleVersion;
+- (id) localizedStringForKey:(id) arg1 value:(id) arg2 table:(id) arg3;
+- (id) localizations;
+- (id) stateDescription;
+- (id) architecture;
+- (id) isFront;
+- (id) isBackgroundApp;
+- (id) cancelButton;
+- (id) defaultButton;
+- (id) isSeparatorItem;
+- (id) keyEquivalent;
+- (id) keyEquivalentModifiers;
+- (id) contentArea;
+- (id) orientation;
+- (id) minValue;
+- (id) maxValue;
+- (id) textLength;
+- (id) numberOfCells;
+- (id) values;
+- (id) selectedValue;
+- (id) pageCount;
+- (id) pageIndex;
+- (id) _logInfoWithChildren;
+- (void) logElement;
+- (void) logElementTree;
+- (void) logAXInfo;
+- (void) logAXTree;
 
 @end
 
-@interface UIAHost : NSObject
-{
+@interface UIAScreen : UIAElement {
+  UIScreen *_uiScreen;
 }
 
-- (id)performTaskWithPath:(id)arg1 arguments:(id)arg2 timeout:(id)arg3;
++ (id) attributeKeys;
+- (id) _initWithUIScreen:(id) arg1 parent:(id) arg2;
+- (void) dealloc;
+- (id) _uiScreen;
+- (id) description;
+- (id) copyWithZone:(struct _NSZone *) arg1;
+- (id) bounds;
+- (id) scale;
+- (id) applicationFrame;
+- (id) _uiaApplicationFrame;
+- (id) uiScreen;
 
 @end
 
-@interface UIATarget : UIAElement
-{
+@interface UIAHost : NSObject {
 }
 
-+ (id)localTarget;
-+ (id)_locationForObject:(id)arg1 withOptions:(id)arg2;
-+ (id)attributeKeys;
-+ (id)toOneRelationshipKeys;
-+ (id)toManyRelationshipKeys;
-- (id)_systemVersionDictionary;
-- (id)init;
-- (void)dealloc;
-- (void)_invalidate;
-- (void)_updateInterfaceOrientation;
-- (int)_interfaceOrientation;
-- (double)_lastAnimationEndedTime;
-- (void)_setLastAnimationEndedTime:(double)arg1;
-- (BOOL)isEqual:(id)arg1;
-- (unsigned int)hash;
-- (BOOL)isValid;
-- (BOOL)checkIsValid;
-- (id)rect;
-- (id)name;
-- (id)model;
-- (id)systemName;
-- (id)systemVersion;
-- (id)systemBuild;
-- (id)uniqueIdentifier;
-- (id)deviceOrientation;
-- (BOOL)setDeviceOrientation:(id)arg1;
-- (BOOL)setLocation:(id)arg1;
-- (BOOL)setLocation:(id)arg1 withOptions:(id)arg2;
-- (id)startupDate;
-- (double)upTime;
-- (id)lastCommandTime;
-- (void)captureScreenWithName:(id)arg1;
-- (id)imageFromRect:(struct CGRect)arg1;
-- (void)captureRect:(id)arg1 withName:(id)arg2;
-- (id)targetClipboard;
-- (void)setTargetClipboard:(id)arg1;
-- (int)textViewValueMaxLength;
-- (void)setTextViewValueMaxLength:(int)arg1;
-- (id)host;
-- (id)applications;
-- (id)frontMostApp;
-- (id)mainScreen;
-- (id)elements;
-- (id)uiaxSystemWideElement;
-- (double)patience;
-- (void)setPatience:(double)arg1;
-- (void)pushPatience:(double)arg1;
-- (double)popPatience;
-- (BOOL)delayForTimeInterval:(double)arg1;
-- (void)setVerboseOptions:(unsigned int)arg1;
-- (unsigned int)verboseOptions;
-- (void)setDelegate:(id)arg1;
-- (id)delegate;
-- (void)setPassiveEventListeningMode:(id)arg1 withDelay:(id)arg2;
-- (BOOL)_handleAlert;
-- (id)scriptingFavoredSynonymString;
-- (id)scriptingSynonymStrings;
-- (id)localizedStringForKey:(id)arg1 value:(id)arg2 table:(id)arg3 bundlePath:(id)arg4;
-- (BOOL)_tapOptionalObject:(id)arg1 tapCount:(double)arg2 touchCount:(double)arg3 tapOffset:(id)arg4;
-- (BOOL)_tapRequiredObject:(id)arg1 tapCount:(double)arg2 touchCount:(double)arg3;
-- (BOOL)_dragFrom:(id)arg1 to:(id)arg2 forDuration:(double)arg3 withTouchCount:(int)arg4 withFlick:(BOOL)arg5;
-- (void)tap:(id)arg1;
-- (void)doubleTap:(id)arg1;
-- (void)twoFingerTap:(id)arg1;
-- (void)tap:(id)arg1 withOptions:(id)arg2;
-- (void)touch:(id)arg1 andHold:(id)arg2;
-- (void)dragFrom:(id)arg1 to:(id)arg2 forDuration:(id)arg3;
-- (void)flickFrom:(id)arg1 to:(id)arg2;
-- (void)pinchCloseFrom:(id)arg1 to:(id)arg2 forDuration:(id)arg3;
-- (void)pinchOpenFrom:(id)arg1 to:(id)arg2 forDuration:(id)arg3;
-- (void)rotate:(id)arg1 withOptions:(id)arg2;
-- (void)shake;
-- (void)clickMenu;
-- (void)holdMenu:(id)arg1;
-- (void)clickLock;
-- (void)holdLock:(id)arg1;
-- (void)clickVolumeUp;
-- (void)holdVolumeUp:(id)arg1;
-- (void)clickVolumeDown;
-- (void)holdVolumeDown:(id)arg1;
-- (void)setRinger:(id)arg1;
-- (BOOL)_screenIsLocked;
-- (id)_lockBar;
-- (BOOL)_screenIsOff;
-- (BOOL)lockForDuration:(id)arg1;
-- (BOOL)lock;
-- (BOOL)unlock;
-- (BOOL)deactivateAppForDuration:(id)arg1;
-- (BOOL)deactivateApp;
-- (BOOL)reactivateApp;
+- (id) performTaskWithPath:(id) arg1 arguments:(id) arg2 timeout:(id) arg3;
+
+@end
+
+@interface UIATarget : UIAElement {
+}
+
++ (id) localTarget;
++ (id) _locationForObject:(id) arg1 withOptions:(id) arg2;
++ (id) attributeKeys;
++ (id) toOneRelationshipKeys;
++ (id) toManyRelationshipKeys;
+- (id) _systemVersionDictionary;
+- (id) init;
+- (void) dealloc;
+- (void) _invalidate;
+- (void) _updateInterfaceOrientation;
+- (int) _interfaceOrientation;
+- (double) _lastAnimationEndedTime;
+- (void) _setLastAnimationEndedTime:(double) arg1;
+- (BOOL) isEqual:(id) arg1;
+- (unsigned int) hash;
+- (BOOL) isValid;
+- (BOOL) checkIsValid;
+- (id) rect;
+- (id) name;
+- (id) model;
+- (id) systemName;
+- (id) systemVersion;
+- (id) systemBuild;
+- (id) uniqueIdentifier;
+- (id) deviceOrientation;
+- (BOOL) setDeviceOrientation:(id) arg1;
+- (BOOL) setLocation:(id) arg1;
+- (BOOL) setLocation:(id) arg1 withOptions:(id) arg2;
+- (id) startupDate;
+- (double) upTime;
+- (id) lastCommandTime;
+- (void) captureScreenWithName:(id) arg1;
+- (id) imageFromRect:(struct CGRect) arg1;
+- (void) captureRect:(id) arg1 withName:(id) arg2;
+- (id) targetClipboard;
+- (void) setTargetClipboard:(id) arg1;
+- (int) textViewValueMaxLength;
+- (void) setTextViewValueMaxLength:(int) arg1;
+- (id) host;
+- (id) applications;
+- (id) frontMostApp;
+- (id) mainScreen;
+- (id) elements;
+- (id) uiaxSystemWideElement;
+- (double) patience;
+- (void) setPatience:(double) arg1;
+- (void) pushPatience:(double) arg1;
+- (double) popPatience;
+- (BOOL) delayForTimeInterval:(double) arg1;
+- (void) setVerboseOptions:(unsigned int) arg1;
+- (unsigned int) verboseOptions;
+- (void) setDelegate:(id) arg1;
+- (id) delegate;
+- (void) setPassiveEventListeningMode:(id) arg1 withDelay:(id) arg2;
+- (BOOL) _handleAlert;
+- (id) scriptingFavoredSynonymString;
+- (id) scriptingSynonymStrings;
+- (id) localizedStringForKey:(id) arg1 value:(id) arg2 table:(id) arg3 bundlePath:(id) arg4;
+- (BOOL) _tapOptionalObject:(id) arg1 tapCount:(double) arg2 touchCount:(double) arg3 tapOffset:(id) arg4;
+- (BOOL) _tapRequiredObject:(id) arg1 tapCount:(double) arg2 touchCount:(double) arg3;
+- (BOOL) _dragFrom:(id) arg1 to:(id) arg2 forDuration:(double) arg3 withTouchCount:(int) arg4 withFlick:(BOOL) arg5;
+- (void) tap:(id) arg1;
+- (void) doubleTap:(id) arg1;
+- (void) twoFingerTap:(id) arg1;
+- (void) tap:(id) arg1 withOptions:(id) arg2;
+- (void) touch:(id) arg1 andHold:(id) arg2;
+- (void) dragFrom:(id) arg1 to:(id) arg2 forDuration:(id) arg3;
+- (void) flickFrom:(id) arg1 to:(id) arg2;
+- (void) pinchCloseFrom:(id) arg1 to:(id) arg2 forDuration:(id) arg3;
+- (void) pinchOpenFrom:(id) arg1 to:(id) arg2 forDuration:(id) arg3;
+- (void) rotate:(id) arg1 withOptions:(id) arg2;
+- (void) shake;
+- (void) clickMenu;
+- (void) holdMenu:(id) arg1;
+- (void) clickLock;
+- (void) holdLock:(id) arg1;
+- (void) clickVolumeUp;
+- (void) holdVolumeUp:(id) arg1;
+- (void) clickVolumeDown;
+- (void) holdVolumeDown:(id) arg1;
+- (void) setRinger:(id) arg1;
+- (BOOL) _screenIsLocked;
+- (id) _lockBar;
+- (BOOL) _screenIsOff;
+- (BOOL) lockForDuration:(id) arg1;
+- (BOOL) lock;
+- (BOOL) unlock;
+- (BOOL) deactivateAppForDuration:(id) arg1;
+- (BOOL) deactivateApp;
+- (BOOL) reactivateApp;
 @property BOOL logElementTakesScreenshot; // @synthesize logElementTakesScreenshot=_logElementTakesScreenshot;
 
 @end
 
-@interface UIATextView : UIAElement
-{
+@interface UIATextView : UIAElement {
 }
 
 @end
 
-
-@interface UIATextField : UIAElement
-{
+@interface UIATextField : UIAElement {
 }
 
-- (BOOL)_textFieldShouldAcceptAXElement:(id)arg1;
-- (id)elements;
-- (id)scriptingActionExpressionShouldFavorTapOffset;
+- (BOOL) _textFieldShouldAcceptAXElement:(id) arg1;
+- (id) elements;
+- (id) scriptingActionExpressionShouldFavorTapOffset;
 
 @end
 
-@interface UIATableCell : UIAElement
-{
+@interface UIATableCell : UIAElement {
 }
 
-+ (Class)_classForSimpleUIAXElement:(id)arg1;
-- (id)name;
-- (id)value;
-- (id)scriptingActionExpressionShouldFavorTapOffset;
++ (Class) _classForSimpleUIAXElement:(id) arg1;
+- (id) name;
+- (id) value;
+- (id) scriptingActionExpressionShouldFavorTapOffset;
 
 @end
 
-@interface UIATableGroup : UIAElement
-{
+@interface UIATableGroup : UIAElement {
 }
 
-+ (Class)_classForSimpleUIAXElement:(id)arg1;
-- (id)name;
++ (Class) _classForSimpleUIAXElement:(id) arg1;
+- (id) name;
 
 @end
 
-@interface UIATableView : UIAElement
-{
-    UIAElementArray *_cells;
+@interface UIATableView : UIAElement {
+  UIAElementArray *_cells;
 }
 
-+ (Class)_classForSimpleUIAXElement:(id)arg1;
-+ (id)_moreToManyRelationshipKeys;
-+ (id)toManyRelationshipKeys;
-- (void)_emptyCaches;
-- (id)value;
-- (id)firstVisibleCellIndex;
-- (id)lastVisibleCellIndex;
-- (id)cellCount;
-- (id)cells;
-- (id)groups;
-- (id)visibleCells;
-- (id)visibleGroups;
++ (Class) _classForSimpleUIAXElement:(id) arg1;
++ (id) _moreToManyRelationshipKeys;
++ (id) toManyRelationshipKeys;
+- (void) _emptyCaches;
+- (id) value;
+- (id) firstVisibleCellIndex;
+- (id) lastVisibleCellIndex;
+- (id) cellCount;
+- (id) cells;
+- (id) groups;
+- (id) visibleCells;
+- (id) visibleGroups;
 
 @end
 
-@interface UIASwitch : UIAElement
-{
+@interface UIASwitch : UIAElement {
 }
 
-- (id)elements;
-- (id)value;
-- (void)setValue:(id)arg1;
+- (id) elements;
+- (id) value;
+- (void) setValue:(id) arg1;
 
 @end
 
-@interface UIASlider : UIAElement
-{
+@interface UIASlider : UIAElement {
 }
 
-- (id)elements;
-- (void)dragToValue:(id)arg1;
+- (id) elements;
+- (void) dragToValue:(id) arg1;
 
 @end
 
-@interface UIAStaticText : UIAElement
-{
+@interface UIAStaticText : UIAElement {
 }
 
-- (BOOL)_shouldAllowSettingValue;
+- (BOOL) _shouldAllowSettingValue;
 
 @end
 
-@interface UIASegmentedControl : UIAElement
-{
+@interface UIASegmentedControl : UIAElement {
 }
 
-- (id)selectedButton;
+- (id) selectedButton;
 
 @end
 
-@interface UIAPopover : UIAElement
-{
+@interface UIAPopover : UIAElement {
 }
 
-- (void)dismiss;
+- (void) dismiss;
 
 @end
 
-@interface UIAScrollView : UIAElement
-{
+@interface UIAScrollView : UIAElement {
 }
 
 @end
 
-@interface UIAProgressIndicator : UIAElement
-{
+@interface UIAProgressIndicator : UIAElement {
 }
 
 @end
 
-@interface UIAPickerWheel : UIAElement
-{
+@interface UIAPickerWheel : UIAElement {
 }
 
-- (id)elements;
-- (id)values;
-- (BOOL)_spinWheel:(int)arg1;
-- (void)selectValue:(id)arg1;
+- (id) elements;
+- (id) values;
+- (BOOL) _spinWheel:(int) arg1;
+- (void) selectValue:(id) arg1;
 
 @end
 
-@interface UIAPicker : UIAElement
-{
+@interface UIAPicker : UIAElement {
 }
 
-+ (id)_moreToManyRelationshipKeys;
-+ (id)toManyRelationshipKeys;
-- (id)wheels;
++ (id) _moreToManyRelationshipKeys;
++ (id) toManyRelationshipKeys;
+- (id) wheels;
 
 @end
 
-@interface UIAPageIndicator : UIAElement
-{
+@interface UIAPageIndicator : UIAElement {
 }
 
-- (id)pageIndex;
-- (id)pageCount;
-- (BOOL)_flipPages:(int)arg1;
-- (void)goToNextPage;
-- (void)goToPreviousPage;
-- (void)selectPage:(id)arg1;
+- (id) pageIndex;
+- (id) pageCount;
+- (BOOL) _flipPages:(int) arg1;
+- (void) goToNextPage;
+- (void) goToPreviousPage;
+- (void) selectPage:(id) arg1;
 
 @end
 
-@interface UIALink : UIAElement
-{
+@interface UIALink : UIAElement {
 }
 
-- (id)scriptingActionExpressionShouldFavorTapOffset;
+- (id) scriptingActionExpressionShouldFavorTapOffset;
 
 @end
 
-@interface UIAKey : UIAElement
-{
+@interface UIAKey : UIAElement {
 }
 
-- (void)_delayForAnimationsInProgress;
-- (id)scriptingActionExpressionShouldFavorTapOffset;
+- (void) _delayForAnimationsInProgress;
+- (id) scriptingActionExpressionShouldFavorTapOffset;
 
 @end
 
-@interface UIAImage : UIAElement
-{
+@interface UIAImage : UIAElement {
 }
 
 @end
 
-@interface UIAButton : UIAElement
-{
+@interface UIAButton : UIAElement {
 }
 
-- (id)value;
-- (id)scriptingActionExpressionShouldFavorTapOffset;
+- (id) value;
+- (id) scriptingActionExpressionShouldFavorTapOffset;
 
 @end
 
-@interface UIAActivityIndicator : UIAElement
-{
-}
-
-@end
-
-@interface UIASyntheticEvents : NSObject
-{
-}
-
-+ (id)sharedEventGenerator;
-- (id)init;
-- (void)_sendHandEventWithPointArray:(struct CGPoint *)arg1 indentifierArray:(int *)arg2 pointCount:(int)arg3;
-- (struct CGPoint)_convertLocation:(struct CGPoint)arg1;
-- (float)_doubleTapSpeedFromDefaults;
-- (void)sendAccelerometerX:(float)arg1 Y:(float)arg2 Z:(float)arg3;
-- (void)sendAccelerometerX:(float)arg1 Y:(float)arg2 Z:(float)arg3 duration:(double)arg4;
-- (void)setOrientation:(int)arg1;
-- (void)_sendSimpleEvent:(int)arg1;
-- (void)_sendDownEvent:(int)arg1 upEvent:(int)arg2;
-- (void)_sendDownEvent:(int)arg1 upEvent:(int)arg2 duration:(double)arg3;
-- (void)clickMenu;
-- (void)holdMenu:(double)arg1;
-- (void)lockDevice;
-- (void)clickLock;
-- (void)holdLock:(double)arg1;
-- (void)clickVolumeUp;
-- (void)holdVolumeUp:(double)arg1;
-- (void)clickVolumeDown;
-- (void)holdVolumeDown:(double)arg1;
-- (void)setRinger:(BOOL)arg1;
-- (void)shake;
-- (void)touchDown:(struct CGPoint)arg1;
-- (void)liftUp:(struct CGPoint)arg1;
-- (void)_moveLastTouchPoint:(struct CGPoint)arg1;
-- (void)sendTap:(struct CGPoint)arg1;
-- (void)sendDoubleTap:(struct CGPoint)arg1;
-- (void)sendDoubleFingerTap:(struct CGPoint)arg1;
-- (void)sendTaps:(int)arg1 location:(struct CGPoint)arg2 withNumberOfTouches:(int)arg3 inRect:(struct CGRect)arg4;
-- (void)sendDragWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3;
-- (void)sendFlickWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3;
-- (void)sendPinchOpenWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3;
-- (void)sendPinchCloseWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3;
-- (void)sendMultifingerDragWithPointArray:(struct CGPoint *)arg1 numPoints:(int)arg2 duration:(double)arg3 numFingers:(int)arg4;
-- (void)sendRotate:(struct CGPoint)arg1 withRadius:(float)arg2 rotation:(float)arg3 duration:(float)arg4 touchCount:(unsigned int)arg5;
-- (void)sendDragWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3 withFlick:(BOOL)arg4 inRect:(struct CGRect)arg5;
-- (void)sendPinchOpenWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3 inRect:(struct CGRect)arg4;
-- (void)sendPinchCloseWithStartPoint:(struct CGPoint)arg1 endPoint:(struct CGPoint)arg2 duration:(double)arg3 inRect:(struct CGRect)arg4;
-
-@end
-
-@interface UIAActionSheet : UIAElement
-{
-}
-
-+ (id)toOneRelationshipKeys;
-- (id)cancelButton;
-
-@end
-
-@interface UIAAlert : UIAElement
-{
-}
-
-+ (id)_moreToOneRelationshipKeys;
-+ (id)toOneRelationshipKeys;
-- (id)name;
-- (id)cancelButton;
-- (id)defaultButton;
-
-@end
-
-@interface UIAEditingMenu : UIAElement
-{
+@interface UIAActivityIndicator : UIAElement {
 }
 
 @end
 
-@interface UIAStatusBar : UIAElement
-{
+@interface UIASyntheticEvents : NSObject {
+}
+
++ (id) sharedEventGenerator;
+- (id) init;
+- (void) _sendHandEventWithPointArray:(struct CGPoint *) arg1 indentifierArray:(int *) arg2 pointCount:(int) arg3;
+- (struct CGPoint) _convertLocation:(struct CGPoint) arg1;
+- (float) _doubleTapSpeedFromDefaults;
+- (void) sendAccelerometerX:(float) arg1 Y:(float) arg2 Z:(float) arg3;
+- (void) sendAccelerometerX:(float) arg1 Y:(float) arg2 Z:(float) arg3 duration:(double) arg4;
+- (void) setOrientation:(int) arg1;
+- (void) _sendSimpleEvent:(int) arg1;
+- (void) _sendDownEvent:(int) arg1 upEvent:(int) arg2;
+- (void) _sendDownEvent:(int) arg1 upEvent:(int) arg2 duration:(double) arg3;
+- (void) clickMenu;
+- (void) holdMenu:(double) arg1;
+- (void) lockDevice;
+- (void) clickLock;
+- (void) holdLock:(double) arg1;
+- (void) clickVolumeUp;
+- (void) holdVolumeUp:(double) arg1;
+- (void) clickVolumeDown;
+- (void) holdVolumeDown:(double) arg1;
+- (void) setRinger:(BOOL) arg1;
+- (void) shake;
+- (void) touchDown:(struct CGPoint) arg1;
+- (void) liftUp:(struct CGPoint) arg1;
+- (void) _moveLastTouchPoint:(struct CGPoint) arg1;
+- (void) sendTap:(struct CGPoint) arg1;
+- (void) sendDoubleTap:(struct CGPoint) arg1;
+- (void) sendDoubleFingerTap:(struct CGPoint) arg1;
+- (void) sendTaps:(int) arg1 location:(struct CGPoint) arg2 withNumberOfTouches:(int) arg3 inRect:(struct CGRect) arg4;
+- (void) sendDragWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3;
+- (void) sendFlickWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3;
+- (void) sendPinchOpenWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3;
+- (void) sendPinchCloseWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3;
+- (void) sendMultifingerDragWithPointArray:(struct CGPoint *) arg1 numPoints:(int) arg2 duration:(double) arg3 numFingers:(int) arg4;
+- (void) sendRotate:(struct CGPoint) arg1 withRadius:(float) arg2 rotation:(float) arg3 duration:(float) arg4 touchCount:(unsigned int) arg5;
+- (void) sendDragWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3 withFlick:(BOOL) arg4 inRect:(struct CGRect) arg5;
+- (void) sendPinchOpenWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3 inRect:(struct CGRect) arg4;
+- (void) sendPinchCloseWithStartPoint:(struct CGPoint) arg1 endPoint:(struct CGPoint) arg2 duration:(double) arg3 inRect:(struct CGRect) arg4;
+
+@end
+
+@interface UIAActionSheet : UIAElement {
+}
+
++ (id) toOneRelationshipKeys;
+- (id) cancelButton;
+
+@end
+
+@interface UIAAlert : UIAElement {
+}
+
++ (id) _moreToOneRelationshipKeys;
++ (id) toOneRelationshipKeys;
+- (id) name;
+- (id) cancelButton;
+- (id) defaultButton;
+
+@end
+
+@interface UIAEditingMenu : UIAElement {
 }
 
 @end
 
-@interface UIAKeyboard : UIAElement
-{
-    double _interKeyDelay;
-    double _interKeyDelayVariance;
+@interface UIAStatusBar : UIAElement {
 }
 
-- (id)init;
-- (void)_typeKeyForString:(id)arg1;
-- (void)typeString:(id)arg1;
+@end
+
+@interface UIAKeyboard : UIAElement {
+  double _interKeyDelay;
+  double _interKeyDelayVariance;
+}
+
+- (id) init;
+- (void) _typeKeyForString:(id) arg1;
+- (void) typeString:(id) arg1;
 @property double interKeyDelayVariance; // @synthesize interKeyDelayVariance=_interKeyDelayVariance;
 @property double interKeyDelay; // @synthesize interKeyDelay=_interKeyDelay;
 
 @end
 
-@interface UIAToolbar : UIAElement
-{
+@interface UIAToolbar : UIAElement {
 }
 
 @end
 
-@interface UIATabBar : UIAElement
-{
+@interface UIATabBar : UIAElement {
 }
 
-- (id)selectedButton;
+- (id) selectedButton;
 
 @end
 
-@interface UIANavigationBar : UIAElement
-{
+@interface UIANavigationBar : UIAElement {
 }
 
-+ (id)_moreToOneRelationshipKeys;
-+ (id)toOneRelationshipKeys;
-- (id)name;
-- (id)leftButton;
-- (id)rightButton;
-- (BOOL)_navBarShouldAcceptAXElement:(id)arg1;
-- (id)elements;
++ (id) _moreToOneRelationshipKeys;
++ (id) toOneRelationshipKeys;
+- (id) name;
+- (id) leftButton;
+- (id) rightButton;
+- (BOOL) _navBarShouldAcceptAXElement:(id) arg1;
+- (id) elements;
 
 @end
 
-@interface UIAWindow : UIAElement
-{
+@interface UIAWindow : UIAElement {
 }
 
-- (id)contentArea;
-- (id)_uiaContentArea;
-- (BOOL)_windowShouldAcceptAXElement:(id)arg1;
-- (id)elements;
+- (id) contentArea;
+- (id) _uiaContentArea;
+- (BOOL) _windowShouldAcceptAXElement:(id) arg1;
+- (id) elements;
 
 @end
 
-@interface UIAApplication : UIAElement
-{
-    UIAElementArray *_windows;
-    void *_privateRef;
+@interface UIAApplication : UIAElement {
+  UIAElementArray *_windows;
+  void *_privateRef;
 }
 
-+ (id)attributeKeys;
-+ (id)toOneRelationshipKeys;
-+ (id)toManyRelationshipKeys;
-- (id)init;
-- (void)dealloc;
-- (void)_invalidate;
-- (id)name;
-- (id)bundlePath;
-- (id)_bundle;
-- (id)version;
-- (id)bundleVersion;
-- (id)bundleID;
-- (id)stateDescription;
-- (id)isVisible;
-- (id)isCameraIrisOpen;
-- (void)setPreferencesValue:(id)arg1 forKey:(id)arg2;
-- (id)preferencesValueForKey:(id)arg1;
-- (int)interfaceOrientation;
-- (id)windows;
-- (id)keyWindow;
-- (id)_axMainWindow;
-- (id)mainWindow;
-- (id)keyboard;
-- (id)actionSheet;
-- (id)alert;
-- (id)statusBar;
-- (id)editingMenu;
-- (id)switcherScrollView;
-- (id)navigationBar;
-- (id)tabBar;
-- (id)toolbar;
-- (id)scriptingSynonymStrings;
++ (id) attributeKeys;
++ (id) toOneRelationshipKeys;
++ (id) toManyRelationshipKeys;
+- (id) init;
+- (void) dealloc;
+- (void) _invalidate;
+- (id) name;
+- (id) bundlePath;
+- (id) _bundle;
+- (id) version;
+- (id) bundleVersion;
+- (id) bundleID;
+- (id) stateDescription;
+- (id) isVisible;
+- (id) isCameraIrisOpen;
+- (void) setPreferencesValue:(id) arg1 forKey:(id) arg2;
+- (id) preferencesValueForKey:(id) arg1;
+- (int) interfaceOrientation;
+- (id) windows;
+- (id) keyWindow;
+- (id) _axMainWindow;
+- (id) mainWindow;
+- (id) keyboard;
+- (id) actionSheet;
+- (id) alert;
+- (id) statusBar;
+- (id) editingMenu;
+- (id) switcherScrollView;
+- (id) navigationBar;
+- (id) tabBar;
+- (id) toolbar;
+- (id) scriptingSynonymStrings;
 
 @end
 
-@interface UIARecorder : NSObject
-{
-    UIATarget *_uiaTarget;
-    double _lastActionTime;
-    double _lastEventReleaseTime;
-    UIAXElement *_previousAXElement;
-    NSArray *_pendingTapExpression;
-    NSMutableArray *_pendingDragExpressions;
-    unsigned int _tapCount;
-    NSTimer *_keystrokeFlushTimer;
-    NSTimer *_expressionFlushTimer;
-    NSMutableString *_keystrokes;
-    BOOL _isRecording;
-    id _delegate;
+@interface UIARecorder : NSObject {
+  UIATarget *_uiaTarget;
+  double _lastActionTime;
+  double _lastEventReleaseTime;
+  UIAXElement *_previousAXElement;
+  NSArray *_pendingTapExpression;
+  NSMutableArray *_pendingDragExpressions;
+  unsigned int _tapCount;
+  NSTimer *_keystrokeFlushTimer;
+  NSTimer *_expressionFlushTimer;
+  NSMutableString *_keystrokes;
+  BOOL _isRecording;
+  id _delegate;
 }
 
-+ (id)defaultRecorder;
-- (id)init;
-- (void)dealloc;
-- (void)start;
-- (void)stop;
-- (void)postRecordedExpression:(id)arg1;
-- (void)postElementNotFoundAtPoint:(struct CGPoint)arg1 description:(id)arg2;
-- (void)postStaleEventMessage;
-- (void)postMutlitouchGestureDetected;
-- (void)handleAlert;
-- (void)handleOrientationChange;
-- (void)_releaseEvents;
-- (id)_scriptingStringForPoint:(struct CGPoint)arg1;
-- (id)_scriptingStringForOffsetWithScreenPoint:(struct CGPoint)arg1 inRect:(struct CGRect)arg2;
-- (void)markNewActionAndLog:(BOOL)arg1;
-- (void)flushTapExpression:(id)arg1;
-- (void)flushDragExpressions:(id)arg1;
-- (void)flushKeystrokes:(id)arg1;
++ (id) defaultRecorder;
+- (id) init;
+- (void) dealloc;
+- (void) start;
+- (void) stop;
+- (void) postRecordedExpression:(id) arg1;
+- (void) postElementNotFoundAtPoint:(struct CGPoint) arg1 description:(id) arg2;
+- (void) postStaleEventMessage;
+- (void) postMutlitouchGestureDetected;
+- (void) handleAlert;
+- (void) handleOrientationChange;
+- (void) _releaseEvents;
+- (id) _scriptingStringForPoint:(struct CGPoint) arg1;
+- (id) _scriptingStringForOffsetWithScreenPoint:(struct CGPoint) arg1 inRect:(struct CGRect) arg2;
+- (void) markNewActionAndLog:(BOOL) arg1;
+- (void) flushTapExpression:(id) arg1;
+- (void) flushDragExpressions:(id) arg1;
+- (void) flushKeystrokes:(id) arg1;
 @property double lastActionTime; // @synthesize lastActionTime=_lastActionTime;
-@property(assign)id delegate; // @synthesize delegate=_delegate;
+@property(assign) id delegate; // @synthesize delegate=_delegate;
 @property BOOL isRecording; // @synthesize isRecording=_isRecording;
 @property(retain) NSArray *pendingTapExpression; // @synthesize pendingTapExpression=_pendingTapExpression;
 @property(retain) UIAXElement *previousAXElement; // @synthesize previousAXElement=_previousAXElement;
@@ -1064,16 +1024,17 @@
 @property(readonly) UIATarget *uiaTarget; // @synthesize uiaTarget=_uiaTarget;
 
 @end
+
 @interface NSValue (UIAutomation)
-- (id)origin;
-- (id)x;
-- (id)y;
-- (id)size;
-- (id)width;
-- (id)height;
+- (id) origin;
+- (id) x;
+- (id) y;
+- (id) size;
+- (id) width;
+- (id) height;
 @end
 
 @interface NSArray (UIAExtras)
-- (unsigned int)_uiaUniqueIndexOfObject:(id)arg1;
+- (unsigned int) _uiaUniqueIndexOfObject:(id) arg1;
 @end
 


### PR DESCRIPTION
## action items

@krukow
@jmoody
- [x] review changes with Karl
- [x] decide whether to merge https://github.com/calabash/calabash-ios-server/pull/30 first
- [x] merge after 0.9.167
- [x] merge before [branch repositioning - google forums](https://groups.google.com/d/msg/calabash-ios/jX61SeuXlQk/A8OQp4ER75cJ)

supercedes:  https://github.com/calabash/calabash-ios-server/pull/32
## motivation

I had to deal with a pull request recently on a file with some truly bizarre formatting that made the diff very difficult to understand.  

Looking at the project as a whole, I identified these issues:
- Xcode project says indent 4 spaces, but some files have tab characters (\t) and different indent settings
- there was whitespace everywhere (newlines and trailing spaces)
- there was no formatting convention follow - every file adopted its own convention or multiple conventions
## strategy

This pull request has _no_ semantic changes.  All the changes are to the formatting.

Because they were 3rd party or submodules, I did not touch these directories:
- Classes/CocoaAsyncSocket
- Classes/CocoaHttpServer
- Classes/JSON 
- LPCDDataScanner.*
- calabash-js/  
###### important
- [x] LPQueryAllOperation.m contains tab characters and inconsistent formatting
  - I did not touch this file in case you want to merge pull request https://github.com/calabash/calabash-ios-server/pull/30
## what i did
- [x] tabs ==> spaces
- [x] reformatted all the source files using AppCode
  - indent 2 spaces 
  - wrap to 80 characters
  - uniform spacing between method bodies
  - `- (void) play:(NSArray *) events` signature style
  - 'smart' argument wrapping
  - manual formatting
- [x] stripped trailing whitespace in _most_ of the files
- [x] removed unused imports
- [x] Xcode project indent is now 2 (was 4)
- [x] Xcode project Organization is now Xamarin
- [x] Xcode project Class prefix is now LP
## questions
- [x] copyright at the top of source files - **we have to keep these** :(
  - LessPainful ==> { Xamarin | remove } 
  - +1 to remove (hard to maintain, ambiguous meaning, visual clutter, opaque to Xcode refactoring, generally useless)
  - [x] Trevor Harmon - LPExitRoute.h/m copyright
  - [x] Jim McBeath - LPAppPropertyRoute and LPLogQueryRoute
- [ ] modernize objc.
## bugs
- [ ] LPEnv.m `[super dealloc]` must be called _last_
- [ ] LPJSONUtils call to `respondsToSelector` is made on `result` and not on `object`
- [ ] LPReflectUtils is missing a return in `invokeSpec:onTarget:withError` and the default switch case is not defined
- [ ] LPUIAChannel [super dealloc] should be called _last_
## analysis
- [ ] should suppress unused variable warnings in LPSetTextOperation with __unused
  - [ ] similar problem in calabash-js/CalabashJS/LPWebQuery.h
  - [ ] why are these not extern'd or in the .m file? 
  - [ ] should i just fix this?
- [ ] fix or suppress unused variable warnings in calabash-js/CalabashJS/LPWebQuery.h
- [ ] should suppress undeclared selector warning is GCDAsyncSocket and LPHTTPServer with clang diagnostics push/pop
- [ ] LPSetTextOperation.h the static variable should externed or moved to the .m
- [ ] LPDebugRoute. result dictionary is never used
- [ ] LPGenericAsync suspicious conversion of UInt64 to -1
- [ ] LPKeyboardRoute missing dealloc method and `_events` ivar is not released
- [ ] LPLocationRoute missing import of UIAutomation.h 
- [ ] LPQueryLogRoute has 2 suspicious unbalanced retains
- [ ] LPScreenshotRoute2 remove or change the name?
- [ ] MKMapView+ZoomLevel.m suspicious conversion of double to NSUInteger 
- [ ] LPRecorder dealloc does not playbackDelegate but it retains it
  - this is a singleton and dealloc is never called, but...
## recommendations
- [ ] drop iOS 4 support and bump min version to 5.1.1 to compile for x86_64
- [ ] turn on verbose warnings
- [ ] update 3rd Party Sources by building them as .a?
## tests

Since there are no semantic changes, I did not run an exhaustive test suite.
- [x] iPad 4 iOS 7.0.4 - 142 scenarios (5 pending, 137 passed) **woot!**
### XTC

```
Apple iPad 2 (6.1.3)
Apple iPad 4th Gen (7.0.4)
Apple iPad Mini Retina (7.0.4)
Apple iPhone 4S (6.1.3)
Apple iPhone 4S (7.0.4)
Apple iPhone 5C (7.0.4)
Apple iPhone 5 (7.0.4)
```
