### PR TITLE
Removes UIDevice uniqueIdentifier call

### DIFF
--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -143,15 +143,6 @@
                                          [info objectForKey:@"CFBundleIdentifier"], @"app_id",
                                          [info objectForKey:@"CFBundleVersion"], @"app_version",
                                          nil];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    if ([[UIDevice currentDevice]
-         respondsToSelector:@selector(uniqueIdentifier)]) {
-      id uuid = [[UIDevice currentDevice]
-                 performSelector:@selector(uniqueIdentifier) withObject:nil];
-      [capabilities setObject:uuid forKey:@"uuid"];
-    }
-#pragma clang diagnostic pop
     [_httpServer setTXTRecordDictionary:capabilities];
     [_httpServer setConnectionClass:[LPRouter class]];
     [_httpServer setPort:37265];


### PR DESCRIPTION
As of Xcode 6, uniqueIdentifier is not available to 3rd party vendors.

We thought this might be causing this output in iOS 8 GM, but it is not.

```
MobileGestaltHelper[909] <Error>: libMobileGestalt MobileGestalt.c:273: server_access_check denied access to question UniqueDeviceID for pid 796 
ScriptAgent[796] <Error>: libMobileGestalt MobileGestaltSupport.m:170: pid 796 (ScriptAgent) does not have sandbox access for re6Zb+zwFKJNlkQTUeT+/w and IS NOT appropriately entitled
ScriptAgent[703] <Error>: libMobileGestalt MobileGestalt.c:534: no access to UniqueDeviceID (see <rdar://problem/11744455>)
```
### On Device Tests

Locally against iOS 6, 7, and 8 GM.
