### PR TITLE
Stabilize Travis CI for Xcode 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ script:
   - make clean
   - make framework
   - make frank
-  - make dylibs
-  - make all
+  # Dylib creation is allowed by Xcode 6, but it requires
+  # code-signing which is not easy to set up on Travis CI.
+  #- make dylibs
+  #- make all
   # The CoreSimulator environment on Travis CI is not ready
   # for calabash testing.  The 'chou' tests are cucumber
   # tests.


### PR DESCRIPTION
Travis CI transitioned to Xcode 6.
- Disabled simulator 'chou' tests; the Core Simulator environment is not stable enough for testing.
- Now using default pre-installed ruby 2.0.0 instead of installing ruby 2.1.1 with rvm (broken).
- Dylibs can be created in Xcode 6, but they require code signing.  Dylib tests are still disabled in Travis CI
