### PR TITLE
Add archicture flags to Xcodebuild args

### DIFF
--- a/scripts/make-calabash-lib.rb
+++ b/scripts/make-calabash-lib.rb
@@ -26,9 +26,11 @@ else
   if target == 'sim'
     target_arg = 'calabash-simulator'
     sdk = 'iphonesimulator'
+    arches = 'i386 x86_64'
   else
     target_arg = 'calabash-device'
     sdk = 'iphoneos'
+    arches = 'armv7 armv7s arm64'
   end
   args =
         [
@@ -36,6 +38,9 @@ else
               "-scheme \"#{target_arg}\"",
               '-configuration Debug',
               'SYMROOT=build',
+              "ARCHS=\"#{arches}\"",
+              "VALID_ARCHS=\"#{arches}\"",
+              'ONLY_ACTIVE_ARCH=NO',
               '-derivedDataPath build',
               "-sdk #{sdk}",
               'IPHONEOS_DEPLOYMENT_TARGET=5.1.1',

--- a/scripts/make-frank-lib.rb
+++ b/scripts/make-frank-lib.rb
@@ -13,9 +13,11 @@ xcpretty_available = `gem list xcpretty -i`.chomp == 'true'
 if target == 'sim'
   target_arg = 'frank-calabash-simulator'
   sdk = 'iphonesimulator'
+  arches = 'i386 x86_64'
 else
   target_arg = 'frank-calabash-device'
   sdk = 'iphoneos'
+  arches = 'armv7 armv7s arm64'
 end
 
 args =
@@ -25,6 +27,9 @@ args =
             '-configuration Debug',
             'SYMROOT=build',
             '-derivedDataPath build',
+            "ARCHS=\"#{arches}\"",
+            "VALID_ARCHS=\"#{arches}\"",
+            'ONLY_ACTIVE_ARCH=NO',
             "-sdk #{sdk}",
             'IPHONEOS_DEPLOYMENT_TARGET=5.1.1',
             xcpretty_available ? '| xcpretty -c' : ''


### PR DESCRIPTION
At some point, Xcode 5.1.1 stopped building the x86_64 frank and calabash libraries.

This was not caught sooner, because the verification test was flawed; FIXED #95 
