### PR TITLE
Replace dumpView:toDictionary w/ insertHitPointIntoMutableDictionary:

### DIFF
--- a/calabash-ios-server-tests/LPJSONUtilsTest.m
+++ b/calabash-ios-server-tests/LPJSONUtilsTest.m
@@ -40,6 +40,7 @@
          respondsTo:(SEL) selector;
 
 + (NSMutableDictionary *) dictionaryByEncodingView:(id) view;
++ (void) insertHitPointIntoMutableDictionary:(NSMutableDictionary *) dictionary;
 
 @end
 
@@ -712,6 +713,42 @@
   XCTAssertEqualObjects(dict[@"value"], [NSNull null]);
   XCTAssertEqualObjects(dict[@"visible"], @(1));
   XCTAssertEqual([dict count], 10);
+}
+
+#pragma mark - insertHitPointIntoMutableDictionary:
+
+- (void) testInsertHitPointIntoMutableDictionaryArgNotMutable {
+  id dict = @{};
+  [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
+  XCTAssertTrue([dict count] == 0);
+}
+
+- (void) testInsertHitPointIntoMutableDictionaryNoRectInDictionary {
+  NSMutableDictionary *dict = [@{} mutableCopy];
+  [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
+  XCTAssertTrue([dict count] == 0);
+}
+
+- (void) testInsertHitPointIntoMutableDictionaryRectHasNoCenterX {
+  NSMutableDictionary *dict = [@{@"rect" : @{@"center_y" : @(55)}} mutableCopy];
+  [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
+  XCTAssertTrue([dict count] == 1);
+}
+
+- (void) testInsertHitPointIntoMutableDictionaryRectHasNoCenterY {
+  NSMutableDictionary *dict = [@{@"rect" : @{@"center_x" : @(55)}} mutableCopy];
+  [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
+  XCTAssertTrue([dict count] == 1);
+}
+
+- (void) testInsertHitPointIntoMutableDictionary {
+  NSDictionary *rect = @{@"rect" : @{@"center_x" : @(55), @"center_y" : @(65)}};
+  NSMutableDictionary *dict = [rect mutableCopy];
+  [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
+  XCTAssertTrue([dict count] == 2);
+  XCTAssertEqualObjects(dict[@"hit-point"][@"x"], @(55));
+  XCTAssertEqualObjects(dict[@"hit-point"][@"y"], @(65));
+  XCTAssertNotNil(dict[@"rect"]);
 }
 
 @end

--- a/calabash-ios-server-tests/LPJSONUtilsTest.m
+++ b/calabash-ios-server-tests/LPJSONUtilsTest.m
@@ -726,19 +726,31 @@
 - (void) testInsertHitPointIntoMutableDictionaryNoRectInDictionary {
   NSMutableDictionary *dict = [@{} mutableCopy];
   [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
-  XCTAssertTrue([dict count] == 0);
+  XCTAssertTrue([dict count] == 1);
+  NSDictionary *hitPoint = dict[@"hit-point"];
+  XCTAssertNotNil(hitPoint);
+  XCTAssertEqualObjects(hitPoint[@"x"], [NSNull null]);
+  XCTAssertEqualObjects(hitPoint[@"y"], [NSNull null]);
 }
 
 - (void) testInsertHitPointIntoMutableDictionaryRectHasNoCenterX {
   NSMutableDictionary *dict = [@{@"rect" : @{@"center_y" : @(55)}} mutableCopy];
   [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
-  XCTAssertTrue([dict count] == 1);
+  XCTAssertTrue([dict count] == 2);
+  NSDictionary *hitPoint = dict[@"hit-point"];
+  XCTAssertNotNil(hitPoint);
+  XCTAssertEqualObjects(hitPoint[@"x"], [NSNull null]);
+  XCTAssertEqualObjects(hitPoint[@"y"], @(55));
 }
 
 - (void) testInsertHitPointIntoMutableDictionaryRectHasNoCenterY {
   NSMutableDictionary *dict = [@{@"rect" : @{@"center_x" : @(55)}} mutableCopy];
   [LPJSONUtils insertHitPointIntoMutableDictionary:dict];
-  XCTAssertTrue([dict count] == 1);
+  XCTAssertTrue([dict count] == 2);
+  NSDictionary *hitPoint = dict[@"hit-point"];
+  XCTAssertNotNil(hitPoint);
+  XCTAssertEqualObjects(hitPoint[@"x"], @(55));
+  XCTAssertEqualObjects(hitPoint[@"y"], [NSNull null]);
 }
 
 - (void) testInsertHitPointIntoMutableDictionary {

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -18,6 +18,9 @@
     setObjectforKey:(NSString *) key
          whenTarget:(id) target
          respondsTo:(SEL) selector;
+
++ (void) insertHitPointIntoMutableDictionary:(NSMutableDictionary *) dictionary;
+
 @end
 
 @implementation LPJSONUtils
@@ -108,7 +111,7 @@
   else if ([object isKindOfClass:[UIView class]]) {
     NSMutableDictionary *viewJson = [self dictionaryByEncodingView:(UIView*) object];
     if (dump) {
-      [self dumpView: object toDictionary:viewJson];
+      [LPJSONUtils insertHitPointIntoMutableDictionary:viewJson];
       if (viewJson[@"class"]) {
         viewJson[@"type"] = viewJson[@"class"];
         [viewJson removeObjectForKey:@"class"];
@@ -357,10 +360,19 @@
   return result;
 }
 
-+(void)dumpView:(UIView*) view toDictionary:(NSMutableDictionary*)viewJson {
-  NSDictionary *rect = viewJson[@"rect"];
 
-  viewJson[@"hit-point"] = @{@"x": rect[@"center_x"], @"y": rect[@"center_y"]};
++ (void) insertHitPointIntoMutableDictionary:(NSMutableDictionary *) dictionary {
+  SEL selector = @selector(setObject:forKey:);
+  if (![dictionary respondsToSelector:selector]) { return ; }
+
+  NSDictionary *rect = dictionary[@"rect"];
+  if (!rect) { return; }
+
+  id centerX = rect[@"center_x"];
+  id centerY = rect[@"center_y"];
+  if (!centerX || !centerY) { return; }
+
+  dictionary[@"hit-point"] = @{@"x" : centerX, @"y" : centerY};
 }
 
 +(void)dumpAccessibilityElement:(id)object toDictionary:(NSMutableDictionary*)viewJson {

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -365,12 +365,17 @@
   SEL selector = @selector(setObject:forKey:);
   if (![dictionary respondsToSelector:selector]) { return ; }
 
-  NSDictionary *rect = dictionary[@"rect"];
-  if (!rect) { return; }
+  id centerX = [NSNull null];
+  id centerY = [NSNull null];
 
-  id centerX = rect[@"center_x"];
-  id centerY = rect[@"center_y"];
-  if (!centerX || !centerY) { return; }
+  NSDictionary *rect = dictionary[@"rect"];
+  if (rect) {
+    id tmpX = rect[@"center_x"];
+    if (tmpX) { centerX = tmpX; }
+
+    id tmpY = rect[@"center_y"];
+    if (tmpY) { centerY = tmpY; }
+  }
 
   dictionary[@"hit-point"] = @{@"x" : centerX, @"y" : centerY};
 }


### PR DESCRIPTION
### Motivation

The original implementation was, in some cases, trying to insert `nil` values into a dictionary.

@krukow Looking back on the fix, it occurs to me, you might always _want_ a `hit-point` key.