### PR TITLE
Gracefully exit the app

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPExitRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPExitRoute.m
@@ -57,11 +57,25 @@
 
   // See discussion above.
   int exitCode = 0;
+  NSNumber *payloadExitCode = [data objectForKey:@"exit_code"];
+  if (payloadExitCode) {
+    exitCode = [payloadExitCode intValue];
+  }
 
   NSTimeInterval defaultDelay = 0.4;
 
   NSTimeInterval postResignActiveDelay = defaultDelay;
   NSTimeInterval postWillTerminateDelay = defaultDelay;
+
+  NSNumber *payloadDelay = [data objectForKey:@"post_resign_active_delay"];
+  if (payloadDelay) {
+    postResignActiveDelay = [payloadDelay doubleValue];
+  }
+
+  payloadDelay = [data objectForKey:@"post_will_terminate_delay"];
+  if (payloadDelay) {
+    postWillTerminateDelay = [payloadDelay doubleValue];
+  }
 
   UIApplication *shared = [UIApplication sharedApplication];
 


### PR DESCRIPTION
We initially thought that `calabash_exit` was causing Briar (and others) to crash iOS 8 devices. [1]

Karl did some testing on the XTC and found that `calabash_exit` was nearly doubling the runtimes.

Ultimately, I discovered the problem was not in `calabash_exit`.  Along the way, I struck upon this nice strategy to exit the app gracefully.

What is nice about this solution is that the UIApplicationDelegate's `applicationWillResignActive:` and `applicationWillTerminate:` selectors are both called before the app is terminated.

Companion:  https://github.com/calabash/calabash-ios/pull/520
### Todo
- [x] Decide whether or not to always call `exit`; even when calling terminateWithSuccess
  - [ ] YES
  - [x] NO
- [x] What is the default exit code?
  - [x] 3
  - [ ] 0
- [x] Can stopping the server be in a different PR?  https://github.com/calabash/calabash-ios/issues/527
  - [x] YES
  - [ ] NO

```
saturn Briar-cal[340] <Warning>: Received http exit.
saturn Briar-cal[340] <Warning>: Calling [[UIApplication delegate] applicationWillResignActive] after a delay of 0.4 s
saturn Briar-cal[340] <Warning>: application will resign active
saturn Briar-cal[340] <Warning>: Calling [UIApplication willTerminate].
saturn Briar-cal[340] <Warning>: Calling [UIApplication terminateWithSuccess] after a delay of 0.4 s
saturn Briar-cal[340] <Warning>: application will terminate
saturn SpringBoard[48] <Warning>: Unable to get short BSD proc info for 340: No such process
saturn SpringBoard[48] <Warning>: Application 'UIKitApplication:com.littlejoysoftware.Briar-cal[0x1993]' exited voluntarily.
```
