### PR TITLE
Modernize screenshot route

### DIFF
--- a/calabash-ios-server-tests/LPScreenshotRouteTest.m
+++ b/calabash-ios-server-tests/LPScreenshotRouteTest.m
@@ -9,6 +9,7 @@
 
 - (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method
                                                   URI:(NSString *) path;
+- (NSData *) takeScreenshot;
 
 @end
 

--- a/calabash-ios-server-tests/LPScreenshotRouteTest.m
+++ b/calabash-ios-server-tests/LPScreenshotRouteTest.m
@@ -3,11 +3,54 @@
 #endif
 
 #import "LPScreenshotRoute.h"
+#import "LPHTTPResponse.h"
 
-@interface LPScreenshotRouteTest : XCTestCase
+@interface LPScreenshotRoute (LPTEST)
+
+- (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method
+                                                  URI:(NSString *) path;
 
 @end
 
-@implementation LPScreenshotRouteTest
+SpecBegin(LPScreenshotRoute)
 
-@end
+describe(@"LPScreenshotRoute", ^{
+
+  describe(@"#supportsMethod:atPath:", ^{
+    it(@"returns true for GET", ^{
+      LPScreenshotRoute *route = [LPScreenshotRoute new];
+      BOOL expected = [route supportsMethod:@"GET" atPath:nil];
+      expect(expected).to.equal(YES);
+    });
+
+    it(@"returns false otherwise", ^{
+      LPScreenshotRoute *route = [LPScreenshotRoute new];
+      BOOL expected = [route supportsMethod:@"BAR" atPath:nil];
+      expect(expected).to.equal(NO);
+    });
+  });
+
+  describe(@"#httpResponseForMethod:URI:", ^{
+    it(@"returns an object that conforms to LPHTTPResponse", ^{
+      LPScreenshotRoute *route = [LPScreenshotRoute new];
+      id mock = OCMPartialMock(route);
+      OCMExpect([mock takeScreenshot]).andReturn([NSData data]);
+
+      id result = [mock httpResponseForMethod:nil URI:nil];
+      XCTAssertNotNil(result);
+      expect(result).to.conformTo(@protocol(LPHTTPResponse));
+      OCMVerify([mock takeScreenshot]);
+    });
+  });
+
+  describe(@"#takeScreenshot", ^{
+    it(@"returns data", ^{
+      LPScreenshotRoute *route = [LPScreenshotRoute new];
+      NSData *result = [route takeScreenshot];
+      XCTAssertNotNil(result);
+      expect(result).to.beKindOf([NSData class]);
+    });
+  });
+});
+
+SpecEnd

--- a/calabash-ios-server-tests/LPScreenshotRouteTest.m
+++ b/calabash-ios-server-tests/LPScreenshotRouteTest.m
@@ -1,0 +1,13 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPScreenshotRoute.h"
+
+@interface LPScreenshotRouteTest : XCTestCase
+
+@end
+
+@implementation LPScreenshotRouteTest
+
+@end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -79,7 +79,7 @@
 		B11358601981B053004B16F4 /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
 		B11358611981B053004B16F4 /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; };
 		B11358621981B053004B16F4 /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
-		B11358631981B053004B16F4 /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; };
+		B11358631981B053004B16F4 /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B11358641981B053004B16F4 /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; };
 		B11358651981B053004B16F4 /* LPSetTextOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDCB14B6DB2B002A744C /* LPSetTextOperation.m */; };
 		B13B7FBF1A31FE560054FFB1 /* LPDumpRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B13B7FBD1A31FE560054FFB1 /* LPDumpRoute.h */; };
@@ -215,7 +215,7 @@
 		B15BFA1819ABB2B100B38577 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA1919ABB2B100B38577 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA1A19ABB2B100B38577 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B15BFA1B19ABB2B100B38577 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B15BFA1B19ABB2B100B38577 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; };
 		B15BFA1C19ABB2B100B38577 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA1D19ABB2B100B38577 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA1E19ABB2B100B38577 /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -297,7 +297,7 @@
 		B1D5BD9A19A23BCE0070E8CE /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		B1D5BD9B19A23BCE0070E8CE /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
 		B1D5BD9C19A23BCE0070E8CE /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
-		B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; };
+		B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9E19A23BCE0070E8CE /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		B1D5BD9F19A23BCE0070E8CE /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
 		B1D5BDA019A23BCE0070E8CE /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
@@ -443,7 +443,7 @@
 		F5091BFB18C4E1D700C85307 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		F5091BFC18C4E1D700C85307 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
 		F5091BFD18C4E1D700C85307 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
-		F5091BFE18C4E1D700C85307 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; };
+		F5091BFE18C4E1D700C85307 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BFF18C4E1D700C85307 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		F5091C0018C4E1D700C85307 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
 		F5091C0118C4E1D700C85307 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
@@ -538,7 +538,7 @@
 		F50CBFAC1A0405B2004AC9DA /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
 		F50CBFAD1A0405B2004AC9DA /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		F50CBFAE1A0405B2004AC9DA /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
-		F50CBFAF1A0405B2004AC9DA /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; };
+		F50CBFAF1A0405B2004AC9DA /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFB01A0405B2004AC9DA /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		F50CBFB11A0405B2004AC9DA /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
 		F50CBFB21A0405B2004AC9DA /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; };
@@ -625,7 +625,7 @@
 		F5821A1918C4E27400293508 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		F5821A1A18C4E27400293508 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
 		F5821A1B18C4E27400293508 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
-		F5821A1C18C4E27400293508 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; };
+		F5821A1C18C4E27400293508 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A1D18C4E27400293508 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		F5821A1E18C4E27400293508 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
 		F5821A1F18C4E27400293508 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		F50CBFCE1A040669004AC9DA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F50CBFCD1A040669004AC9DA /* UIKit.framework */; };
 		F50CBFCF1A040707004AC9DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
 		F50E42791AA86D36003DB030 /* libSpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50E42711AA86D36003DB030 /* libSpecta.a */; };
+		F50E427B1AA86FA3003DB030 /* LPScreenshotRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F50E427A1AA86FA3003DB030 /* LPScreenshotRouteTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F52BF6321A3A0BC700E173AF /* LPTouchUtilsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F50CBF781A03F9FF004AC9DA /* LPTouchUtilsTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5329C941A9D6F2900FE3800 /* LPWebQueryResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F5329C931A9D6F2900FE3800 /* LPWebQueryResult.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F537397318E5200C004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -969,6 +970,7 @@
 		F50E42761AA86D36003DB030 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSharedExampleGroups.h; sourceTree = "<group>"; };
 		F50E42771AA86D36003DB030 /* SPTSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSpec.h; sourceTree = "<group>"; };
 		F50E42781AA86D36003DB030 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		F50E427A1AA86FA3003DB030 /* LPScreenshotRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPScreenshotRouteTest.m; sourceTree = "<group>"; };
 		F5329C921A9D6F2900FE3800 /* LPWebQueryResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPWebQueryResult.h; sourceTree = "<group>"; };
 		F5329C931A9D6F2900FE3800 /* LPWebQueryResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPWebQueryResult.m; sourceTree = "<group>"; };
 		F537398C18E5253B004133FA /* version */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = version; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1566,6 +1568,7 @@
 				F5CB7D571A7CF45B00DACC8B /* InvokerFactory.m */,
 				F5329C921A9D6F2900FE3800 /* LPWebQueryResult.h */,
 				F5329C931A9D6F2900FE3800 /* LPWebQueryResult.m */,
+				F50E427A1AA86FA3003DB030 /* LPScreenshotRouteTest.m */,
 			);
 			path = "calabash-ios-server-tests";
 			sourceTree = "<group>";
@@ -2707,6 +2710,7 @@
 				F50CBF891A04056F004AC9DA /* LPHTTPAsyncFileResponse.m in Sources */,
 				F50CBFAB1A0405B2004AC9DA /* LPInterpolateRoute.m in Sources */,
 				F50CBFA01A0405B2004AC9DA /* LPUIARouteOverUserPrefs.m in Sources */,
+				F50E427B1AA86FA3003DB030 /* LPScreenshotRouteTest.m in Sources */,
 				F50CBFBB1A0405CE004AC9DA /* UIScriptASTPredicate.m in Sources */,
 				F5C0945A1A97B7CB00AE5991 /* LPWebQuery.m in Sources */,
 				F56630891A39B00700DEA0C0 /* LPInfoPlistTest.m in Sources */,

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.h
@@ -9,6 +9,4 @@
 
 @interface LPScreenshotRoute : NSObject <LPRoute>
 
-- (NSData *) takeScreenshot;
-
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -18,23 +18,19 @@
 
 @end
 
-// UIGetScreenImage violates t
 @implementation LPScreenshotRoute
 
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
   return [method isEqualToString:@"GET"];
 }
 
-
 - (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
   LPHTTPDataResponse *drsp = [[LPHTTPDataResponse alloc]
-          initWithData:[self takeScreenshot]];
+                              initWithData:[self takeScreenshot]];
   return drsp;
 }
 
-
 - (NSData *) takeScreenshot {
-  // Create a graphics context with the target size
 
   CGSize imageSize = [[UIScreen mainScreen] bounds].size;
   UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
@@ -53,8 +49,8 @@
       CGContextConcatCTM(context, [window transform]);
       // Offset by the portion of the bounds left of and above the anchor point
       CGContextTranslateCTM(context,
-              -[window bounds].size.width * [[window layer] anchorPoint].x,
-              -[window bounds].size.height * [[window layer] anchorPoint].y);
+                            -[window bounds].size.width * [[window layer] anchorPoint].x,
+                            -[window bounds].size.height * [[window layer] anchorPoint].y);
 
       // Render the layer hierarchy to the current context
       [[window layer] renderInContext:context];
@@ -69,18 +65,16 @@
 
   UIGraphicsEndImageContext();
 
-
-//    NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
-//    static NSDateFormatter *fm = nil;
-//    if (!fm) {
-//        fm=[[NSDateFormatter alloc] init];
-//        [fm setDateFormat:@"ddMM'-'HH':'mm':'SSSS"];
-//    }
-//    NSString* timestamp = [fm stringFromDate:[NSDate date]];
-//    NSString* tempFile = [NSString stringWithFormat:@"%@screenshot_%@_%@.png",tempDir,appID,timestamp,nil];
+  //    NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
+  //    static NSDateFormatter *fm = nil;
+  //    if (!fm) {
+  //        fm=[[NSDateFormatter alloc] init];
+  //        [fm setDateFormat:@"ddMM'-'HH':'mm':'SSSS"];
+  //    }
+  //    NSString* timestamp = [fm stringFromDate:[NSDate date]];
+  //    NSString* tempFile = [NSString stringWithFormat:@"%@screenshot_%@_%@.png",tempDir,appID,timestamp,nil];
 
   return UIImagePNGRepresentation(image);
 }
-
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -1,3 +1,7 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 //
 //  ScreenshotRoute.m
 //  Created by Karl Krukow on 13/08/11.
@@ -25,7 +29,7 @@
 - (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method URI:(NSString *) path {
   LPHTTPDataResponse *drsp = [[LPHTTPDataResponse alloc]
           initWithData:[self takeScreenshot]];
-  return [drsp autorelease];
+  return drsp;
 }
 
 

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -8,6 +8,11 @@
 #import "LPHTTPDataResponse.h"
 #import "LPTouchUtils.h"
 
+@interface LPScreenshotRoute ()
+
+- (NSData *) takeScreenshot;
+
+@end
 
 // UIGetScreenImage violates t
 @implementation LPScreenshotRoute

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -65,15 +65,6 @@
 
   UIGraphicsEndImageContext();
 
-  //    NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
-  //    static NSDateFormatter *fm = nil;
-  //    if (!fm) {
-  //        fm=[[NSDateFormatter alloc] init];
-  //        [fm setDateFormat:@"ddMM'-'HH':'mm':'SSSS"];
-  //    }
-  //    NSString* timestamp = [fm stringFromDate:[NSDate date]];
-  //    NSString* tempFile = [NSString stringWithFormat:@"%@screenshot_%@_%@.png",tempDir,appID,timestamp,nil];
-
   return UIImagePNGRepresentation(image);
 }
 

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -26,19 +26,9 @@
 
 - (NSData *) takeScreenshot {
   // Create a graphics context with the target size
-  // On iOS 4 and later, use UIGraphicsBeginImageContextWithOptions to take the scale into consideration
-  // On iOS prior to 4, fall back to use UIGraphicsBeginImageContext
 
-  // todo - this can be refactored becase we no longer support iOS 4
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunreachable-code"
   CGSize imageSize = [[UIScreen mainScreen] bounds].size;
-  if (NULL != UIGraphicsBeginImageContextWithOptions) {
-    UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
-  } else {
-    UIGraphicsBeginImageContext(imageSize);
-  }
-#pragma clang diagnostic pop
+  UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
 
   CGContextRef context = UIGraphicsGetCurrentContext();
 


### PR DESCRIPTION
### Motivation

Xcode 6.3 brought to my attention that we were incorrectly testing for `UIGraphicsBeginImageContentWithOptions`.

```
# Always evals false.
if (NULL != UIGraphicsBeginImageContextWithOptions)
```

This check was required for iOS 4 support.  Since we don't support iOS 4, we can safely remove this branch.

##### Other work

* Put the class under test
* Put the class under ARC
* Reformatted
