### PR TITLE
Fix fall-through causing double write of http chunk

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -79,6 +79,7 @@
 
   if (self.curCount == self.maxCount) {
     [self failWithMessageFormat:@"Timed out waiting for condition %@" message:condition];
+    return;
   }
 
   self.curCount += 1;
@@ -123,6 +124,9 @@
 
 
 - (void) failWithMessageFormat:(NSString *) messageFmt message:(NSString *) message {
+  if (!self.timer) { //to prevent accidental double writing of http chunks
+    return;
+  }
   [self.timer invalidate];
   self.timer = nil;
   [super failWithMessageFormat:messageFmt message:message];
@@ -130,6 +134,9 @@
 
 
 - (void) succeedWithResult:(NSArray *) result {
+  if (!self.timer) { //to prevent accidental double writing of http chunks
+    return;
+  }
   [self.timer invalidate];
   self.timer = nil;
   [super succeedWithResult:result];

--- a/calabash/Classes/FranklyServer/Routes/LPUIATapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPUIATapRoute.m
@@ -69,6 +69,7 @@
   if (self.timer == nil) {return;}
   if (self.curCount == self.maxCount) {
     [self failWithMessageFormat:@"Timed out waiting for view to not animate." message:nil];
+    return;
   }
   self.curCount += 1;
 


### PR DESCRIPTION
There was a path through the condition route which would write an http chunk twice leading to an invalid HTTP message (causing the client parser to throw an exception).

This should be fixed with this PR.