### PR TITLE
Fix case where a coordinate is inf or nan

### DIFF
--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -710,6 +710,25 @@
   XCTAssertEqual([dict count], 10);
 }
 
+- (void) testJsonifyViewWithInfCoords {
+  CGRect frame = CGRectMake(-INFINITY, INFINITY, CGFLOAT_MAX, CGFLOAT_MIN);
+  UIWindow *fakewindow = [UIWindow new];
+  UIView *view = [[UIView alloc] initWithFrame:frame];
+  [fakewindow addSubview:view];
+  NSDictionary *dict = [LPJSONUtils dictionaryByEncodingView:view];
+
+  XCTAssertEqual(((NSDictionary *)[dict objectForKey:@"frame"]).count, 4);
+  XCTAssertEqualObjects(dict[@"frame"][@"x"], @(CGFLOAT_MIN));
+  XCTAssertEqualObjects(dict[@"frame"][@"y"], @(CGFLOAT_MAX));
+  XCTAssertEqualObjects(dict[@"frame"][@"width"], @(CGFLOAT_MAX));
+  XCTAssertEqualObjects(dict[@"frame"][@"height"], @(CGFLOAT_MIN));
+
+
+  XCTAssertEqualObjects(dict[@"visible"], @(0));
+
+}
+
+
 #pragma mark - insertHitPointIntoMutableDictionary:
 
 - (void) testInsertHitPointIntoMutableDictionaryArgNotMutable {

--- a/calabash/Classes/Utils/LPTouchUtils.m
+++ b/calabash/Classes/Utils/LPTouchUtils.m
@@ -4,6 +4,7 @@
 //  Copyright 2011 LessPainful. All rights reserved.
 //
 #import <sys/utsname.h>
+#import <math.h>
 
 
 
@@ -231,6 +232,12 @@
   if (![view isKindOfClass:[UIView class]] || [self isViewOrParentsHidden:view]) {return NO;}
   UIWindow *windowForView = [self windowForView:view];
   if (!windowForView) {return YES;/* what can I do?*/}
+
+  CGRect viewRect = [view frame];
+  if (!(isfinite(viewRect.origin.x) && isfinite(viewRect.origin.y))) {
+    //we don't consider this visible although there is a theorectical infinite view which would be
+    return NO;
+  }
 
   CGPoint center = [self centerOfView:view inWindow:windowForView];
 


### PR DESCRIPTION
We observed JSON parse errors for (admittedly strange) views that had a frame with `x` or `y` equal to `inf` or `-inf`.

Particularly we observed an app with a view that serialized as invalid JSON:

```
{"id":null,"description":"<UIButtonLabel: 0x127f05b30; frame = (inf 0; 0 0); hidden = YES; opaque = NO; userInteractionEnabled = NO; layer = <_UILabelLayer: 0x17009d470>>",
"label":null,"frame":{"y":0,"x":inf,"width":0,"height":0},
"accessibilityElement":0,"value":null,"alpha":1,"enabled":true,"visible":0,"text":null,"class":"UIButtonLabel",
"rect":{"y":-inf,"height":inf,"center_y":0,"x":-inf,"center_x":0,"width":inf}}],"outcome":"SUCCESS"}
```