### PR TITLE
Fix 4inch detection

### DIFF
--- a/calabash/Classes/Utils/LPTouchUtils.m
+++ b/calabash/Classes/Utils/LPTouchUtils.m
@@ -24,7 +24,7 @@
   BOOL iphone5Like = NO;
   if ([@"iPhone Simulator" isEqualToString:[device model]]) {
 
-    NSPredicate *inch5PhonePred = [NSPredicate predicateWithFormat:@"IPHONE_SIMULATOR_VERSIONS LIKE '*iPhone*Retina*4-inch*'"];
+    NSPredicate *inch5PhonePred = [NSPredicate predicateWithFormat:@"IPHONE_SIMULATOR_VERSIONS LIKE '*iPhone*Retina*4-inch*' OR SIMULATOR_VERSION_INFO LIKE '*iPhone 5*' OR SIMULATOR_VERSION_INFO LIKE '*iPhone 6*'"];
     iphone5Like = [inch5PhonePred evaluateWithObject:env];
   } else if ([[device model] hasPrefix:@"iPhone"]) {
     iphone5Like = [system hasPrefix:@"iPhone5"] || [system hasPrefix:@"iPhone6"];


### PR DESCRIPTION
Hi!
The 4inch detection was broken so I patched it.

That is said, I think that the new resolutions of 6 and 6 Plus made it obsolete.
I guess we should introduce something new like "resolution" and return 640x960, 640x1136, 750x1334, 1242x2208.

What do you think?
