### PR TITLE
Guard calls to lpIsWebView since we also touch non UIView objects

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -42,7 +42,7 @@
     }
     
     return _view;
-  } else if ([_view lpIsWebView]) {
+  } else if ([_view respondsToSelector:@selector(lpIsWebView)] && [_view lpIsWebView]) {
     UIView<LPWebViewProtocol> *webView = (UIView<LPWebViewProtocol> *)_view;
     NSString *scrollJS = @"window.scrollBy(%@,%@);";
     if ([@"up" isEqualToString:dir]) {

--- a/calabash/Classes/FranklyServer/Routes/LPDumpRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPDumpRoute.m
@@ -69,7 +69,7 @@
   for (id view in children) {
     NSDictionary *viewDic = [LPJSONUtils jsonifyObject:view fullDump:YES];
     if ([viewDic isKindOfClass:[NSDictionary class]]) {
-      if ([view lpIsWebView]) {
+      if ([view respondsToSelector:@selector(lpIsWebView)] && [view lpIsWebView]) {
         NSMutableDictionary *viewCopy = [NSMutableDictionary dictionaryWithDictionary:viewDic];
         viewCopy[@"children"] =
         @[[LPWebQuery dictionaryOfViewsInWebView:(UIView<LPWebViewProtocol> *)view]];

--- a/calabash/Classes/UISpec/UIScriptASTWith.m
+++ b/calabash/Classes/UISpec/UIScriptASTWith.m
@@ -115,7 +115,7 @@
         [res addObject:dict];
       }
     } else {
-      if ([v lpIsWebView]) {
+      if ([v respondsToSelector:@selector(lpIsWebView)] && [v lpIsWebView]) {
         [res addObjectsFromArray:[self handleWebView:(UIView<LPWebViewProtocol> *) v
                                           visibility:visibility]];
         continue;


### PR DESCRIPTION
We had several call sites which called `lpIsWebView` unguarded. Since the view hierarchy can contain both DOM elements (dictionaries) as well as accessibility objects this could lead to crashes.