### PR TITLE
Release/0.14.1:  Wrong merge branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.14.1
+
+* Guard calls to lpIsWebView since we also query non-UIView objects #152
+* Fix fall-through causing double write of http chunk #151
+* Fix case where a coordinate is inf or nan #150
+
 ### 0.14.0
 
 * Handle case where DOCUMENT\_NODE has empty rect #148

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
@@ -21,7 +21,7 @@
  Do not change the 'CALABASH VERSION' portion of the following constant without
  updating the ruby API.
  ******************/
-#define kLPCALABASHVERSION @"CALABASH VERSION: 0.14.0"
+#define kLPCALABASHVERSION @"CALABASH VERSION: 0.14.1"
 
 @interface LPVersionRoute : NSObject <LPRoute>
 


### PR DESCRIPTION
### 0.14.1

* Guard calls to lpIsWebView since we also query non-UIView objects #152
* Fix fall-through causing double write of http chunk #151
* Fix case where a coordinate is inf or nan #150
