### PR TITLE
Fix change in Preferences path for Xcode6.1 simulators

### DIFF
--- a/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
+++ b/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
@@ -213,8 +213,8 @@ const static NSTimeInterval LPUIAChannelUIADelay = 0.1;
 // It is not clear whether or not the fact that file does not exist until
 // the app tries to store something will influence UIA interactions.
 // // Xcode 6.1
-// ~/Library/Developer/CoreSimulator/Devices/[UDID]/data/Library/Preferences/[bundle ID].plist
-// see http://stackoverflow.com/questions/4977673/reading-preferences-set-by-uiautomations-uiaapplication-setpreferencesvaluefork
+// ~/Library/Developer/CoreSimulator/Devices/[Sim UDID]/data/Containers/Data/Application/[App UDID]/Library/Preferences/[bundle id].plist
+
 
 
 - (NSString *)simulatorPreferencesPath {


### PR DESCRIPTION
In Xcode 6.1 preferences changed again to:

```
~/Library/Developer/CoreSimulator/Devices/2471BD90-9A5E-484A-B31B-2B65CA39FBAE/data/Containers/Data/Application/580B0EC9-4552-43B5-A0A1-A188AAE589A5/Library/Preferences/[bundle id].plist
```
