### PR TITLE
LPSliderOperation should support any UIControlEvent the target slider is registered to receive

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -61,20 +61,10 @@
   [slider setValue:targetValue animated:animate];
 
   if (notifyTargets) {
-    NSSet *targets = [slider allTargets];
-    for (id target in targets) {
-      NSArray *actions = [slider actionsForTarget:target
-                                  forControlEvent:UIControlEventValueChanged];
-      for (NSString *action in actions) {
-        SEL sel = NSSelectorFromString(action);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        [target performSelector:sel withObject:slider];
-#pragma clang diagnostic pop
-      }
-    }
+    [slider sendActionsForControlEvents:UIControlEventValueChanged];
   }
 
   return [LPJSONUtils jsonifyObject:_view];
 }
+
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -66,6 +66,6 @@
   }
 
   return [LPJSONUtils jsonifyObject:_view];
-}
 
+}
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "LPSliderOperation.h"
+#import "LPJSONUtils.h"
 
 @implementation LPSliderOperation
 
@@ -74,6 +75,6 @@
     }
   }
 
-  return _view;
+  return [LPJSONUtils jsonifyObject:_view];
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -61,7 +61,8 @@
   [slider setValue:targetValue animated:animate];
 
   if (notifyTargets) {
-    [slider sendActionsForControlEvents:UIControlEventValueChanged];
+    UIControlEvents events = [slider allControlEvents];
+    [slider sendActionsForControlEvents:UIControlEventAllEvents];
   }
 
   return [LPJSONUtils jsonifyObject:_view];


### PR DESCRIPTION
### Motivation

We got a feature request to support UIControlEvents other than UIControlEventValueDidChange for UISlider.

### TODO

- [x] @krukow This is a little beyond the scope of the original API.  Are you comfortable?

### Testing

With briar-ios-example.