### PR TITLE
More guards in [LPJSONUtils jsonifyAccessibilityElement:] against unrecognized selectors

### DIFF
--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -35,6 +35,11 @@
          whenTarget:(id) target
          respondsTo:(SEL) selector;
 
++ (void) dictionary:(NSMutableDictionary *) dictionary
+ ensureObjectForKey:(NSString *) key
+         withTarget:(id) target
+           selector:(SEL) selector;
+
 + (NSMutableDictionary *) dictionaryByEncodingView:(id) view;
 + (void) insertHitPointIntoMutableDictionary:(NSMutableDictionary *) dictionary;
 
@@ -778,3 +783,34 @@
 }
 
 @end
+
+SpecBegin(LPJSONUtils)
+
+describe(@"dictionary:ensureObjectForKey:withTarget:selector:", ^{
+
+  it(@"inserts nil when target does not respond to selector", ^{
+    NSMutableDictionary *dict = [@{} mutableCopy];
+    SEL sel = NSSelectorFromString(@"doesNotExistSelector");
+    NSObject *target = [NSObject new];
+    [LPJSONUtils dictionary:dict
+         ensureObjectForKey:@"key"
+                 withTarget:target
+                   selector:sel];
+    expect(dict.count).to.equal(1);
+    expect(dict[@"key"]).to.equal([NSNull null]);
+  });
+
+  it(@"inserts a value when target does respond", ^{
+    NSMutableDictionary *dict = [@{} mutableCopy];
+    NSObject *target = [NSObject new];
+    SEL sel = NSSelectorFromString(@"description");
+    [LPJSONUtils dictionary:dict
+         ensureObjectForKey:@"key"
+                 withTarget:target
+                   selector:sel];
+    expect(dict.count).to.equal(1);
+    expect(dict[@"key"]).to.beAKindOf([NSString class]);
+  });
+});
+
+SpecEnd

--- a/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
@@ -89,7 +89,7 @@
 
 @end
 
-SpecBegin(LPJSONUtils)
+SpecBegin(LPJSONUtilsAccessibilityElement)
 
 describe(@".jsonifyAccessibilityElement:", ^{
   it(@"returns dictionary with correct key/value pairs", ^{

--- a/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
@@ -1,0 +1,80 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPJSONUtils.h"
+
+@interface LPJSONUtils (LPXCTEST)
+
++(NSMutableDictionary*)jsonifyAccessibilityElement:(id)object;
+
+@end
+
+@interface LPTestAccessibilityElement : NSObject
+
+- (NSString *) accessibilityLabel;
+// Don't implement this because jsonifyAccessibilityElement sets this directly.
+//- (BOOL) accessibilityElement;
+- (NSString *) accessibilityIdentifier;
+- (NSString *) accessibilityHint;
+- (NSString *) accessibilityValue;
+- (CGRect) accessibilityFrame;
+- (NSString *) text;
+// Don't implement this because jsonifyAccessibilityElement sets this directly.
+//- (BOOL) visible;
+- (BOOL) isSelected;
+- (BOOL) isEnabled;
+- (CGFloat) alpha;
+- (NSString *) description;
+
+@end
+
+@implementation LPTestAccessibilityElement
+
+- (NSString *) accessibilityLabel { return @"label"; }
+- (NSString *) accessibilityIdentifier { return @"id"; }
+- (NSString *) accessibilityHint { return @"hint"; }
+- (NSString *) accessibilityValue { return @"value"; }
+- (CGRect) accessibilityFrame { return CGRectZero; }
+- (NSString *) text { return @"text"; }
+- (BOOL) isSelected { return YES; }
+- (BOOL) isEnabled { return YES; }
+- (CGFloat) alpha { return 1.0; }
+- (NSString *) description { return @"description"; }
+
+@end
+
+SpecBegin(LPJSONUtils)
+
+describe(@".jsonifyAccessibilityElement:", ^{
+  it(@"returns dictionary with correct key/value pairs", ^{
+    LPTestAccessibilityElement *obj = [LPTestAccessibilityElement new];
+    NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
+
+    expect(dict.count).to.equal(13);
+    for (NSString *key in [dict allKeys]) {
+      id value = dict[key];
+      if ([key isEqualToString:@"class"]) {
+        expect(value).to.equal(NSStringFromClass([obj class]));
+      } else if ([key isEqualToString:@"rect"]) {
+        expect(value).to.beAKindOf([NSDictionary class]);
+        for (NSString *frameKey in [value allKeys]) {
+          expect(value[frameKey]).to.equal(@(0));
+        }
+      } else if ([key isEqualToString:@"selected"] ||
+                 [key isEqualToString:@"enabled"]  ||
+                 [key isEqualToString:@"accessibilityElement"]  ||
+                 [key isEqualToString:@"visible"]) {
+        expect(value).to.equal(@(1));
+      } else if ([key isEqualToString:@"alpha"]) {
+        expect(value).to.equal(@(1.0));
+      } else {
+        expect(value).to.equal(key);
+      }
+    }
+
+    NSLog(@"dict = %@", dict);
+  });
+});
+
+SpecEnd

--- a/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
@@ -92,31 +92,34 @@
 SpecBegin(LPJSONUtilsAccessibilityElement)
 
 describe(@".jsonifyAccessibilityElement:", ^{
-  it(@"returns dictionary with correct key/value pairs", ^{
-    LPTestAccessibilityElement *obj = [LPTestAccessibilityElement new];
-    NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
 
-    expect(dict.count).to.equal(13);
-    for (NSString *key in [dict allKeys]) {
-      id value = dict[key];
-      if ([key isEqualToString:@"class"]) {
-        expect(value).to.equal(NSStringFromClass([obj class]));
-      } else if ([key isEqualToString:@"rect"]) {
-        expect(value).to.beAKindOf([NSDictionary class]);
-        for (NSString *frameKey in [value allKeys]) {
-          expect(value[frameKey]).to.equal(@(0));
+  describe(@"LPTestAccessibilityElement instance", ^{
+    it(@"returns dictionary with correct key/value pairs", ^{
+      LPTestAccessibilityElement *obj = [LPTestAccessibilityElement new];
+      NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
+
+      expect(dict.count).to.equal(13);
+      for (NSString *key in [dict allKeys]) {
+        id value = dict[key];
+        if ([key isEqualToString:@"class"]) {
+          expect(value).to.equal(NSStringFromClass([obj class]));
+        } else if ([key isEqualToString:@"rect"]) {
+          expect(value).to.beAKindOf([NSDictionary class]);
+          for (NSString *frameKey in [value allKeys]) {
+            expect(value[frameKey]).to.equal(@(0));
+          }
+        } else if ([key isEqualToString:@"selected"] ||
+                   [key isEqualToString:@"enabled"]  ||
+                   [key isEqualToString:@"accessibilityElement"]  ||
+                   [key isEqualToString:@"visible"]) {
+          expect(value).to.equal(@(1));
+        } else if ([key isEqualToString:@"alpha"]) {
+          expect(value).to.equal(@(1.0));
+        } else {
+          expect(value).to.equal(key);
         }
-      } else if ([key isEqualToString:@"selected"] ||
-                 [key isEqualToString:@"enabled"]  ||
-                 [key isEqualToString:@"accessibilityElement"]  ||
-                 [key isEqualToString:@"visible"]) {
-        expect(value).to.equal(@(1));
-      } else if ([key isEqualToString:@"alpha"]) {
-        expect(value).to.equal(@(1.0));
-      } else {
-        expect(value).to.equal(key);
       }
-    }
+    });
   });
 
   describe(@"finding the frame rect", ^{
@@ -135,6 +138,24 @@ describe(@".jsonifyAccessibilityElement:", ^{
       expect(dict.count).to.equal(10);
       expect(dict[@"rect"]).to.equal([NSNull null]);
     });
+  });
+
+  it(@"NSOject instance", ^{
+    id obj = [NSObject new];
+    NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
+    expect(dict.count).to.equal(10);
+  });
+
+  it(@"UIView instance", ^{
+    id obj = [[UIView alloc] initWithFrame:CGRectZero];
+    NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
+    expect(dict.count).to.equal(12);
+  });
+
+  fit(@"UIControl instance", ^{
+    id obj = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+    NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
+    expect(dict.count).to.equal(13);
   });
 });
 

--- a/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
@@ -125,14 +125,14 @@ describe(@".jsonifyAccessibilityElement:", ^{
                                  initWithSelector:@selector(accessibilityFrame)];
 
       NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
-      expect(dict.count).to.equal(9);
+      expect(dict.count).to.equal(10);
       expect(dict[@"value"]).to.equal([NSNull null]);
     });
 
     it(@"can handle accessibilityFrame raising an exception", ^{
       LPRaisesOnAccessibilityFrame *obj = [LPRaisesOnAccessibilityFrame new];
       NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
-      expect(dict.count).to.equal(9);
+      expect(dict.count).to.equal(10);
       expect(dict[@"value"]).to.equal([NSNull null]);
     });
   });

--- a/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtils_AccessibilityElementTest.m
@@ -126,14 +126,14 @@ describe(@".jsonifyAccessibilityElement:", ^{
 
       NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
       expect(dict.count).to.equal(10);
-      expect(dict[@"value"]).to.equal([NSNull null]);
+      expect(dict[@"rect"]).to.equal([NSNull null]);
     });
 
     it(@"can handle accessibilityFrame raising an exception", ^{
       LPRaisesOnAccessibilityFrame *obj = [LPRaisesOnAccessibilityFrame new];
       NSDictionary *dict = [LPJSONUtils jsonifyAccessibilityElement:obj];
       expect(dict.count).to.equal(10);
-      expect(dict[@"value"]).to.equal([NSNull null]);
+      expect(dict[@"rect"]).to.equal([NSNull null]);
     });
   });
 });

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -543,6 +543,7 @@
 		F537398D18E5253B004133FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
 		F537399B18E6E0BE004133FA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F537399918E6E0BE004133FA /* main.m */; };
 		F5396A721AA6056D00D75E78 /* lp-simple-example.html in Resources */ = {isa = PBXBuildFile; fileRef = F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */; };
+		F5419F0D1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5419F0C1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F55185571AC3866300CE06DC /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5A33A721AC01E8E00224639 /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F55185581AC3875200CE06DC /* LPWebViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F5A33A601AC01A9F00224639 /* LPWebViewProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F55185591AC3875900CE06DC /* UIWebView+LPWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5A33A4F1AC00D1300224639 /* UIWebView+LPWebView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1029,6 +1030,7 @@
 		F537398C18E5253B004133FA /* version */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = version; sourceTree = BUILT_PRODUCTS_DIR; };
 		F537399918E6E0BE004133FA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "lp-simple-example.html"; sourceTree = "<group>"; };
+		F5419F0C1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPJSONUtils_AccessibilityElementTest.m; sourceTree = "<group>"; };
 		F5543F211ABF7D7000E1A0BF /* LPPluginLoaderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPPluginLoaderTest.m; sourceTree = "<group>"; };
 		F5543F231ABF7DE900E1A0BF /* LPPluginLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPPluginLoader.h; sourceTree = "<group>"; };
 		F5543F241ABF7DE900E1A0BF /* LPPluginLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPPluginLoader.m; sourceTree = "<group>"; };
@@ -1735,6 +1737,7 @@
 				F5C224DF1AD473F0001DB4FA /* LPTouchUtilsTest.m */,
 				F5C224D61AD472B1001DB4FA /* LPInvoker */,
 				F5543F211ABF7D7000E1A0BF /* LPPluginLoaderTest.m */,
+				F5419F0C1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2989,6 +2992,7 @@
 				F50CBF911A04058C004AC9DA /* LPCollectionViewScrollToItemOperation.m in Sources */,
 				F50CBF9F1A040599004AC9DA /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */,
 				F50CBFB81A0405CE004AC9DA /* LPCJSONSerializer.m in Sources */,
+				F5419F0D1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m in Sources */,
 				F50CBF7A1A040511004AC9DA /* LPTouchUtils.m in Sources */,
 				F50CBFAC1A0405B2004AC9DA /* LPMapRoute.m in Sources */,
 				F50CBFC01A0405CE004AC9DA /* UIScriptASTFirst.m in Sources */,

--- a/calabash/Classes/Utils/LPInvoker.m
+++ b/calabash/Classes/Utils/LPInvoker.m
@@ -121,7 +121,6 @@ NSString *const LPUnspecifiedInvocationError = @"*invocation error*";
     } @catch (NSException *exception) {
       NSLog(@"LPInvoker caught an exception: %@", exception);
       NSLog(@"=== INVOCATION DETAILS ===");
-      NSLog(@"target = %@", target);
       NSLog(@"target class = %@", [target class]);
       NSLog(@"selector = %@", NSStringFromSelector(selector));
       NSLog(@"target responds to selector: %@", [target respondsToSelector:selector] ? @"YES" : @"NO");

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -312,61 +312,51 @@
   result[@"visible"] = @(1);
   result[@"accessibilityElement"] = @(1);
 
-  NSString *lbl = [object accessibilityLabel];
-  if (lbl) {
-    [result setObject:lbl forKey:@"label"];
-  } else {
-    [result setObject:[NSNull null] forKey:@"label"];
-  }
+  // Be defensive: user *might* have a view with a 'nil' description.
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"description"
+               whenTarget:object
+               respondsTo:@selector(description)];
 
-  if ([object respondsToSelector:@selector(accessibilityIdentifier)]) {
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"label"
+               whenTarget:object
+               respondsTo:@selector(accessibilityLabel)];
 
-    NSString *aid = [object accessibilityIdentifier];
-    if (aid) {
-      [result setObject:aid forKey:@"id"];
-    } else {
-      [result setObject:[NSNull null] forKey:@"id"];
-    }
-  }
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"id"
+               whenTarget:object
+               respondsTo:@selector(accessibilityIdentifier)];
 
-  if ([object respondsToSelector:@selector(accessibilityHint)]) {
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"hint"
+               whenTarget:object
+               respondsTo:@selector(accessibilityHint)];
 
-    NSString *accHint = [object accessibilityHint];
-    if (accHint) {
-      [result setObject:accHint forKey:@"hint"];
-    } else {
-      [result setObject:[NSNull null] forKey:@"hint"];
-    }
-  }
-  if ([object respondsToSelector:@selector(accessibilityValue)]) {
-    NSString *accVal = [object accessibilityValue];
-    if (accVal) {
-      [result setObject:accVal forKey:@"value"];
-    } else {
-      [result setObject:[NSNull null] forKey:@"value"];
-    }
-  }
-  if ([object respondsToSelector:@selector(text)]) {
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"value"
+               whenTarget:object
+               respondsTo:@selector(accessibilityValue)];
 
-    NSString *text = [object text];
-    if (text) {
-      [result setObject:text forKey:@"text"];
-    } else {
-      [result setObject:[NSNull null] forKey:@"text"];
-    }
-  }
-  if ([object respondsToSelector:@selector(isSelected)]) {
-    BOOL selected = [object isSelected];
-    [result setObject:@(selected) forKey:@"selected"];
-  }
-  if ([object respondsToSelector:@selector(isEnabled)]) {
-    BOOL enabled = [object isEnabled];
-    [result setObject:@(enabled) forKey:@"enabled"];
-  }
-  if ([object respondsToSelector:@selector(alpha)]) {
-    CGFloat alpha = [object alpha];
-    [result setObject:@(alpha) forKey:@"alpha"];
-  }
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"text"
+               whenTarget:object
+               respondsTo:@selector(text)];
+
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"selected"
+               whenTarget:object
+               respondsTo:@selector(isSelected)];
+
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"enabled"
+               whenTarget:object
+               respondsTo:@selector(isEnabled)];
+
+  [LPJSONUtils dictionary:result
+          setObjectforKey:@"alpha"
+               whenTarget:object
+               respondsTo:@selector(alpha)];
 
   CGRect frame = [object accessibilityFrame];
   CGPoint center = [LPTouchUtils centerOfFrame:frame shouldTranslate:YES];

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -337,34 +337,34 @@
 
   // Be defensive: user *might* have a view with a 'nil' description.
   [LPJSONUtils dictionary:result
-          setObjectforKey:@"description"
-               whenTarget:object
-               respondsTo:@selector(description)];
+       ensureObjectForKey:@"description"
+               withTarget:object
+                 selector:@selector(description)];
 
   [LPJSONUtils dictionary:result
-          setObjectforKey:@"label"
-               whenTarget:object
-               respondsTo:@selector(accessibilityLabel)];
+       ensureObjectForKey:@"label"
+               withTarget:object
+                 selector:@selector(accessibilityLabel)];
 
   [LPJSONUtils dictionary:result
-          setObjectforKey:@"id"
-               whenTarget:object
-               respondsTo:@selector(accessibilityIdentifier)];
+       ensureObjectForKey:@"id"
+               withTarget:object
+                 selector:@selector(accessibilityIdentifier)];
 
   [LPJSONUtils dictionary:result
-          setObjectforKey:@"hint"
-               whenTarget:object
-               respondsTo:@selector(accessibilityHint)];
+       ensureObjectForKey:@"hint"
+               withTarget:object
+               selector:@selector(accessibilityHint)];
 
   [LPJSONUtils dictionary:result
-          setObjectforKey:@"value"
-               whenTarget:object
-               respondsTo:@selector(accessibilityValue)];
+       ensureObjectForKey:@"value"
+               withTarget:object
+                 selector:@selector(accessibilityValue)];
 
   [LPJSONUtils dictionary:result
-          setObjectforKey:@"text"
-               whenTarget:object
-               respondsTo:@selector(text)];
+       ensureObjectForKey:@"text"
+               withTarget:object
+                 selector:@selector(text)];
 
   [LPJSONUtils dictionary:result
           setObjectforKey:@"selected"

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -18,10 +18,21 @@
 
 @interface LPJSONUtils ()
 
+// If the target responds to the selector, invoke the selector on the target and
+// insert the value into the dictionary.  LPInvoker is responsible for ensuring
+// the value is not nil and is an object (not a primative).
+// @todo Add check for nil key
 + (void) dictionary:(NSMutableDictionary *) dictionary
     setObjectforKey:(NSString *) key
          whenTarget:(id) target
          respondsTo:(SEL) selector;
+
+// If the target does not respond to the selector, insert NSNull for key.
+// @todo Add check for nil key
++ (void) dictionary:(NSMutableDictionary *) dictionary
+ ensureObjectForKey:(NSString *) key
+         withTarget:(id) target
+           selector:(SEL) selector;
 
 + (void) insertHitPointIntoMutableDictionary:(NSMutableDictionary *) dictionary;
 
@@ -36,6 +47,18 @@
   if ([target respondsToSelector:selector]) {
     id value = [LPInvoker invokeSelector:selector withTarget:target];
     [dictionary setObject:value forKey:key];
+  }
+}
+
++ (void) dictionary:(NSMutableDictionary *) dictionary
+ ensureObjectForKey:(NSString *) key
+         withTarget:(id) target
+           selector:(SEL) selector {
+  if ([target respondsToSelector:selector]) {
+    id value = [LPInvoker invokeSelector:selector withTarget:target];
+    [dictionary setObject:value forKey:key];
+  } else {
+    [dictionary setObject:[NSNull null] forKey:key];
   }
 }
 

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -309,9 +309,9 @@
   NSMutableDictionary *result = [NSMutableDictionary dictionary];
 
   result[@"class"] = NSStringFromClass([object class]);
-
-  [result setObject:@(1) forKey:@"visible"];
+  result[@"visible"] = @(1);
   result[@"accessibilityElement"] = @(1);
+
   NSString *lbl = [object accessibilityLabel];
   if (lbl) {
     [result setObject:lbl forKey:@"label"];
@@ -368,7 +368,6 @@
     [result setObject:@(alpha) forKey:@"alpha"];
   }
 
-
   CGRect frame = [object accessibilityFrame];
   CGPoint center = [LPTouchUtils centerOfFrame:frame shouldTranslate:YES];
   NSDictionary *frameDic = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:frame.origin.x], @"x",
@@ -379,9 +378,8 @@
                             [NSNumber numberWithFloat:center.y], @"center_y",
                             nil];
 
-  [result setObject:frameDic forKey:@"rect"];
-
-  [result setObject:[object description] forKey:@"description"];
+  result[@"rect"] = frameDic;
+  result[@"description"] = [object description];
 
   return result;
 }

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -358,18 +358,30 @@
                whenTarget:object
                respondsTo:@selector(alpha)];
 
-  CGRect frame = [object accessibilityFrame];
-  CGPoint center = [LPTouchUtils centerOfFrame:frame shouldTranslate:YES];
-  NSDictionary *frameDic = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:frame.origin.x], @"x",
-                            [NSNumber numberWithFloat:frame.origin.y], @"y",
-                            [NSNumber numberWithFloat:frame.size.width], @"width",
-                            [NSNumber numberWithFloat:frame.size.height], @"height",
-                            [NSNumber numberWithFloat:center.x], @"center_x",
-                            [NSNumber numberWithFloat:center.y], @"center_y",
-                            nil];
+  NSDictionary *frameDictionary = nil;
 
-  result[@"rect"] = frameDic;
-  result[@"description"] = [object description];
+  SEL frameSelector = @selector(accessibilityFrame);
+  if ([object respondsToSelector:frameSelector]) {
+    @try {
+      CGRect frame = [object accessibilityFrame];
+      CGPoint center = [LPTouchUtils centerOfFrame:frame shouldTranslate:YES];
+      NSMutableDictionary *tmp = [self serializeRect:frame];
+      tmp[@"center_x"] = [self normalizeFloat:center.x];
+      tmp[@"center_y"] = [self normalizeFloat:center.y];
+      frameDictionary = [NSDictionary dictionaryWithDictionary:tmp];
+    } @catch (NSException *exception) {
+      NSLog(@"LPJSONUtils caught an exception in jsonifyAccessibilityElement:");
+      NSLog(@"%@", exception);
+      NSLog(@"while trying to find the accessibilityFrame of this object:");
+      NSLog(@"%@", object);
+    }
+  }
+
+  if (frameDictionary) {
+    result[@"rect"] = frameDictionary;
+  } else {
+    result[@"rect"] = [NSNull null];
+  }
 
   return result;
 }

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -306,8 +306,9 @@
 }
 
 +(NSMutableDictionary*)jsonifyAccessibilityElement:(id)object {
-  NSMutableDictionary *result = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                    NSStringFromClass([object class]), @"class", nil];
+  NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+  result[@"class"] = NSStringFromClass([object class]);
 
   [result setObject:@(1) forKey:@"visible"];
   result[@"accessibilityElement"] = @(1);


### PR DESCRIPTION
### Motivation

Tightens up the `jsonifyAccessibilityElement:` method.

- [x] @krukow Needs a review.  It solves one class of problems, but I am still struggling with a element that has an accessibilityIdentifier that is an NSNumber.