### PR TITLE
LPInvoker: bridge invocation result into ARC

### DIFF
--- a/calabash/Classes/Utils/LPInvoker.m
+++ b/calabash/Classes/Utils/LPInvoker.m
@@ -110,9 +110,14 @@ NSString *const LPUnspecifiedInvocationError = @"*invocation error*";
 
   if ([invoker selectorReturnsObject]) {
     NSInvocation *invocation = invoker.invocation;
-    id result;
+
+    NSUInteger length = [invoker.signature methodReturnLength];
+    void *buffer = (void *) malloc(length);
+
     [invocation invoke];
-    [invocation getReturnValue:&result];
+    [invocation getReturnValue:&buffer];
+
+    id result = (__bridge id)buffer;
 
     if(!result) {
       return [NSNull null];


### PR DESCRIPTION
#### Motivation

Fixes bad accesses in downstream calls to dealloc on the `NSDictionary` created by `LPJSONUtils jsonsifyView`.

The problem was revealed by integration tests in calabash-ios; test apps were crashing during certain API calls.