### PR TITLE
Try/Catch around LPInvoker invokeSelector:withTarget:

### DIFF
--- a/calabash/Classes/Utils/LPInvoker.m
+++ b/calabash/Classes/Utils/LPInvoker.m
@@ -111,12 +111,22 @@ NSString *const LPUnspecifiedInvocationError = @"*invocation error*";
   if ([invoker selectorReturnsObject]) {
     NSInvocation *invocation = invoker.invocation;
 
-    void *buffer;
+    id result = nil;
 
-    [invocation invoke];
-    [invocation getReturnValue:&buffer];
-
-    id result = (__bridge id)buffer;
+    @try {
+      void *buffer;
+      [invocation invoke];
+      [invocation getReturnValue:&buffer];
+      result = (__bridge id)buffer;
+    } @catch (NSException *exception) {
+      NSLog(@"LPInvoker caught an exception: %@", exception);
+      NSLog(@"=== INVOCATION DETAILS ===");
+      NSLog(@"target = %@", target);
+      NSLog(@"target class = %@", [target class]);
+      NSLog(@"selector = %@", NSStringFromSelector(selector));
+      NSLog(@"target responds to selector: %@", [target respondsToSelector:selector] ? @"YES" : @"NO");
+      result = nil;
+    }
 
     if(!result) {
       return [NSNull null];


### PR DESCRIPTION
### Motivation

NSNumber is receiving an unrecognized selector isEqualToString:.

This is being thrown when we ask for the accessibilityLabel of a UITextField.

As far as I can tell, we are not directly responsible for calling isEqualToString on the NSNumber instance.

### Stack trace

```
	NSInvalidArgumentException: -[__NSCFNumber isEqualToString:]: unrecognized selector sent to instance 0x7ae719c0
		0   CoreFoundation                      0x0768c746 __exceptionPreprocess + 182
		1   libobjc.A.dylib                     0x07a31a97 objc_exception_throw + 44
		2   CoreFoundation                      0x07694705 -[NSObject(NSObject) doesNotRecognizeSelector:] + 277
		3   CoreFoundation                      0x075db287 ___forwarding___ + 1047
		4   CoreFoundation                      0x075dae4e _CF_forwarding_prep_0 + 14
		5   MessageUIFramework                  0x18ed0f28 -[UIMessageUITextFieldAccessibility accessibilityLabel] + 90
		6   CoreFoundation                      0x0756d84d __invoking___ + 29
		7   CoreFoundation                      0x0756d6f8 -[NSInvocation invoke] + 360
		8   PatientHubFrameworkTouch            0x00128461 +[LPInvoker invokeSelector:withTarget:] + 545
		9   PatientHubFrameworkTouch            0x0011e96d +[LPJSONUtils dictionary:setObjectforKey:whenTarget:respondsTo:] + 221
		10  PatientHubFrameworkTouch            0x001201c9 +[LPJSONUtils dictionaryByEncodingView:] + 809
		11  PatientHubFrameworkTouch            0x0011f7bc +[LPJSONUtils jsonifyObject:fullDump:] + 876
		12  PatientHubFrameworkTouch            0x0011f412 +[LPJSONUtils jsonifyObject:] + 98
		13  PatientHubFrameworkTouch            0x000f6f06 -[LPQueryAllOperation performWithTarget:error:] + 134
		14  PatientHubFrameworkTouch            0x000f9b89 -[LPQueryOperation performWithTarget:error:] + 89
```

### Catching the exception

```
PatientHubFrameworkTouch[11661]: LPInvoker caught an exception: -[__NSCFNumber isEqualToString:]: 
                                 unrecognized selector sent to instance 0x7b783860
PatientHubFrameworkTouch[11661]: === INVOCATION DETAILS ===
PatientHubFrameworkTouch[11661]: target = <UITextField: 0x7b616aa0; frame = (58 268; 204 30); text = 'Password1'; clipsToBounds = YES; opaque = NO; autoresize = RM+BM; gestureRecognizers = <NSArray: 0x7e1572c0>; layer = <CALayer: 0x7b61bd40>>
PatientHubFrameworkTouch[11661]: target class = UITextField
PatientHubFrameworkTouch[11661]: selector = accessibilityLabel
PatientHubFrameworkTouch[11661]: target responds to selector: YES
```

### Analysis

My best guess is that `UIMessageUITextFieldAccessibility` is part of the UITextField class cluster.  I cannot find this class in the iOS 8 private header sources.[1][2]  It does appear in the iOS 7 SDK.

The fact that we are not directly involved in calling `isEqualToString` on an NSNumber instance, makes me think this is an Apple bug.

- [1] https://github.com/nst/iOS-Runtime-Headers
- [2] https://github.com/ichitaso/iOS-iphoneheaders
