### PR TITLE
Support alternative Xcode6 pref plist path

### DIFF
--- a/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
+++ b/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
@@ -210,7 +210,17 @@ const static NSTimeInterval LPUIAChannelUIADelay = 0.1;
     NSString *userDirectoryPath = [userDirURL path];
 
     // 2. get out of our application directory, back to the root support directory for this system version
-    plistRootPath = [userDirectoryPath substringToIndex:([userDirectoryPath rangeOfString:@"Applications"].location)];
+    NSRange appsIndex = [userDirectoryPath rangeOfString:@"Applications"];
+    if (appsIndex.location == NSNotFound) {
+      appsIndex = [userDirectoryPath rangeOfString:@"Containers"];
+    }
+    if (appsIndex == NSNotFound) {
+      NSLog(@"Unable to find simulator app preferences path in: %@", userDirectoryPath);
+      path = nil;
+      return;
+    }
+
+    plistRootPath = [userDirectoryPath substringToIndex:appsIndex.location];
 
     // 3. locate, relative to here, /Library/Preferences/[bundle ID].plist
     relativePlistPath = [NSString stringWithFormat:@"Library/Preferences/%@", plistName];


### PR DESCRIPTION
With Xcode6 user preferences have paths similar to:

```
/Users/krukow/Library/Developer/CoreSimulator/Devices/0181D092-6792-4358-9B70-9348A7DC8061/data/Library/Preferences/com.lesspainful.example.LPSimpleExample.plist
```

we need to support this for simulator tests.
