### PR TITLE
"index" keyword used in combination with the "all" keyword is not handled correctly when targeting tableView/collectionView cells

### DIFF
--- a/calabash/Classes/UISpec/UIScriptASTClassName.m
+++ b/calabash/Classes/UISpec/UIScriptASTClassName.m
@@ -85,10 +85,10 @@ static NSInteger sortFunction(UIView *v1, UIView *v2, void *ctx) {
     NSInteger sections = [dataSource numberOfSectionsInCollectionView: collectionView];
     for (NSInteger section = 0; section < sections; section++)
     {
-      NSInteger rows = [dataSource collectionView: collectionView numberOfItemsInSection: section];
-      for (NSInteger row = 0; row < rows; row++)
+      NSInteger items = [dataSource collectionView: collectionView numberOfItemsInSection: section];
+      for (NSInteger item = 0; item < items; item++)
       {
-        UICollectionViewCell * cell = [dataSource collectionView: collectionView cellForItemAtIndexPath: [NSIndexPath indexPathForRow: row inSection: section]];
+        UICollectionViewCell * cell = [dataSource collectionView: collectionView cellForItemAtIndexPath: [NSIndexPath indexPathForItem: item inSection: section]];
         if (cell)
           [cells addObject: cell];
       }


### PR DESCRIPTION
When executing queries like : query("all tableView tableViewCell index:5"), if the 6th cell is out of the screen, the result depend of the query can change if the cell has been reused/already displayed and so on.. 

In order to fix this, when using the "all" keyword, the data source of the tableView/collectionView are called to retrieve the cells. So the index:5 returns the cell that tableView:cellForRowAtIndexPath: {0,5} would have returned.
