### PR TITLE
Releasing 'tokenValue' too early

### DIFF
--- a/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
+++ b/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
@@ -230,7 +230,6 @@ const static NSTimeInterval LPUIAChannelUIADelay = 0.1;
     [[NSUserDefaults standardUserDefaults] setObject:tokenValue forKey:tokenKey];
 
     if (udid != NULL) { CFRelease(udid);  }
-    if (tokenValue) { [tokenValue release]; }
 
     [[NSUserDefaults standardUserDefaults] synchronize];
 
@@ -262,6 +261,8 @@ const static NSTimeInterval LPUIAChannelUIADelay = 0.1;
                                                                 plistName:plistName] copy];
       }
     }
+
+    if (tokenValue) { [tokenValue release]; }
   });
   NSLog(@"NSUserDefaults path = %@", path);
   return path;


### PR DESCRIPTION
Causes occasional crashes.

**FIX** Intermittent crashing when testing against iOS Simulators. https://github.com/calabash/calabash-ios/issues/582
