### PR TITLE
XCTests will fail on compilation errors

### DIFF
--- a/scripts/test/xctest.rb
+++ b/scripts/test/xctest.rb
@@ -2,7 +2,9 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'test-helpers'))
 
 working_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
-xcpretty_available = `gem list xcpretty -i`.chomp == 'true'
+
+# See the note below about why we cannot use xcpretty.
+#xcpretty_available = `gem list xcpretty -i`.chomp == 'true'
 
 XCODE_MAJOR_VERSION=`xcrun -k xcodebuild -version | tr -d "\n" | cut -c 7`.chomp
 if XCODE_MAJOR_VERSION == '5'
@@ -21,11 +23,23 @@ args =
             '-scheme calabash-ios-server-tests',
             "-destination 'platform=iOS Simulator,name=#{target_simulator_name},OS=latest'",
             '-sdk iphonesimulator',
-            '-configuration Debug',
-            xcpretty_available ? '| xcpretty -c' : ''
+            '-configuration Debug'
+      # See the note below about why we cannot use xcpretty.
+      # xcpretty_available ? '| xcpretty -c' : ''
       ]
 
 Dir.chdir(working_dir) do
   terminate_all_sims
-  do_system "xcrun xcodebuild #{args.join(' ')}"
+  # Would like to use xcpretty here, but there are two problems.
+  #
+  # 1. xcodebuild + test + xcpretty does _not_ return a non-zero exit code
+  #    when there is a compilation error.
+  # 2. We cannot use xcodebuild _without_ xcpretty on Travis CI; there is too
+  #    much output to stdout and the build will fail.
+  #
+  # To compensate, we don't use xcpretty and suppress xcodebuild output.
+  cmd = "xcrun xcodebuild #{args.join(' ')} > /dev/null"
+  do_system(cmd,
+            {:pass_msg => 'XCTests passed',
+             :fail_msg => 'XCTests failed'})
 end


### PR DESCRIPTION
**Undefined symbols for architecture i386 > Symbol: _OBJC_CLASS_$_LPUIARouteOverSharedElement > Referenced from: objc-class-ref in CalabashServer.o** [#629](https://github.com/calabash/calabash-ios/issues/629)

Tests that should fail are passing.  This pull request addresses this problem.

This PR will fail on travis; it is expected.
