### PR TITLE
Prefer to run cli tests with xcpretty

### DIFF
--- a/scripts/test/xctest.rb
+++ b/scripts/test/xctest.rb
@@ -3,8 +3,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'test-helpers')
 
 working_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
 
-# See the note below about why we cannot use xcpretty.
-#xcpretty_available = `gem list xcpretty -i`.chomp == 'true'
+xcpretty_available = `gem list xcpretty -i`.chomp == 'true'
 
 XCODE_MAJOR_VERSION=`xcrun -k xcodebuild -version | tr -d "\n" | cut -c 7`.chomp
 if XCODE_MAJOR_VERSION == '5'
@@ -23,22 +22,13 @@ args =
             '-scheme calabash-ios-server-tests',
             "-destination 'platform=iOS Simulator,name=#{target_simulator_name},OS=latest'",
             '-sdk iphonesimulator',
-            '-configuration Debug'
-      # See the note below about why we cannot use xcpretty.
-      # xcpretty_available ? '| xcpretty -c' : ''
+            '-configuration Debug',
+            xcpretty_available ? '| xcpretty -tc && exit ${PIPESTATUS[0]}' : ''
       ]
 
 Dir.chdir(working_dir) do
   terminate_all_sims
-  # Would like to use xcpretty here, but there are two problems.
-  #
-  # 1. xcodebuild + test + xcpretty does _not_ return a non-zero exit code
-  #    when there is a compilation error.
-  # 2. We cannot use xcodebuild _without_ xcpretty on Travis CI; there is too
-  #    much output to stdout and the build will fail.
-  #
-  # To compensate, we don't use xcpretty and suppress xcodebuild output.
-  cmd = "xcrun xcodebuild #{args.join(' ')} > /dev/null"
+  cmd = "xcrun xcodebuild #{args.join(' ')}"
   do_system(cmd,
             {:pass_msg => 'XCTests passed',
              :fail_msg => 'XCTests failed'})


### PR DESCRIPTION
### Motivation

We've been piping to xcodebuild output to `> /dev/null` because travis does not allow the HUGE amount of output xcodebuild generates.

We would like to use xcpretty, but were having problems handling the exit code.  In particular, if there was a compile error, xcpretty would report success.

I believe this change does the right thing and forwards the correct xcodebuild exit code in all cases.