### PR TITLE
LPVersionRoute converted to ARC, safer fetching of values from Info.plist, and CalabashServer logs the App's Base SDK

### DIFF
--- a/XCTest/LPInfoPlistTest.m
+++ b/XCTest/LPInfoPlistTest.m
@@ -58,6 +58,11 @@ describe(@"LPInfoPlist", ^{
     expect([infoPlist stringForDTSDKName]).to.equal(@"foo");
   });
 
+  it(@"CFBundleDisplayName", ^{
+    [[[mainBundleMock expect]
+      andReturn:@{@"CFBundleDisplayName" : @"foo"}] infoDictionary];
+    expect([infoPlist stringForDisplayName]).to.equal(@"foo");
+  });
 });
 
 SpecEnd

--- a/XCTest/LPInfoPlistTest.m
+++ b/XCTest/LPInfoPlistTest.m
@@ -73,15 +73,68 @@ describe(@"LPInfoPlist", ^{
       [infoMock stopMocking];
     });
 
-    it(@"DTSDKName", ^{
-      [[[infoMock expect] andReturn:@{@"DTSDKName" : @"foo"}] infoDictionary];
-      expect([infoMock stringForDTSDKName]).to.equal(@"foo");
+    describe(@"DTSDKName", ^{
+      it(@"value exists", ^{
+        [[[infoMock expect] andReturn:@{@"DTSDKName" : @"foo"}] infoDictionary];
+        expect([infoMock stringForDTSDKName]).to.equal(@"foo");
+      });
+
+      it(@"value does not exist", ^{
+        [[[infoMock expect] andReturn:@{}] infoDictionary];
+        expect([infoMock stringForDTSDKName]).to.beEmpty();
+      });
     });
 
-    it(@"CFBundleDisplayName", ^{
-      mockedPlist = @{@"CFBundleDisplayName" : @"foo"};
-      [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
-      expect([infoMock stringForDisplayName]).to.equal(@"foo");
+    describe(@"CFBundleDisplayName", ^{
+      it(@"value exists", ^{
+        mockedPlist = @{@"CFBundleDisplayName" : @"foo"};
+        [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+        expect([infoMock stringForDisplayName]).to.equal(@"foo");
+      });
+
+      it(@"value does not exist", ^{
+        [[[infoMock expect] andReturn:@{}] infoDictionary];
+        expect([infoMock stringForDisplayName]).to.beEmpty();
+      });
+    });
+
+    describe(@"CFBundleIdentifier", ^{
+      it(@"value exists", ^{
+        mockedPlist = @{@"CFBundleIdentifier" : @"foo"};
+        [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+        expect([infoMock stringForIdentifier]).to.equal(@"foo");
+      });
+
+      it(@"value does not exist", ^{
+        [[[infoMock expect] andReturn:@{}] infoDictionary];
+        expect([infoMock stringForIdentifier]).to.beEmpty();
+      });
+    });
+
+    describe(@"CFBundleVersion", ^{
+      it(@"value exists", ^{
+        mockedPlist = @{@"CFBundleVersion" : @"foo"};
+        [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+        expect([infoMock stringForVersion]).to.equal(@"foo");
+      });
+
+      it(@"value does not exist", ^{
+        [[[infoMock expect] andReturn:@{}] infoDictionary];
+        expect([infoMock stringForVersion]).to.beEmpty();
+      });
+    });
+
+    describe(@"CFBundleShortVersionString", ^{
+      it(@"value exists", ^{
+        mockedPlist = @{@"CFBundleShortVersionString" : @"foo"};
+        [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+        expect([infoMock stringForShortVersion]).to.equal(@"foo");
+      });
+
+      it(@"value does not exist", ^{
+        [[[infoMock expect] andReturn:@{}] infoDictionary];
+        expect([infoMock stringForShortVersion]).to.beEmpty();
+      });
     });
   });
 });

--- a/XCTest/LPInfoPlistTest.m
+++ b/XCTest/LPInfoPlistTest.m
@@ -4,6 +4,12 @@
 
 #import "LPInfoPlist.h"
 
+@interface LPInfoPlist (LPTesting)
+
+- (NSDictionary *) infoDictionary;
+
+@end
+
 @interface LPInfoPlistTest : XCTestCase
 
 @property (strong, nonatomic) LPInfoPlist *infoPlist;
@@ -40,28 +46,43 @@ SpecBegin(LPInfoPlist)
 
 describe(@"LPInfoPlist", ^{
   __block LPInfoPlist *infoPlist;
-  __block id mainBundleMock;
 
   beforeEach(^{
     infoPlist = [LPInfoPlist new];
-    mainBundleMock = [OCMockObject partialMockForObject:[NSBundle mainBundle]];
   });
 
-  afterEach(^{
+  it(@"#infoDictionary", ^{
+    id mainBundleMock = [OCMockObject partialMockForObject:[NSBundle mainBundle]];
+    [[[mainBundleMock expect] andReturn:@{@"key" : @"value"}] infoDictionary];
+    NSDictionary *actual = [infoPlist infoDictionary];
+    expect(actual[@"key"]).to.equal(@"value");
     [mainBundleMock verify];
     [mainBundleMock stopMocking];
   });
 
-  it(@"DTSDKName", ^{
-    [[[mainBundleMock expect]
-      andReturn:@{@"DTSDKName" : @"foo"}] infoDictionary];
-    expect([infoPlist stringForDTSDKName]).to.equal(@"foo");
-  });
+  describe(@"Accessing Info.plist Keys", ^{
+    __block id infoMock;
+    __block NSDictionary *mockedPlist;
 
-  it(@"CFBundleDisplayName", ^{
-    [[[mainBundleMock expect]
-      andReturn:@{@"CFBundleDisplayName" : @"foo"}] infoDictionary];
-    expect([infoPlist stringForDisplayName]).to.equal(@"foo");
+    beforeEach(^{
+      infoMock = [OCMockObject partialMockForObject:infoPlist];
+    });
+
+    afterEach(^{
+      [infoMock verify];
+      [infoMock stopMocking];
+    });
+
+    it(@"DTSDKName", ^{
+      [[[infoMock expect] andReturn:@{@"DTSDKName" : @"foo"}] infoDictionary];
+      expect([infoMock stringForDTSDKName]).to.equal(@"foo");
+    });
+
+    it(@"CFBundleDisplayName", ^{
+      mockedPlist = @{@"CFBundleDisplayName" : @"foo"};
+      [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+      expect([infoMock stringForDisplayName]).to.equal(@"foo");
+    });
   });
 });
 

--- a/XCTest/LPInfoPlistTest.m
+++ b/XCTest/LPInfoPlistTest.m
@@ -41,7 +41,6 @@ SpecBegin(LPInfoPlist)
 describe(@"LPInfoPlist", ^{
   __block LPInfoPlist *infoPlist;
   __block id mainBundleMock;
-  __block NSDictionary *plistDictionary;
 
   beforeEach(^{
     infoPlist = [LPInfoPlist new];
@@ -49,27 +48,14 @@ describe(@"LPInfoPlist", ^{
   });
 
   afterEach(^{
+    [mainBundleMock verify];
     [mainBundleMock stopMocking];
   });
 
-  describe(@"stringForDTSDKName", ^{
-
-    it(@"returns the DTSDKName if avaliable", ^{
-      NSString *expected = @"foo";
-      plistDictionary = @{@"DTSDKName" : expected};
-      [[[mainBundleMock expect] andReturn:plistDictionary] infoDictionary];
-      NSString *actual = [infoPlist stringForDTSDKName];
-      expect(actual).to.equal(expected);
-      [mainBundleMock verify];
-    });
-
-    it(@"returns nil if the DTSDName is not available", ^{
-      plistDictionary = @{};
-      [[[mainBundleMock expect] andReturn:plistDictionary] infoDictionary];
-      NSString *actual = [infoPlist stringForDTSDKName];
-      expect(actual).to.equal(nil);
-      [mainBundleMock verify];
-    });
+  it(@"DTSDKName", ^{
+    [[[mainBundleMock expect]
+      andReturn:@{@"DTSDKName" : @"foo"}] infoDictionary];
+    expect([infoPlist stringForDTSDKName]).to.equal(@"foo");
   });
 
 });

--- a/XCTest/LPInfoPlistTest.m
+++ b/XCTest/LPInfoPlistTest.m
@@ -35,3 +35,43 @@
 }
 
 @end
+
+SpecBegin(LPInfoPlist)
+
+describe(@"LPInfoPlist", ^{
+  __block LPInfoPlist *infoPlist;
+  __block id mainBundleMock;
+  __block NSDictionary *plistDictionary;
+
+  beforeEach(^{
+    infoPlist = [LPInfoPlist new];
+    mainBundleMock = [OCMockObject partialMockForObject:[NSBundle mainBundle]];
+  });
+
+  afterEach(^{
+    [mainBundleMock stopMocking];
+  });
+
+  describe(@"stringForDTSDKName", ^{
+
+    it(@"returns the DTSDKName if avaliable", ^{
+      NSString *expected = @"foo";
+      plistDictionary = @{@"DTSDKName" : expected};
+      [[[mainBundleMock expect] andReturn:plistDictionary] infoDictionary];
+      NSString *actual = [infoPlist stringForDTSDKName];
+      expect(actual).to.equal(expected);
+      [mainBundleMock verify];
+    });
+
+    it(@"returns nil if the DTSDName is not available", ^{
+      plistDictionary = @{};
+      [[[mainBundleMock expect] andReturn:plistDictionary] infoDictionary];
+      NSString *actual = [infoPlist stringForDTSDKName];
+      expect(actual).to.equal(nil);
+      [mainBundleMock verify];
+    });
+  });
+
+});
+
+SpecEnd

--- a/XCTest/LPInfoPlistTest.m
+++ b/XCTest/LPInfoPlistTest.m
@@ -38,6 +38,8 @@
   NSDictionary *plistDictionary = @{@"CalabashServerPort" : @(expectedPort)};
   [[[mainBundleMock stub] andReturn:plistDictionary] infoDictionary];
   XCTAssertEqual([self.infoPlist serverPort], expectedPort);
+  [mainBundleMock verify];
+  [mainBundleMock stopMocking];
 }
 
 @end

--- a/XCTest/LPVersionRouteTest.m
+++ b/XCTest/LPVersionRouteTest.m
@@ -28,3 +28,22 @@
 }
 
 @end
+
+SpecBegin(LPVersionRoute)
+
+describe(@"LPVersionRoute", ^{
+  describe(@"#JSONResponsForMethod:URI:data:", ^{
+    __block NSDictionary *response;
+
+    before(^{
+      LPVersionRoute *route = [LPVersionRoute new];
+      response = [route JSONResponseForMethod:nil URI:nil data:nil];
+    });
+
+    it(@"contains app_base_sdk key", ^{
+      XCTAssertNotNil(response[@"app_base_sdk"]);
+    });
+  });
+});
+
+SpecEnd

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		B1135845197F1351004B16F4 /* LPHTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A714E6564200663205 /* LPHTTPRedirectResponse.m */; };
 		B1135846197F1351004B16F4 /* LPCORSResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B1059F0418C546EB005A0262 /* LPCORSResponse.m */; };
 		B1135847197F1390004B16F4 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* GCDAsyncSocket.m */; };
-		B1135848197F1A38004B16F4 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
+		B1135848197F1A38004B16F4 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B11358491981AE00004B16F4 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
 		B11358581981B053004B16F4 /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; };
 		B11358591981B053004B16F4 /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; };
@@ -140,7 +140,7 @@
 		B15BF9CA19ABB1DE00B38577 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BF9CB19ABB1DE00B38577 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BF9CC19ABB1DE00B38577 /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B15BF9CD19ABB1DE00B38577 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B15BF9CD19ABB1DE00B38577 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
 		B15BF9CE19ABB1DE00B38577 /* LPISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B13B29241627389500433F6C /* LPISO8601DateFormatter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BF9CF19ABB1DE00B38577 /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* CDataScanner_Extensions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BF9D019ABB1DE00B38577 /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -219,7 +219,7 @@
 		B15BFA1C19ABB2B100B38577 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA1D19ABB2B100B38577 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA1E19ABB2B100B38577 /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B15BFA1F19ABB2B100B38577 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B15BFA1F19ABB2B100B38577 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
 		B15BFA2019ABB2B100B38577 /* LPISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B13B29241627389500433F6C /* LPISO8601DateFormatter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA2119ABB2B100B38577 /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* CDataScanner_Extensions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		B15BFA2219ABB2B100B38577 /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -300,7 +300,7 @@
 		B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9E19A23BCE0070E8CE /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		B1D5BD9F19A23BCE0070E8CE /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
-		B1D5BDA019A23BCE0070E8CE /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
+		B1D5BDA019A23BCE0070E8CE /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDA119A23BCE0070E8CE /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* CDataScanner_Extensions.m */; };
 		B1D5BDA219A23BCE0070E8CE /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; };
 		B1D5BDA319A23BCE0070E8CE /* LPCJSONScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDE314B6DB2B002A744C /* LPCJSONScanner.m */; };
@@ -446,7 +446,7 @@
 		F5091BFE18C4E1D700C85307 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BFF18C4E1D700C85307 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		F5091C0018C4E1D700C85307 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
-		F5091C0118C4E1D700C85307 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
+		F5091C0118C4E1D700C85307 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C0218C4E1D700C85307 /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* CDataScanner_Extensions.m */; };
 		F5091C0318C4E1D700C85307 /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; };
 		F5091C0418C4E1D700C85307 /* LPCJSONScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDE314B6DB2B002A744C /* LPCJSONScanner.m */; };
@@ -542,7 +542,7 @@
 		F50CBFB01A0405B2004AC9DA /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		F50CBFB11A0405B2004AC9DA /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
 		F50CBFB21A0405B2004AC9DA /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; };
-		F50CBFB31A0405B2004AC9DA /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
+		F50CBFB31A0405B2004AC9DA /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFB41A0405CE004AC9DA /* LPISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B13B29241627389500433F6C /* LPISO8601DateFormatter.m */; };
 		F50CBFB51A0405CE004AC9DA /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* CDataScanner_Extensions.m */; };
 		F50CBFB61A0405CE004AC9DA /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; };
@@ -628,7 +628,7 @@
 		F5821A1C18C4E27400293508 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A1D18C4E27400293508 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
 		F5821A1E18C4E27400293508 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
-		F5821A1F18C4E27400293508 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; };
+		F5821A1F18C4E27400293508 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A2018C4E27400293508 /* CDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* CDataScanner_Extensions.m */; };
 		F5821A2118C4E27400293508 /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; };
 		F5821A2218C4E27400293508 /* LPCJSONScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDE314B6DB2B002A744C /* LPCJSONScanner.m */; };

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -141,6 +141,7 @@
 
     [_httpServer setName:@"Calabash Server"];
     [_httpServer setType:@"_http._tcp."];
+    [_httpServer setConnectionClass:[LPRouter class]];
 
     LPInfoPlist *infoPlist = [LPInfoPlist new];
     [_httpServer setPort:[infoPlist serverPort]];
@@ -157,7 +158,6 @@
       };
 
     [_httpServer setTXTRecordDictionary:capabilities];
-    [_httpServer setConnectionClass:[LPRouter class]];
 
     NSLog(@"Creating the server: %@", _httpServer);
     NSLog(@"Calabash iOS server version: %@", kLPCALABASHVERSION);

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -143,6 +143,7 @@
     [_httpServer setType:@"_http._tcp."];
 
     LPInfoPlist *infoPlist = [LPInfoPlist new];
+    [_httpServer setPort:[infoPlist serverPort]];
 
     // Advertise this device's capabilities to our listeners inside of the TXT record
     UIDevice *device = [UIDevice currentDevice];
@@ -155,10 +156,6 @@
       @"app_version" : [infoPlist stringForVersion],
       };
 
-    [_httpServer setPort:[infoPlist serverPort]];
-    NSString *dtSdkName = [infoPlist stringForDTSDKName];
-    [infoPlist release];
-
     [_httpServer setTXTRecordDictionary:capabilities];
     [_httpServer setConnectionClass:[LPRouter class]];
 
@@ -167,7 +164,11 @@
     //        [_httpServer setDocumentRoot:webPath];
     NSLog(@"Creating the server: %@", _httpServer);
     NSLog(@"Calabash iOS server version: %@", kLPCALABASHVERSION);
+
+    NSString *dtSdkName = [infoPlist stringForDTSDKName];
     NSLog(@"App Base SDK: %@", dtSdkName);
+
+    [infoPlist release];
   }
   return self;
 }

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -159,9 +159,6 @@
     [_httpServer setTXTRecordDictionary:capabilities];
     [_httpServer setConnectionClass:[LPRouter class]];
 
-    // Serve files from our embedded Web folder
-    //        NSString *webPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Web"];
-    //        [_httpServer setDocumentRoot:webPath];
     NSLog(@"Creating the server: %@", _httpServer);
     NSLog(@"Calabash iOS server version: %@", kLPCALABASHVERSION);
 

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -142,20 +142,19 @@
     [_httpServer setName:@"Calabash Server"];
     [_httpServer setType:@"_http._tcp."];
 
-    // Advertise this device's capabilities to our listeners inside of the TXT record
-    NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+    LPInfoPlist *infoPlist = [LPInfoPlist new];
 
+    // Advertise this device's capabilities to our listeners inside of the TXT record
     UIDevice *device = [UIDevice currentDevice];
     NSDictionary *capabilities =
     @{
       @"name" : [device name],
       @"os_version" : [device systemVersion],
-      @"app" : [info objectForKey:@"CFBundleDisplayName"],
-      @"app_id" : [info objectForKey:@"CFBundleIdentifier"],
-      @"app_version" : [info objectForKey:@"CFBundleVersion"]
+      @"app" : [infoPlist stringForDisplayName],
+      @"app_id" : [infoPlist stringForIdentifier],
+      @"app_version" : [infoPlist stringForVersion],
       };
 
-    LPInfoPlist *infoPlist = [LPInfoPlist new];
     [_httpServer setPort:[infoPlist serverPort]];
     NSString *dtSdkName = [infoPlist stringForDTSDKName];
     [infoPlist release];

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -153,15 +153,16 @@
 
     // Advertise this device's capabilities to our listeners inside of the TXT record
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
-    NSMutableDictionary *capabilities = [[NSMutableDictionary alloc]
-                                         initWithObjectsAndKeys:[[UIDevice currentDevice] name], @"name",
-                                         [[UIDevice currentDevice] model], @"model",
-                                         [[UIDevice currentDevice]
-                                          systemVersion], @"os_version",
-                                         [info objectForKey:@"CFBundleDisplayName"], @"app",
-                                         [info objectForKey:@"CFBundleIdentifier"], @"app_id",
-                                         [info objectForKey:@"CFBundleVersion"], @"app_version",
-                                         nil];
+
+    UIDevice *device = [UIDevice currentDevice];
+    NSDictionary *capabilities =
+    @{
+      @"name" : [device name],
+      @"os_version" : [device systemVersion],
+      @"app" : [info objectForKey:@"CFBundleDisplayName"],
+      @"app_id" : [info objectForKey:@"CFBundleIdentifier"],
+      @"app_version" : [info objectForKey:@"CFBundleVersion"]
+      };
 
     LPInfoPlist *infoPlist = [LPInfoPlist new];
     [_httpServer setPort:[infoPlist serverPort]];
@@ -170,7 +171,7 @@
 
     [_httpServer setTXTRecordDictionary:capabilities];
     [_httpServer setConnectionClass:[LPRouter class]];
-    [capabilities release];
+
     // Serve files from our embedded Web folder
     //        NSString *webPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Web"];
     //        [_httpServer setDocumentRoot:webPath];

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -137,15 +137,6 @@
     [LPRouter addRoute:dumpRoute forPath:@"dump"];
     [dumpRoute release];
 
-
-
-
-    //
-    //        LPScreencastRoute *scr = [LPScreencastRoute new];
-    //        [LPRouter addRoute:scr forPath:@"/screencast"];
-    //        [scr release];
-    //
-
     _httpServer = [[[LPHTTPServer alloc] init] retain];
 
     [_httpServer setName:@"Calabash Server"];

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -165,6 +165,7 @@
 
     LPInfoPlist *infoPlist = [LPInfoPlist new];
     [_httpServer setPort:[infoPlist serverPort]];
+    NSString *dtSdkName = [infoPlist stringForDTSDKName];
     [infoPlist release];
 
     [_httpServer setTXTRecordDictionary:capabilities];
@@ -175,6 +176,7 @@
     //        [_httpServer setDocumentRoot:webPath];
     NSLog(@"Creating the server: %@", _httpServer);
     NSLog(@"Calabash iOS server version: %@", kLPCALABASHVERSION);
+    NSLog(@"App Base SDK: %@", dtSdkName);
   }
   return self;
 }

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -83,18 +83,20 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
 }
 
 - (id)handleRequestForPath:(NSArray *)path withConnection:(id)connection {
-  if (![self canHandlePostForPath:path]) {
-    return nil;
-  }
-  NSDictionary *version = [self JSONResponseForMethod:@"GET" URI:@"calabash_version" data:nil];
-  NSData *jsonData = [[LPJSONUtils serializeDictionary:version] dataUsingEncoding:NSUTF8StringEncoding];
+  if (![self canHandlePostForPath:path]) {  return nil;  }
+
+  NSDictionary *version = [self JSONResponseForMethod:@"GET"
+                                                  URI:@"calabash_version"
+                                                 data:nil];
+  NSData *jsonData = [[LPJSONUtils serializeDictionary:version]
+                      dataUsingEncoding:NSUTF8StringEncoding];
   
   return [[LPHTTPDataResponse alloc] initWithData:jsonData];
-  
 }
 
-
-- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data {
   NSString *versionString = [[NSBundle mainBundle]
                              objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   if (!versionString) {
@@ -126,7 +128,13 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   if (!sim) {  sim = @"";  }
 
   BOOL isIphoneAppEmulated = [self isIPhoneAppEmulatedOnIPad];
-  NSDictionary *git = @{@"revision" : kLPGitShortRevision, @"branch" : kLPGitBranch, @"remote_origin" : kLPGitRemoteOrigin};
+
+  NSDictionary *git =
+  @{
+    @"revision" : kLPGitShortRevision,
+    @"branch" : kLPGitBranch,
+    @"remote_origin" : kLPGitRemoteOrigin
+    };
 
 
   NSString *calabashVersion = [kLPCALABASHVERSION componentsSeparatedByString:@" "].lastObject;
@@ -135,22 +143,26 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   NSNumber *serverPort = @([infoPlist serverPort]);
   NSString *appBaseSdkName = [infoPlist stringForDTSDKName];
 
-  NSDictionary *res = @{@"version": calabashVersion,
-                        @"app_id": idString,
-                        @"iOS_version": [[UIDevice currentDevice]
-                                         systemVersion],
-                        @"app_name": nameString,
-                        @"screen_dimensions": [[LPDevice sharedDevice] screenDimensions],
-                        @"system": machine,
-                        @"4inch": @(is4inDevice),
-                        @"simulator_device": dev,
-                        @"simulator": sim,
-                        @"app_version": versionString,
-                        @"outcome": @"SUCCESS",
-                        @"iphone_app_emulated_on_ipad": @(isIphoneAppEmulated),
-                        @"git": git,
-                        @"server_port" : serverPort,
-                        @"app_base_sdk" : appBaseSdkName};
+  NSDictionary *res =
+  @{
+
+    @"version": calabashVersion,
+    @"app_id": idString,
+    @"iOS_version": [[UIDevice currentDevice]
+                     systemVersion],
+    @"app_name": nameString,
+    @"screen_dimensions": [[LPDevice sharedDevice] screenDimensions],
+    @"system": machine,
+    @"4inch": @(is4inDevice),
+    @"simulator_device": dev,
+    @"simulator": sim,
+    @"app_version": versionString,
+    @"outcome": @"SUCCESS",
+    @"iphone_app_emulated_on_ipad": @(isIphoneAppEmulated),
+    @"git": git,
+    @"server_port" : serverPort,
+    @"app_base_sdk" : appBaseSdkName
+    };
   return res;
 }
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -143,13 +143,13 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   NSNumber *serverPort = @([infoPlist serverPort]);
   NSString *appBaseSdkName = [infoPlist stringForDTSDKName];
 
-  NSDictionary *res =
+  return
+
   @{
 
     @"version": calabashVersion,
     @"app_id": idString,
-    @"iOS_version": [[UIDevice currentDevice]
-                     systemVersion],
+    @"iOS_version": [[UIDevice currentDevice] systemVersion],
     @"app_name": nameString,
     @"screen_dimensions": [[LPDevice sharedDevice] screenDimensions],
     @"system": machine,
@@ -162,8 +162,8 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
     @"git": git,
     @"server_port" : serverPort,
     @"app_base_sdk" : appBaseSdkName
+
     };
-  return res;
 }
 
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -121,7 +121,9 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
     @"remote_origin" : kLPGitRemoteOrigin
     };
 
-  NSString *calabashVersion = [kLPCALABASHVERSION componentsSeparatedByString:@" "].lastObject;
+  NSArray *versionTokens = [kLPCALABASHVERSION componentsSeparatedByString:@" "];
+  NSString *calabashVersion = [versionTokens lastObject];
+  if (!calabashVersion) { calabashVersion = @""; }
 
   LPInfoPlist *infoPlist = [LPInfoPlist new];
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -1,3 +1,7 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 //
 //  LPVersionRoute.m
 //  calabash
@@ -85,7 +89,7 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   NSDictionary *version = [self JSONResponseForMethod:@"GET" URI:@"calabash_version" data:nil];
   NSData *jsonData = [[LPJSONUtils serializeDictionary:version] dataUsingEncoding:NSUTF8StringEncoding];
   
-  return [[[LPHTTPDataResponse alloc] initWithData:jsonData] autorelease];
+  return [[LPHTTPDataResponse alloc] initWithData:jsonData];
   
 }
 
@@ -130,8 +134,6 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   LPInfoPlist *infoPlist = [LPInfoPlist new];
   NSNumber *serverPort = @([infoPlist serverPort]);
   NSString *appBaseSdkName = [infoPlist stringForDTSDKName];
-  [infoPlist release];
-
 
   NSDictionary *res = @{@"version": calabashVersion,
                         @"app_id": idString,

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -129,6 +129,7 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
 
   LPInfoPlist *infoPlist = [LPInfoPlist new];
   NSNumber *serverPort = @([infoPlist serverPort]);
+  NSString *appBaseSdkName = [infoPlist stringForDTSDKName];
   [infoPlist release];
 
 
@@ -146,7 +147,8 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
                         @"outcome": @"SUCCESS",
                         @"iphone_app_emulated_on_ipad": @(isIphoneAppEmulated),
                         @"git": git,
-                        @"server_port" : serverPort};
+                        @"server_port" : serverPort,
+                        @"app_base_sdk" : appBaseSdkName};
   return res;
 }
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -97,21 +97,6 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
 - (NSDictionary *) JSONResponseForMethod:(NSString *) method
                                      URI:(NSString *) path
                                     data:(NSDictionary *) data {
-  NSString *versionString = [[NSBundle mainBundle]
-                             objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-  if (!versionString) {
-    versionString = @"Unknown";
-  }
-  NSString *idString = [[NSBundle mainBundle]
-                        objectForInfoDictionaryKey:@"CFBundleIdentifier"];
-
-  if (!idString) { idString = @"Unknown";  }
-
-  NSString *nameString = [[NSBundle mainBundle]
-                          objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-
-  if (!nameString) { nameString = @"Unknown";  }
-
   struct utsname systemInfo;
   uname(&systemInfo);
 
@@ -136,32 +121,29 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
     @"remote_origin" : kLPGitRemoteOrigin
     };
 
-
   NSString *calabashVersion = [kLPCALABASHVERSION componentsSeparatedByString:@" "].lastObject;
 
   LPInfoPlist *infoPlist = [LPInfoPlist new];
-  NSNumber *serverPort = @([infoPlist serverPort]);
-  NSString *appBaseSdkName = [infoPlist stringForDTSDKName];
 
   return
 
   @{
 
     @"version": calabashVersion,
-    @"app_id": idString,
+    @"app_id": [infoPlist stringForIdentifier],
     @"iOS_version": [[UIDevice currentDevice] systemVersion],
-    @"app_name": nameString,
+    @"app_name": [infoPlist stringForDisplayName],
     @"screen_dimensions": [[LPDevice sharedDevice] screenDimensions],
     @"system": machine,
     @"4inch": @(is4inDevice),
     @"simulator_device": dev,
     @"simulator": sim,
-    @"app_version": versionString,
+    @"app_version": [infoPlist stringForVersion],
     @"outcome": @"SUCCESS",
     @"iphone_app_emulated_on_ipad": @(isIphoneAppEmulated),
     @"git": git,
-    @"server_port" : serverPort,
-    @"app_base_sdk" : appBaseSdkName
+    @"server_port" : @([infoPlist serverPort]),
+    @"app_base_sdk" : [infoPlist stringForDTSDKName]
 
     };
 }

--- a/calabash/Classes/Utils/LPInfoPlist.h
+++ b/calabash/Classes/Utils/LPInfoPlist.h
@@ -4,5 +4,6 @@
 
 - (unsigned short) serverPort;
 - (NSString *) stringForDTSDKName;
+- (NSString *) stringForDisplayName;
 
 @end

--- a/calabash/Classes/Utils/LPInfoPlist.h
+++ b/calabash/Classes/Utils/LPInfoPlist.h
@@ -5,5 +5,8 @@
 - (unsigned short) serverPort;
 - (NSString *) stringForDTSDKName;
 - (NSString *) stringForDisplayName;
+- (NSString *) stringForIdentifier;
+- (NSString *) stringForVersion;
+- (NSString *) stringForShortVersion;
 
 @end

--- a/calabash/Classes/Utils/LPInfoPlist.h
+++ b/calabash/Classes/Utils/LPInfoPlist.h
@@ -3,5 +3,6 @@
 @interface LPInfoPlist : NSObject
 
 - (unsigned short) serverPort;
+- (NSString *) stringForDTSDKName;
 
 @end

--- a/calabash/Classes/Utils/LPInfoPlist.m
+++ b/calabash/Classes/Utils/LPInfoPlist.m
@@ -10,6 +10,7 @@ static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
 @interface LPInfoPlist ()
 
 @property(strong, nonatomic, readonly) NSDictionary *infoDictionary;
+- (NSString *) stringForKey:(NSString *) key;
 
 @end
 
@@ -23,6 +24,12 @@ static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
   return _infoDictionary;
 }
 
+- (NSString *) stringForKey:(NSString *) key {
+  NSString *value = self.infoDictionary[key];
+  if (!value) { value = @""; }
+  return value;
+}
+
 - (unsigned short) serverPort {
   NSDictionary *info = self.infoDictionary;
   NSNumber *infoPlistValue = info[LPCalabashServerPortInfoPlistKey];
@@ -34,11 +41,23 @@ static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
 }
 
 - (NSString *) stringForDTSDKName {
-  return self.infoDictionary[@"DTSDKName"];
+  return [self stringForKey:@"DTSDKName"];
 }
 
 - (NSString *) stringForDisplayName {
-  return self.infoDictionary[@"CFBundleDisplayName"];
+  return [self stringForKey:@"CFBundleDisplayName"];
+}
+
+- (NSString *) stringForIdentifier {
+  return [self stringForKey:@"CFBundleIdentifier"];
+}
+
+- (NSString *) stringForVersion {
+  return [self stringForKey:@"CFBundleVersion"];
+}
+
+- (NSString *) stringForShortVersion {
+  return [self stringForKey:@"CFBundleShortVersionString"];
 }
 
 @end

--- a/calabash/Classes/Utils/LPInfoPlist.m
+++ b/calabash/Classes/Utils/LPInfoPlist.m
@@ -19,4 +19,9 @@ static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
   }
 }
 
+- (NSString *) stringForDTSDKName {
+  NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+  return info[@"DTSDKName"];
+}
+
 @end

--- a/calabash/Classes/Utils/LPInfoPlist.m
+++ b/calabash/Classes/Utils/LPInfoPlist.m
@@ -24,4 +24,8 @@ static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
   return info[@"DTSDKName"];
 }
 
+- (NSString *) stringForDisplayName {
+  return [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
+}
+
 @end

--- a/calabash/Classes/Utils/LPInfoPlist.m
+++ b/calabash/Classes/Utils/LPInfoPlist.m
@@ -7,10 +7,24 @@
 static unsigned short const LPCalabashServerDefaultPort = 37265;
 static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
 
+@interface LPInfoPlist ()
+
+@property(strong, nonatomic, readonly) NSDictionary *infoDictionary;
+
+@end
+
 @implementation LPInfoPlist
 
+@synthesize infoDictionary = _infoDictionary;
+
+- (NSDictionary *) infoDictionary {
+  if (_infoDictionary) { return _infoDictionary; }
+  _infoDictionary = [[NSBundle mainBundle] infoDictionary];
+  return _infoDictionary;
+}
+
 - (unsigned short) serverPort {
-  NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+  NSDictionary *info = self.infoDictionary;
   NSNumber *infoPlistValue = info[LPCalabashServerPortInfoPlistKey];
   if (!infoPlistValue) {
     return LPCalabashServerDefaultPort;
@@ -20,12 +34,11 @@ static NSString *const LPCalabashServerPortInfoPlistKey = @"CalabashServerPort";
 }
 
 - (NSString *) stringForDTSDKName {
-  NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
-  return info[@"DTSDKName"];
+  return self.infoDictionary[@"DTSDKName"];
 }
 
 - (NSString *) stringForDisplayName {
-  return [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
+  return self.infoDictionary[@"CFBundleDisplayName"];
 }
 
 @end


### PR DESCRIPTION
This is a combination three of the behaviors.   I decided to keep them together because they all required changes to how we interact with the Info.plist.


* Put LPVersionRoute under ARC - part of an on-going effort to put the entire server under ARC.
* CalabashServer now reports the base SDK of the app under test.
* The version route also reports the base SDK of the app under test.
* The version route now reports "CFBundleVersion" vs. "CFBundleShortVersionString", which is sometimes empty.


```
 App Base SDK: iphonesimulator8.3
```