### PR TITLE
WIP fixes several examples of success checks against NSError

### DIFF
--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -36,7 +36,7 @@
   LPCJSONSerializer *s = [LPCJSONSerializer serializer];
   NSError *error = nil;
   NSData *d = [s serializeDictionary:dictionary error:&error];
-  if (error) {
+  if (!d) {
     NSLog(@"Unable to serialize dictionary (%@), %@", error, dictionary);
   }
   NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
@@ -49,7 +49,7 @@
   NSError *error = nil;
   NSDictionary *res = [ds deserializeAsDictionary:[string dataUsingEncoding:NSUTF8StringEncoding]
                                             error:&error];
-  if (error) {
+  if (!res) {
     NSLog(@"Unable to deserialize  %@", string);
   }
   return res;
@@ -59,8 +59,8 @@
   LPCJSONSerializer *s = [LPCJSONSerializer serializer];
   NSError *error = nil;
   NSData *d = [s serializeArray:array error:&error];
-  if (error) {
-    NSLog(@"Unable to serialize arrayy (%@), %@", error, array);
+  if (!d) {
+    NSLog(@"Unable to serialize array (%@), %@", error, array);
   }
   NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
                                          encoding:NSUTF8StringEncoding];
@@ -73,7 +73,7 @@
   NSError *error = nil;
   NSArray *res = [ds deserializeAsArray:[string dataUsingEncoding:NSUTF8StringEncoding]
                                   error:&error];
-  if (error) {
+  if (!res) {
     NSLog(@"Unable to deserialize  %@", string);
   }
   return res;
@@ -84,7 +84,7 @@
   LPCJSONSerializer *s = [LPCJSONSerializer serializer];
   NSError *error = nil;
   NSData *d = [s serializeObject:obj error:&error];
-  if (error) {
+  if (!d) {
     NSLog(@"Unable to serialize object (%@), %@", error, [obj description]);
   }
   NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]


### PR DESCRIPTION
**WIP**  Expect more changes.

> Important Success or failure is indicated by the return value of the method. Although Cocoa methods that indirectly return error objects in the Cocoa error domain are guaranteed to return such objects if the method indicates failure by directly returning nil or NO, you should always check that the return value is nil or NO before attempting to do anything with the NSError object.

In this case, I don't think there is any harm, because we control the class that is being called.  However, it is not a good pattern.

Not for 0.12.3 release.
