### PR TITLE
Set GCC_TREAT_WARNINGS_AS_ERRORS=YES for command-line builds

### DIFF
--- a/scripts/make-calabash-dylib.rb
+++ b/scripts/make-calabash-dylib.rb
@@ -31,6 +31,7 @@ args =
             'SYMROOT=build',
             "-sdk #{sdk}",
             'IPHONEOS_DEPLOYMENT_TARGET=5.1.1',
+            'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
             xcpretty_available ? '| xcpretty -c' : ''
       ].join(' ')
 

--- a/scripts/make-calabash-lib.rb
+++ b/scripts/make-calabash-lib.rb
@@ -17,6 +17,7 @@ if target == 'version'
               "-target \"version\"",
               '-configuration Debug',
               'SYMROOT=build',
+              'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
               xcpretty_available ? '| xcpretty -c' : ''
         ].join(' ')
 
@@ -44,6 +45,7 @@ else
               '-derivedDataPath build',
               "-sdk #{sdk}",
               'IPHONEOS_DEPLOYMENT_TARGET=5.1.1',
+              'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
               xcpretty_available ? '| xcpretty -c' : ''
         ].join(' ')
 

--- a/scripts/make-frank-lib.rb
+++ b/scripts/make-frank-lib.rb
@@ -32,6 +32,7 @@ args =
             'ONLY_ACTIVE_ARCH=NO',
             "-sdk #{sdk}",
             'IPHONEOS_DEPLOYMENT_TARGET=5.1.1',
+            'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
             xcpretty_available ? '| xcpretty -c' : ''
       ].join(' ')
 

--- a/scripts/make-lp-test-app.rb
+++ b/scripts/make-lp-test-app.rb
@@ -29,6 +29,7 @@ args =
             '-scheme LPTestTarget',
             '-sdk iphonesimulator',
             '-configuration Debug',
+            'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
             '| xcpretty -c && exit ${PIPESTATUS[0]}'
       ]
 


### PR DESCRIPTION
### Motivation

Recently, we had a file that should have been under ARC, but was missing a flag.  A warning was generated, but uncaught during command-line builds.