### PR TITLE
Maintenance patch for translating rects for legacy apps running in iOS 8 environments

### DIFF
--- a/XCTest/LPLegacyAppRectTranslatorTest.m
+++ b/XCTest/LPLegacyAppRectTranslatorTest.m
@@ -1,0 +1,19 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+@interface LPLegacyAppRectTranslatorTest : XCTestCase
+
+@end
+
+@implementation LPLegacyAppRectTranslatorTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+@end

--- a/XCTest/LPLegacyAppRectTranslatorTest.m
+++ b/XCTest/LPLegacyAppRectTranslatorTest.m
@@ -2,18 +2,405 @@
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
-@interface LPLegacyAppRectTranslatorTest : XCTestCase
+#import "LPLegacyAppRectTranslator.h"
+#import "LPTouchUtils.h"
+#import "LPInfoPlist.h"
+
+@interface LPLegacyAppRectTranslator (LPXCTEST)
+
+@property(strong, nonatomic) LPInfoPlist *infoPlist;
+@property(strong, nonatomic) UIDevice *device;
+
+- (BOOL) appCompiledAgainstSDK6;
+- (BOOL) iOSVersionOnTestDeviceIsGteTo80;
+- (UIInterfaceOrientation) statusBarOrientation;
+- (BOOL) appOrientationRequiresTranslation;
+- (CGSize) canonicalScreenSizeForLegacyApp;
 
 @end
 
-@implementation LPLegacyAppRectTranslatorTest
+SpecBegin(LPLegacyAppRectTranslator)
 
-- (void)setUp {
-  [super setUp];
-}
+describe(@"LPLegacyAppRectTranslator", ^{
 
-- (void)tearDown {
-  [super tearDown];
-}
+  it(@"#infoPlist", ^{
+    LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+    LPInfoPlist *plist = translator.infoPlist;
+    expect(plist).notTo.equal(nil);
+    expect(plist).to.beAnInstanceOf([LPInfoPlist class]);
+  });
 
-@end
+  it(@"#device", ^{
+    LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+    UIDevice *device = translator.device;
+    expect(device).notTo.equal(nil);
+    expect(device).to.beAnInstanceOf([UIDevice class]);
+  });
+
+  it(@"#statusBarOrientation", ^{
+    LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+    UIInterfaceOrientation orientation = translator.statusBarOrientation;
+    expect(orientation).to.beInTheRangeOf(UIDeviceOrientationPortrait,
+                                          UIDeviceOrientationLandscapeRight);
+  });
+
+  describe(@"#appCompliedAgainstSDK6", ^{
+    describe(@"returns YES", ^{
+      __block LPInfoPlist *plist;
+
+      beforeEach(^{
+        plist = mock([LPInfoPlist class]);
+      });
+
+      it(@"when simulator target", ^{
+        NSString *dtSdk = @"iphonesimulator6.1";
+        [given([plist stringForDTSDKName]) willReturn:dtSdk];
+        LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+        translator.infoPlist = plist;
+        expect([translator appCompiledAgainstSDK6]).equal(YES);
+      });
+
+      it (@"when device target", ^{
+        NSString *dtSdk = @"iphoneos6.1";
+        [given([plist stringForDTSDKName]) willReturn:dtSdk];
+        LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+        translator.infoPlist = plist;
+        expect([translator appCompiledAgainstSDK6]).equal(YES);
+      });
+    });
+
+    describe(@"returns NO in all other cases", ^{
+      it(@"when simulator target", ^{
+        LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+        expect([translator appCompiledAgainstSDK6]).equal(NO);
+      });
+    });
+  });
+
+  describe(@"#systemVersionIs80", ^{
+
+    __block UIDevice *device;
+
+    beforeEach(^{
+      device = mock([UIDevice class]);
+    });
+
+    describe(@"returns YES", ^{
+      it(@"when iOS == 8.0", ^{
+        NSString *sdkVersion = @"8.0";
+        [given([device systemVersion]) willReturn:sdkVersion];
+        LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+        translator.device = device;
+        expect([translator iOSVersionOnTestDeviceIsGteTo80]).to.equal(YES);
+      });
+
+      it(@"when iOS > 8.0", ^{
+        NSString *sdkVersion = @"8.1";
+        [given([device systemVersion]) willReturn:sdkVersion];
+        LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+        translator.device = device;
+        expect([translator iOSVersionOnTestDeviceIsGteTo80]).to.equal(YES);
+      });
+    });
+
+    it(@"returns false otherwise", ^{
+      NSString *sdkVersion = @"7.1";
+      [given([device systemVersion]) willReturn:sdkVersion];
+      LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+      translator.device = device;
+      expect([translator iOSVersionOnTestDeviceIsGteTo80]).to.equal(NO);
+    });
+  });
+
+  describe(@"#appOrientationRequiresTranslation", ^{
+    __block LPLegacyAppRectTranslator *translator;
+    __block UIInterfaceOrientation left = UIInterfaceOrientationLandscapeLeft;
+    __block UIInterfaceOrientation right = UIInterfaceOrientationLandscapeRight;
+    __block UIInterfaceOrientation portrait = UIInterfaceOrientationPortrait;
+    __block UIInterfaceOrientation upsideDown = UIInterfaceOrientationPortraitUpsideDown;
+
+    beforeEach(^{
+      translator = [LPLegacyAppRectTranslator new];
+    });
+
+    it(@"returns NO when app is in portrait", ^{
+      id translatorMock = [OCMockObject partialMockForObject:translator];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(portrait)]
+       statusBarOrientation];
+      expect([translatorMock appOrientationRequiresTranslation]).to.equal(NO);
+      [translatorMock verify];
+    });
+
+    describe(@"return YES", ^{
+      it(@"when app is in left landscape", ^{
+        id translatorMock = [OCMockObject partialMockForObject:translator];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(left)]
+         statusBarOrientation];
+        expect([translatorMock appOrientationRequiresTranslation]).to.equal(YES);
+        [translatorMock verify];
+      });
+
+      it(@"when app is in right landscape", ^{
+        id translatorMock = [OCMockObject partialMockForObject:translator];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(right)]
+         statusBarOrientation];
+        expect([translatorMock appOrientationRequiresTranslation]).to.equal(YES);
+        [translatorMock verify];
+      });
+
+      it(@"when app is in upside down", ^{
+        id translatorMock = [OCMockObject partialMockForObject:translator];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(upsideDown)]
+         statusBarOrientation];
+        expect([translatorMock appOrientationRequiresTranslation]).to.equal(YES);
+        [translatorMock verify];
+      });
+    });
+  });
+
+  describe(@"#appUnderTestRequiresLegacyRectTranslation", ^{
+
+    __block LPLegacyAppRectTranslator *translator;
+    __block BOOL yes = YES;
+    __block BOOL no = NO;
+
+    beforeEach(^{
+      translator = [LPLegacyAppRectTranslator new];
+    });
+
+    describe(@"returns NO", ^{
+      it(@"when app is not compiled under SDK 6.0", ^{
+        id translatorMock = [OCMockObject partialMockForObject:translator];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(no)]
+         appCompiledAgainstSDK6];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+         iOSVersionOnTestDeviceIsGteTo80];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+         appOrientationRequiresTranslation];
+        expect([translatorMock appUnderTestRequiresLegacyRectTranslation]).to.equal(NO);
+      });
+
+      it(@"when device under test is >= iOS 8.0", ^{
+        id translatorMock = [OCMockObject partialMockForObject:translator];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+         appCompiledAgainstSDK6];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(no)]
+         iOSVersionOnTestDeviceIsGteTo80];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+         appOrientationRequiresTranslation];
+        expect([translatorMock appUnderTestRequiresLegacyRectTranslation]).to.equal(NO);
+      });
+
+      it(@"when app has orientation landscape", ^{
+        id translatorMock = [OCMockObject partialMockForObject:translator];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+         appCompiledAgainstSDK6];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+         iOSVersionOnTestDeviceIsGteTo80];
+        [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(no)]
+         appOrientationRequiresTranslation];
+        expect([translatorMock appUnderTestRequiresLegacyRectTranslation]).to.equal(NO);
+      });
+    });
+
+    it(@"returns YES when app compile under SDK 6.0 and device under test is >= iOS 8.0", ^{
+      id translatorMock = [OCMockObject partialMockForObject:translator];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+       appCompiledAgainstSDK6];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+       iOSVersionOnTestDeviceIsGteTo80];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(yes)]
+       appOrientationRequiresTranslation];
+      expect([translatorMock appUnderTestRequiresLegacyRectTranslation]).to.equal(YES);
+    });
+  });
+
+  describe(@"#canonicalScreenSizeForLegacyApp", ^{
+
+    __block LPLegacyAppRectTranslator *translator;
+    __block BOOL yes = YES;
+    __block BOOL no = NO;
+    __block UIUserInterfaceIdiom ipad = UIUserInterfaceIdiomPad;
+    __block UIUserInterfaceIdiom iphone = UIUserInterfaceIdiomPhone;
+    __block CGSize actual;
+
+    beforeEach(^{
+      translator = [LPLegacyAppRectTranslator new];
+    });
+
+    it(@"returns CGSizeZero if no canonical size can be found", ^{
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(iphone)] userInterfaceIdiom];
+
+      id touchUtilsMock = [OCMockObject mockForClass:[LPTouchUtils class]];
+      [[[touchUtilsMock stub] andReturnValue:@(no)] isThreeAndAHalfInchDevice];
+      [[[touchUtilsMock stub] andReturnValue:@(no)] is4InchDevice];
+
+      actual = [translator canonicalScreenSizeForLegacyApp];
+      expect(actual.height).to.equal(0);
+      expect(actual.width).to.equal(0);
+    });
+
+    it(@"returns correct size for iPad", ^{
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(ipad)] userInterfaceIdiom];
+
+      id touchUtilsMock = [OCMockObject mockForClass:[LPTouchUtils class]];
+      [[[touchUtilsMock stub] andReturnValue:@(no)] isThreeAndAHalfInchDevice];
+      [[[touchUtilsMock stub] andReturnValue:@(no)] is4InchDevice];
+
+      actual = [translator canonicalScreenSizeForLegacyApp];
+      expect(actual.height).to.equal(1024);
+      expect(actual.width).to.equal(768);
+    });
+
+    it(@"returns correct size for iPhone 3in", ^{
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(iphone)] userInterfaceIdiom];
+
+      id touchUtilsMock = [OCMockObject mockForClass:[LPTouchUtils class]];
+      [[[touchUtilsMock stub] andReturnValue:@(yes)] isThreeAndAHalfInchDevice];
+      [[[touchUtilsMock stub] andReturnValue:@(no)] is4InchDevice];
+
+      actual = [translator canonicalScreenSizeForLegacyApp];
+      expect(actual.height).to.equal(480);
+      expect(actual.width).to.equal(320);
+    });
+
+    it(@"returns correct size for iPhone 4in", ^{
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(iphone)] userInterfaceIdiom];
+
+      id touchUtilsMock = [OCMockObject mockForClass:[LPTouchUtils class]];
+      [[[touchUtilsMock stub] andReturnValue:@(no)] isThreeAndAHalfInchDevice];
+      [[[touchUtilsMock stub] andReturnValue:@(yes)] is4InchDevice];
+
+      actual = [translator canonicalScreenSizeForLegacyApp];
+      expect(actual.height).to.equal(568);
+      expect(actual.width).to.equal(320);
+    });
+  });
+
+  describe(@"#dictionaryAfterLegacyRectTranslation:", ^{
+    __block NSDictionary *original;
+    __block NSDictionary *expected;
+    __block NSDictionary *actual;
+
+    __block LPLegacyAppRectTranslator *translator;
+
+    __block UIInterfaceOrientation left = UIInterfaceOrientationLandscapeLeft;
+    __block UIInterfaceOrientation right = UIInterfaceOrientationLandscapeRight;
+    __block UIInterfaceOrientation portrait = UIInterfaceOrientationPortrait;
+    __block UIInterfaceOrientation upsideDown = UIInterfaceOrientationPortraitUpsideDown;
+
+    __block UIUserInterfaceIdiom ipad = UIUserInterfaceIdiomPad;
+
+    beforeEach(^{
+      translator = [LPLegacyAppRectTranslator new];
+      original = @{@"center_x" : @(345),
+                   @"center_y" : @(512.5),
+                   @"x" : @(325),
+                   @"y" : @(223),
+                   @"width" : @(40),
+                   @"height" : @(579)};
+    });
+
+    it(@"returns nil if dictionary to translate is nil", ^{
+      expect([translator dictionaryAfterLegacyRectTranslation:nil]).to.equal(nil);
+    });
+
+    it(@"returns the original dictionary if keys are missing", ^{
+      NSDictionary *dict = @{@"a" : @"b", @"c" : @"d"};
+      actual = [translator dictionaryAfterLegacyRectTranslation:dict];
+      expect(actual).to.equal(dict);
+    });
+
+    it(@"does no translation if orientation is portrait", ^{
+      id translatorMock = [OCMockObject partialMockForObject:translator];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(portrait)]
+       statusBarOrientation];
+      actual = [translatorMock dictionaryAfterLegacyRectTranslation:original];
+      expect(actual).to.equal(original);
+      [translatorMock verify];
+    });
+
+    it(@"translates when orientation is left", ^{
+      expected = @{@"center_x" : @(511.5),
+                   @"center_y" : @(345),
+                   @"x" : @(325),
+                   @"y" : @(223),
+                   @"width" : @(40),
+                   @"height" : @(579)};
+
+      id translatorMock = [OCMockObject partialMockForObject:translator];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(left)]
+       statusBarOrientation];
+
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(ipad)] userInterfaceIdiom];
+
+      actual = [translatorMock dictionaryAfterLegacyRectTranslation:original];
+
+      expect(actual[@"center_x"]).to.equal(expected[@"center_x"]);
+      expect(actual[@"center_y"]).to.equal(expected[@"center_y"]);
+      expect(actual[@"x"]).to.equal(expected[@"x"]);
+      expect(actual[@"y"]).to.equal(expected[@"y"]);
+      expect(actual[@"width"]).to.equal(expected[@"width"]);
+      expect(actual[@"height"]).to.equal(expected[@"height" ]);
+    });
+
+    it(@"translates when orientation is right", ^{
+      expected = @{@"center_x" : @(512.5),
+                   @"center_y" : @(423),
+                   @"x" : @(325),
+                   @"y" : @(223),
+                   @"width" : @(40),
+                   @"height" : @(579)};
+
+      id translatorMock = [OCMockObject partialMockForObject:translator];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(right)]
+       statusBarOrientation];
+
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(ipad)] userInterfaceIdiom];
+
+      actual = [translatorMock dictionaryAfterLegacyRectTranslation:original];
+
+      expect(actual[@"center_x"]).to.equal(expected[@"center_x"]);
+      expect(actual[@"center_y"]).to.equal(expected[@"center_y"]);
+      expect(actual[@"x"]).to.equal(expected[@"x"]);
+      expect(actual[@"y"]).to.equal(expected[@"y"]);
+      expect(actual[@"width"]).to.equal(expected[@"width"]);
+      expect(actual[@"height"]).to.equal(expected[@"height" ]);
+
+    });
+
+    it(@"translates when orientation is upside down", ^{
+      expected = @{@"center_x" : @(423),
+                   @"center_y" : @(511.5),
+                   @"x" : @(325),
+                   @"y" : @(223),
+                   @"width" : @(40),
+                   @"height" : @(579)};
+
+      id translatorMock = [OCMockObject partialMockForObject:translator];
+      [[[translatorMock expect] andReturnValue:OCMOCK_VALUE(upsideDown)]
+       statusBarOrientation];
+
+      id currentDeviceMock = [OCMockObject partialMockForObject:[UIDevice currentDevice]];
+      [[[currentDeviceMock stub] andReturnValue:OCMOCK_VALUE(ipad)] userInterfaceIdiom];
+
+      actual = [translatorMock dictionaryAfterLegacyRectTranslation:original];
+
+      expect(actual[@"center_x"]).to.equal(expected[@"center_x"]);
+      expect(actual[@"center_y"]).to.equal(expected[@"center_y"]);
+      expect(actual[@"x"]).to.equal(expected[@"x"]);
+      expect(actual[@"y"]).to.equal(expected[@"y"]);
+      expect(actual[@"width"]).to.equal(expected[@"width"]);
+      expect(actual[@"height"]).to.equal(expected[@"height" ]);
+
+    });
+  });
+});
+
+SpecEnd

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -559,6 +559,14 @@
 		F50CBFCF1A040707004AC9DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
 		F50E42791AA86D36003DB030 /* libSpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50E42711AA86D36003DB030 /* libSpecta.a */; };
 		F50E427B1AA86FA3003DB030 /* LPScreenshotRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F50E427A1AA86FA3003DB030 /* LPScreenshotRouteTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A201AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A211AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A221AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A231AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A241AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A251AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A261AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5252A281AAF7EA5005A4FA4 /* LPLegacyAppRectTranslatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5252A271AAF7EA5005A4FA4 /* LPLegacyAppRectTranslatorTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F52BF6321A3A0BC700E173AF /* LPTouchUtilsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F50CBF781A03F9FF004AC9DA /* LPTouchUtilsTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5329C941A9D6F2900FE3800 /* LPWebQueryResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F5329C931A9D6F2900FE3800 /* LPWebQueryResult.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F537397318E5200C004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -954,6 +962,9 @@
 		F50E42771AA86D36003DB030 /* SPTSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSpec.h; sourceTree = "<group>"; };
 		F50E42781AA86D36003DB030 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Specta.h"; sourceTree = "<group>"; };
 		F50E427A1AA86FA3003DB030 /* LPScreenshotRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPScreenshotRouteTest.m; sourceTree = "<group>"; };
+		F5252A181AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPLegacyAppRectTranslator.h; sourceTree = "<group>"; };
+		F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPLegacyAppRectTranslator.m; sourceTree = "<group>"; };
+		F5252A271AAF7EA5005A4FA4 /* LPLegacyAppRectTranslatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPLegacyAppRectTranslatorTest.m; sourceTree = "<group>"; };
 		F5329C921A9D6F2900FE3800 /* LPWebQueryResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPWebQueryResult.h; sourceTree = "<group>"; };
 		F5329C931A9D6F2900FE3800 /* LPWebQueryResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPWebQueryResult.m; sourceTree = "<group>"; };
 		F537398C18E5253B004133FA /* version */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = version; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1518,6 +1529,8 @@
 				F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */,
 				F5F600411A7C69760020637D /* LPInvoker.h */,
 				F5F600421A7C69760020637D /* LPInvoker.m */,
+				F5252A181AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.h */,
+				F5252A191AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1552,6 +1565,7 @@
 				F5329C921A9D6F2900FE3800 /* LPWebQueryResult.h */,
 				F5329C931A9D6F2900FE3800 /* LPWebQueryResult.m */,
 				F50E427A1AA86FA3003DB030 /* LPScreenshotRouteTest.m */,
+				F5252A271AAF7EA5005A4FA4 /* LPLegacyAppRectTranslatorTest.m */,
 			);
 			path = XCTest;
 			sourceTree = SOURCE_ROOT;
@@ -2250,6 +2264,7 @@
 				F5C094551A979CC200AE5991 /* LPWebQuery.m in Sources */,
 				B113585E1981B053004B16F4 /* LPOrientationOperation.m in Sources */,
 				B1F772241A22A398009A2336 /* LPSharedUIATextField.m in Sources */,
+				F5252A221AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				B1058E7B197F043100B4A57B /* LPCalabashFrankRegistrar.m in Sources */,
 				B11358621981B053004B16F4 /* LPQueryOperation.m in Sources */,
 				B1135846197F1351004B16F4 /* LPCORSResponse.m in Sources */,
@@ -2360,6 +2375,7 @@
 				B15BF9CD19ABB1DE00B38577 /* LPVersionRoute.m in Sources */,
 				B15BF9CE19ABB1DE00B38577 /* LPISO8601DateFormatter.m in Sources */,
 				B15BF9CF19ABB1DE00B38577 /* CDataScanner_Extensions.m in Sources */,
+				F5252A241AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				B1670E2C1A32410F00000A62 /* LPDumpRoute.m in Sources */,
 				B15BF9D019ABB1DE00B38577 /* LPCJSONDeserializer.m in Sources */,
 				B15BF9D119ABB1DE00B38577 /* LPCJSONScanner.m in Sources */,
@@ -2451,6 +2467,7 @@
 				B15BFA1F19ABB2B100B38577 /* LPVersionRoute.m in Sources */,
 				B15BFA2019ABB2B100B38577 /* LPISO8601DateFormatter.m in Sources */,
 				B15BFA2119ABB2B100B38577 /* CDataScanner_Extensions.m in Sources */,
+				F5252A251AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				B1670E2D1A32410F00000A62 /* LPDumpRoute.m in Sources */,
 				B15BFA2219ABB2B100B38577 /* LPCJSONDeserializer.m in Sources */,
 				B15BFA2319ABB2B100B38577 /* LPCJSONScanner.m in Sources */,
@@ -2568,6 +2585,7 @@
 				B1D5BDC319A23BCE0070E8CE /* LPScrollToRowWithMarkOperation.m in Sources */,
 				B1D5BDC419A23BCE0070E8CE /* LPOrientationOperation.m in Sources */,
 				B1D5BDC519A23BCE0070E8CE /* LPCORSResponse.m in Sources */,
+				F5252A231AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				B1D5BDC619A23BCE0070E8CE /* LPDatePickerOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2659,6 +2677,7 @@
 				F5091C2418C4E1D700C85307 /* LPScrollToRowWithMarkOperation.m in Sources */,
 				F5091C2518C4E1D700C85307 /* LPOrientationOperation.m in Sources */,
 				F5F53D6B18C619CB00BD9731 /* LPCORSResponse.m in Sources */,
+				F5252A201AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				F5091C2618C4E1D700C85307 /* LPDatePickerOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2703,6 +2722,7 @@
 				F5F600501A7C69BA0020637D /* LPInvokerTest.m in Sources */,
 				F50CBF9D1A040599004AC9DA /* LPScrollToMarkOperation.m in Sources */,
 				B15369FC1A32620A0093923F /* LPUIASharedElementChannel.m in Sources */,
+				F5252A281AAF7EA5005A4FA4 /* LPLegacyAppRectTranslatorTest.m in Sources */,
 				F50CBFCA1A0405E9004AC9DA /* LPLog.m in Sources */,
 				F50CBF8B1A04056F004AC9DA /* LPHTTPDynamicFileResponse.m in Sources */,
 				B1670E2E1A32411100000A62 /* LPDumpRoute.m in Sources */,
@@ -2716,6 +2736,7 @@
 				F50CBF951A04058C004AC9DA /* LPFlashOperation.m in Sources */,
 				F58937E31A9BD749007B9A5B /* LPWebQueryTest.m in Sources */,
 				F50CBF921A04058C004AC9DA /* LPSliderOperation.m in Sources */,
+				F5252A261AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				F50CBF9E1A040599004AC9DA /* LPScrollToRowWithMarkOperation.m in Sources */,
 				F50CBF861A040564004AC9DA /* DDData.m in Sources */,
 				F50CBF841A040564004AC9DA /* LPHTTPMessage.m in Sources */,
@@ -2863,6 +2884,7 @@
 				F5821A4218C4E27400293508 /* LPScrollToRowWithMarkOperation.m in Sources */,
 				F5821A4318C4E27400293508 /* LPOrientationOperation.m in Sources */,
 				F5F53D6A18C619CB00BD9731 /* LPCORSResponse.m in Sources */,
+				F5252A211AAF7DF1005A4FA4 /* LPLegacyAppRectTranslator.m in Sources */,
 				F5821A4418C4E27400293508 /* LPDatePickerOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -14,6 +14,8 @@
 #import "LPDevice.h"
 #import "LPOrientationOperation.h"
 #import "LPInvoker.h"
+#import "LPInfoPlist.h"
+#import "LPLegacyAppRectTranslator.h"
 
 @interface LPJSONUtils ()
 
@@ -277,6 +279,14 @@
                           @"y" : @(rect.origin.y),
                           @"width" : @(rect.size.width),
                           @"height" : @(rect.size.height)};
+
+      LPLegacyAppRectTranslator *translator = [LPLegacyAppRectTranslator new];
+      if ([translator appUnderTestRequiresLegacyRectTranslation]) {
+        NSDictionary *translatedRect;
+        NSDictionary *originalRect = result[@"rect"];
+        translatedRect = [translator dictionaryAfterLegacyRectTranslation:originalRect];
+        result[@"rect"] = translatedRect;
+      }
     }
   }
 

--- a/calabash/Classes/Utils/LPLegacyAppRectTranslator.h
+++ b/calabash/Classes/Utils/LPLegacyAppRectTranslator.h
@@ -1,0 +1,8 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+#import <Foundation/Foundation.h>
+
+@interface LPLegacyAppRectTranslator : NSObject
+
+@end

--- a/calabash/Classes/Utils/LPLegacyAppRectTranslator.h
+++ b/calabash/Classes/Utils/LPLegacyAppRectTranslator.h
@@ -1,8 +1,9 @@
-#if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
-#endif
 #import <Foundation/Foundation.h>
 
+// Supports apps that have been compiled under SDK 6.* but are running on iOS >= 8.0
 @interface LPLegacyAppRectTranslator : NSObject
+
+- (BOOL) appUnderTestRequiresLegacyRectTranslation;
+- (NSDictionary *) dictionaryAfterLegacyRectTranslation:(NSDictionary *) rectDictionary;
 
 @end

--- a/calabash/Classes/Utils/LPLegacyAppRectTranslator.m
+++ b/calabash/Classes/Utils/LPLegacyAppRectTranslator.m
@@ -1,5 +1,127 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #import "LPLegacyAppRectTranslator.h"
+#import "LPInfoPlist.h"
+#import "LPTouchUtils.h"
+
+@interface LPLegacyAppRectTranslator ()
+
+@property(strong, nonatomic) LPInfoPlist *infoPlist;
+@property(strong, nonatomic) UIDevice *device;
+
+- (BOOL) appCompiledAgainstSDK6;
+- (BOOL) iOSVersionOnTestDeviceIsGteTo80;
+- (UIInterfaceOrientation) statusBarOrientation;
+- (BOOL) appOrientationRequiresTranslation;
+- (CGSize) canonicalScreenSizeForLegacyApp;
+
+@end
 
 @implementation LPLegacyAppRectTranslator
+
+- (LPInfoPlist *) infoPlist {
+  if (_infoPlist) { return _infoPlist; }
+  _infoPlist = [LPInfoPlist new];
+  return _infoPlist;
+}
+
+- (UIDevice *) device {
+  if (_device) { return _device; }
+  _device = [UIDevice currentDevice];
+  return _device;
+}
+
+- (UIInterfaceOrientation) statusBarOrientation {
+  return [[UIApplication sharedApplication] statusBarOrientation];
+}
+
+- (BOOL) appCompiledAgainstSDK6 {
+  NSString *dkSdk = [self.infoPlist stringForDTSDKName];
+  return
+  [dkSdk rangeOfString:@"6.0"].location != NSNotFound ||
+  [dkSdk rangeOfString:@"6.1"].location != NSNotFound;
+}
+
+- (BOOL) iOSVersionOnTestDeviceIsGteTo80 {
+  NSString *systemVersion = [self.device systemVersion];
+  return [systemVersion compare:@"8.0" options:NSNumericSearch] != NSOrderedAscending;
+}
+
+// Don't be fooled: the UIDeviceOrientationIsLandscape(orientation) macro
+// cannot be used here.
+- (BOOL) appOrientationRequiresTranslation {
+  NSUInteger orientation = [self statusBarOrientation];
+  return
+  orientation == UIInterfaceOrientationLandscapeLeft ||
+  orientation == UIInterfaceOrientationLandscapeRight ||
+  orientation == UIInterfaceOrientationPortraitUpsideDown;
+}
+
+- (BOOL) appUnderTestRequiresLegacyRectTranslation {
+  return
+  [self appCompiledAgainstSDK6] &&
+  [self iOSVersionOnTestDeviceIsGteTo80] &&
+  [self appOrientationRequiresTranslation];
+}
+
+- (CGSize) canonicalScreenSizeForLegacyApp {
+  if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    return CGSizeMake(768, 1024);
+  } else if ([LPTouchUtils isThreeAndAHalfInchDevice]) {
+    return CGSizeMake(320, 480);
+  } else if ([LPTouchUtils is4InchDevice]) {
+    return CGSizeMake(320, 568);
+  } else {
+    return CGSizeZero;
+  }
+}
+
+- (NSDictionary *) dictionaryAfterLegacyRectTranslation:(NSDictionary *) rectDictionary {
+  if (!rectDictionary) {
+    NSLog(@"Cannot translate a nil dictionary; nothing to do");
+    return rectDictionary;
+  }
+
+  NSArray *expectedKeys = @[@"center_x", @"center_y", @"x", @"y", @"width", @"height"];
+  for (NSString *expectedKey in expectedKeys) {
+    if (!rectDictionary[expectedKey]) {
+      NSLog(@"Cannot translate dictionary: %@ it is missing key: %@",
+            rectDictionary, expectedKey);
+      NSLog(@"returning the original dictionary");
+      return rectDictionary;
+    }
+  }
+
+  UIInterfaceOrientation orientation = [self statusBarOrientation];
+
+  NSMutableDictionary *translated;
+  translated = [NSMutableDictionary dictionaryWithDictionary:rectDictionary];
+
+  CGSize canonicalScreenSize = [self canonicalScreenSizeForLegacyApp];
+  CGFloat canonWidth = canonicalScreenSize.width;
+  CGFloat canonHeight = canonicalScreenSize.height;
+
+  if (orientation == UIInterfaceOrientationLandscapeLeft) {
+    CGFloat originalX = [rectDictionary[@"center_x"] floatValue];
+    CGFloat originalY = [rectDictionary[@"center_y"] floatValue];
+    translated[@"center_x"] = @(canonHeight - originalY);
+    translated[@"center_y"] = @(originalX);
+  } else if (orientation == UIInterfaceOrientationLandscapeRight) {
+    CGFloat originalX = [rectDictionary[@"center_x"] floatValue];
+    CGFloat originalY = [rectDictionary[@"center_y"] floatValue];
+    translated[@"center_x"] = @(originalY);
+    translated[@"center_y"] = @(canonWidth - originalX);
+  } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
+    CGFloat originalX = [rectDictionary[@"center_x"] floatValue];
+    CGFloat originalY = [rectDictionary[@"center_y"] floatValue];
+    translated[@"center_x"] = @(canonWidth - originalX);
+    translated[@"center_y"] = @(canonHeight - originalY);
+  } else {
+    return rectDictionary;
+  }
+  return [NSDictionary dictionaryWithDictionary:translated];
+}
 
 @end

--- a/calabash/Classes/Utils/LPLegacyAppRectTranslator.m
+++ b/calabash/Classes/Utils/LPLegacyAppRectTranslator.m
@@ -1,0 +1,5 @@
+#import "LPLegacyAppRectTranslator.h"
+
+@implementation LPLegacyAppRectTranslator
+
+@end


### PR DESCRIPTION
#### Motivation

Checks for _legacy apps running in iOS 8 environments_ and assumes the responsibility of the translating the touch coordinates. 

Historically, the `Calabash::Cucumber::InstrumentsActions::normalize_rect_for_orientation!` method did this work.  Starting in 0.11.0, the server performs the normalization when the test device is iOS 8.

This patch will allow legacy apps to use the most recent version of the calabash gem (0.13.0).

A _legacy app_ has a base SDK of iOS 6.*.

@anujb @jescriba @rasmuskl @TobiasRoikjer @krukow @john7doe @acroos 