### PR TITLE
Add cucumber integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ calabash-ios
 .env
 .irb-history
 .irbrc
+Gemfile.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   #- make all
   - make dylib_sim
   - scripts/test/xctest.rb
+  - scripts/test/cucumber.rb
   - scripts/test/run-chou-tests.rb
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
   #- make all
   - make dylib_sim
   - scripts/test/xctest.rb
-  - scripts/test/cucumber.rb
   - scripts/test/run-chou-tests.rb
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ script:
   - make framework
   - make frank
   # Dylib creation is allowed by Xcode 6, but it requires
-  # code-signing which is not easy to set up on Travis CI.
+  # code-signing for the on-device library, which is not easy
+  # to set up on Travis CI.
   #- make dylibs
   #- make all
+  - make dylib_sim
   - scripts/test/xctest.rb
   - scripts/test/run-chou-tests.rb
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ dylibs:
 	scripts/make-calabash-dylib.rb device
 	scripts/make-libraries.rb verify-dylibs
 
+dylib_sim:
+	rm -rf build
+	rm -rf calabash-dylibs
+	scripts/make-calabash-dylib.rb sim
+	scripts/make-libraries.rb verify-sim-dylib
+
 install_test_binaries:
 	$(MAKE) dylibs
 	./scripts/install-test-binaries.rb

--- a/cucumber/Gemfile
+++ b/cucumber/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'calabash-cucumber', '~> 0.13'
+gem 'run_loop', '~> 1.2'
+gem 'multi_test'
+gem 'pry'
+gem 'pry-nav'

--- a/cucumber/Gemfile.develop
+++ b/cucumber/Gemfile.develop
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'calabash-cucumber', :github => 'calabash/calabash-ios', :branch => 'develop'
+gem 'run_loop', :github => 'calabash/run_loop', :branch => 'develop'
+gem 'multi_test'
+gem 'pry'
+gem 'pry-nav'

--- a/cucumber/config/cucumber.yml
+++ b/cucumber/config/cucumber.yml
@@ -1,0 +1,20 @@
+<%
+
+if ENV["USER"] == "jenkins"
+  formatter = "progress"
+  keep_sim_open_after = "0"
+else
+  formatter = "Slowhandcuke::Formatter"
+  keep_sim_open_after = "1"
+end
+
+%>
+
+verbose: DEBUG=1
+common: -f <%= formatter %>
+
+app:           APP="../LPTestTarget.app"
+bundle_id:     BUNDLE_ID=com.xamarin.LPTestTarget
+
+simulator:     -p app -p common NO_STOP=<%= keep_sim_open_after %>
+default:       -p simulator

--- a/cucumber/config/xtc-profiles.yml
+++ b/cucumber/config/xtc-profiles.yml
@@ -1,0 +1,16 @@
+# careful using the @not_xtc tag
+# use for stuff like Scenario Outlines which are nyi on XTC
+not_xtc:     --tags ~@not_xtc
+not_sim:     --tags ~@simulator --tags ~@simulator_only
+no_launch:   --tags ~@no_launch
+iphone_only: --tags ~@ipad --tags ~@ipad_only
+ipad_only:   --tags ~@iphone --tags ~@iphone_only
+
+tags:        -p not_xtc -p not_sim -p no_launch
+
+default:     -p tags
+ci:          -p tags --tags ~@no_ci
+
+wip:         -p tags --tags @wip
+iphone:      -p tags -p iphone_only
+ipad:        -p tags -p ipad_only

--- a/cucumber/features/screenshot.feature
+++ b/cucumber/features/screenshot.feature
@@ -1,0 +1,8 @@
+Feature:  Screenshots
+  In order to see what the screen looked like during a test
+  As a tester
+  I want screenshot feature
+
+  Scenario: Can take a screenshot
+    Given that the app has launched
+    When I take a screenshot, a png is created

--- a/cucumber/features/step_definitions/common_steps.rb
+++ b/cucumber/features/step_definitions/common_steps.rb
@@ -1,0 +1,20 @@
+Given(/^that the app has launched$/) do
+  wait_for do
+    !query('view').empty?
+  end
+end
+
+When(/^I take a screenshot, a png is created$/) do
+  with_env('SCREENSHOT_PATH', nil) do
+    name = 'my_screenshot'
+    `rm -f #{name}*.png`
+    unless Dir.glob("./#{name}*.png").empty?
+      raise "Could not remove screenshot with name '#{name}'"
+    end
+    path = screenshot(name: name)
+    unless File.exist?(path)
+      raise "Expected screenshot at '#{path}'"
+    end
+    `rm -f #{path}`
+  end
+end

--- a/cucumber/features/support/01_launch.rb
+++ b/cucumber/features/support/01_launch.rb
@@ -1,0 +1,40 @@
+require 'calabash-cucumber/launcher'
+require 'singleton'
+
+module Calabash
+  class LaunchControl
+    include Singleton
+
+    def launcher
+      @launcher ||= Calabash::Cucumber::Launcher.new
+    end
+
+    def dylib
+      @dylib ||= lambda {
+        dirname = File.dirname(__FILE__)
+        joined = File.join(dirname, '..', '..', '..', 'calabash-dylibs', 'libCalabashDynSim.dylib')
+        File.expand_path(joined)
+      }.call
+    end
+
+  end
+end
+
+
+Before do |scenario|
+  options =
+        {
+              :inject_dylib => Calabash::LaunchControl.instance.dylib
+        }
+
+  launcher = Calabash::LaunchControl.instance.launcher
+  launcher.relaunch(options)
+  launcher.calabash_notify(self)
+end
+
+After do |scenario|
+  launcher = Calabash::LaunchControl.instance.launcher
+  unless launcher.calabash_no_stop?
+    calabash_exit
+  end
+end

--- a/cucumber/features/support/env.rb
+++ b/cucumber/features/support/env.rb
@@ -1,0 +1,38 @@
+require 'calabash-cucumber/wait_helpers'
+require 'calabash-cucumber/operations'
+
+World(Calabash::Cucumber::Operations)
+
+module Calabash
+  module Cucumber
+    module ServerTestExtensions
+      def with_env(var_name, new_value, &block)
+        original_value = ENV[var_name]
+        begin
+          ENV[var_name] = new_value
+          block.call
+        ensure
+          ENV[var_name] = original_value
+        end
+      end
+    end
+  end
+end
+
+World(Calabash::Cucumber::ServerTestExtensions)
+
+if ENV['XAMARIN_TEST_CLOUD'] != '1'
+  require 'pry'
+end
+
+# override cucumber `pending` on the XTC
+if ENV['XAMARIN_TEST_CLOUD'] == '1'
+  module Cucumber
+    module RbSupport
+      def pending(message = 'TODO')
+        raise "PENDING: #{message}"
+      end
+    end
+  end
+  World(Cucumber::RbSupport)
+end

--- a/scripts/test-helpers.rb
+++ b/scripts/test-helpers.rb
@@ -34,7 +34,8 @@ def do_system(cmd, opts={})
                   :exit_on_nonzero_status => true,
                   :env_vars => {},
                   :log_cmd => true,
-                  :obscure_fields => []}
+                  :obscure_fields => [],
+                  :on_failure_proc => nil}
   merged_opts = default_opts.merge(opts)
 
   obscure_fields = merged_opts[:obscure_fields]
@@ -65,6 +66,8 @@ def do_system(cmd, opts={})
     log_pass merged_opts[:pass_msg]
   else
     log_fail merged_opts[:fail_msg]
+    on_failure_proc = merged_opts[:on_failure_proc]
+    on_failure_proc.call if on_failure_proc
     exit exit_code if exit_on_err
   end
   system 'set -e'

--- a/scripts/test/cucumber.rb
+++ b/scripts/test/cucumber.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'test-helpers'))
+
+working_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+
+Dir.chdir working_dir do
+
+  do_system('make clean')
+  do_system('make dylib_sim')
+  do_system('make test_app')
+
+end
+
+working_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'cucumber'))
+
+Dir.chdir working_dir do
+
+  ensure_proc = Proc.new do
+    do_system('mv Gemfile.backup Gemfile')
+  end
+
+  opts = {
+        :on_failure_proc => ensure_proc
+  }
+
+  do_system('rm -rf .bundle')
+  do_system('mkdir .bundle')
+  do_system('touch .bundle/config')
+  do_system('rm Gemfile.lock')
+
+  do_system('mv Gemfile Gemfile.backup')
+  do_system('cp Gemfile.develop Gemfile', opts)
+  do_system('bundle update', opts)
+
+  do_system('bundle exec cucumber', opts)
+
+  ensure_proc.call
+
+end

--- a/scripts/test/cucumber.rb
+++ b/scripts/test/cucumber.rb
@@ -28,7 +28,7 @@ Dir.chdir working_dir do
   do_system('rm -rf .bundle')
   do_system('mkdir .bundle')
   do_system('touch .bundle/config')
-  do_system('rm Gemfile.lock')
+  do_system('rm -f Gemfile.lock')
 
   do_system('mv Gemfile Gemfile.backup')
   do_system('cp Gemfile.develop Gemfile', opts)

--- a/scripts/test/run-chou-tests.rb
+++ b/scripts/test/run-chou-tests.rb
@@ -20,7 +20,7 @@ Dir.chdir working_dir do
 
   # if calabash.framework exists, it was built in another step
   unless File.exist?('calabash.framework')
-    do_system('make')
+    do_system('make framework')
   end
 
 end

--- a/scripts/test/test-make-rules.rb
+++ b/scripts/test/test-make-rules.rb
@@ -13,6 +13,7 @@ def test_make_rules(env_vars, xcode_version)
   # Requires injecting xcspec files into Xcode.app bundle for Xcode < 6.0
   if xcode_version >= RunLoop::Version.new('6.0')
     do_system('make dylibs', {:env_vars => env_vars})
+    do_system('make dylib_sim', {:env_vars => env_vars})
     do_system('make all', {:env_vars => env_vars})
   end
 


### PR DESCRIPTION
### Motivation

Looking for a way of pushing integration tests out of XCTest.

Not sure if this approach has legs yet.

If this causes problems in Travis, I will remove the cucumber job. 

 Otherwise, this pull-request no effect on the system and can be safely merged.

**UPDATE** Cucumber + dylib injection not stable enough yet for travis.  Remove cucumber.rb from travis build.