### PR TITLE
LPJSONSerializer can encode arbitrary objects

### DIFF
--- a/LPTestTarget/AppDelegate.h
+++ b/LPTestTarget/AppDelegate.h
@@ -1,7 +1,9 @@
 #import <UIKit/UIKit.h>
+@class NSManagedObjectContext;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
+@property (strong, nonatomic, readonly) NSManagedObjectContext *managedObjectContext;
 
 @end

--- a/LPTestTarget/AppDelegate.m
+++ b/LPTestTarget/AppDelegate.m
@@ -1,10 +1,20 @@
 #import "AppDelegate.h"
+#import <CoreData/CoreData.h>
+#import "LPCoreDataStack.h"
 
 @interface AppDelegate ()
 
 @end
 
 @implementation AppDelegate
+
+@synthesize managedObjectContext = _managedObjectContext;
+
+- (NSManagedObjectContext *) managedObjectContext {
+  if (_managedObjectContext) { return _managedObjectContext; }
+  _managedObjectContext = [[LPCoreDataStack new] managedObjectContext];
+  return _managedObjectContext;
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   return YES;

--- a/LPTestTarget/LPCoreDataStack.h
+++ b/LPTestTarget/LPCoreDataStack.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@interface LPCoreDataStack : NSObject
+
+@property (readonly, strong, nonatomic) NSManagedObjectContext *managedObjectContext;
+@property (readonly, strong, nonatomic) NSManagedObjectModel *managedObjectModel;
+@property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+
+- (void) saveContext;
+
+@end

--- a/LPTestTarget/LPCoreDataStack.m
+++ b/LPTestTarget/LPCoreDataStack.m
@@ -1,0 +1,70 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPCoreDataStack.h"
+
+@implementation LPCoreDataStack
+
+@synthesize managedObjectContext = _managedObjectContext;
+@synthesize managedObjectModel = _managedObjectModel;
+@synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
+
+- (NSManagedObjectModel *) managedObjectModel {
+  if (_managedObjectModel != nil) { return _managedObjectModel; }
+  NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"LPTestTarget" withExtension:@"momd"];
+  _managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+  return _managedObjectModel;
+}
+
+- (NSPersistentStoreCoordinator *) persistentStoreCoordinator {
+  if (_persistentStoreCoordinator != nil) { return _persistentStoreCoordinator; }
+
+  _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc]
+                                 initWithManagedObjectModel:[self managedObjectModel]];
+  NSError *error = nil;
+  NSString *failureReason = @"There was an error creating or loading the application's saved data.";
+  if (![_persistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType
+                                                 configuration:nil
+                                                           URL:nil
+                                                       options:nil
+                                                         error:&error]) {
+
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    dict[NSLocalizedDescriptionKey] = @"Failed to initialize the application's saved data";
+    dict[NSLocalizedFailureReasonErrorKey] = failureReason;
+    dict[NSUnderlyingErrorKey] = error;
+    error = [NSError errorWithDomain:@"LP XCTest" code:9999 userInfo:dict];
+    NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+    abort();
+  }
+
+  return _persistentStoreCoordinator;
+}
+
+
+- (NSManagedObjectContext *) managedObjectContext {
+  if (_managedObjectContext != nil) { return _managedObjectContext; }
+
+  NSPersistentStoreCoordinator *coordinator = [self persistentStoreCoordinator];
+  if (!coordinator) { return nil; }
+
+  _managedObjectContext = [[NSManagedObjectContext alloc] init];
+  [_managedObjectContext setPersistentStoreCoordinator:coordinator];
+  return _managedObjectContext;
+}
+
+#pragma mark - Core Data Saving support
+
+- (void) saveContext {
+  NSManagedObjectContext *managedObjectContext = self.managedObjectContext;
+  if (managedObjectContext != nil) {
+    NSError *error = nil;
+    if ([managedObjectContext hasChanges] && ![managedObjectContext save:&error]) {
+      NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+      abort();
+    }
+  }
+}
+
+@end

--- a/LPTestTarget/LPServerEntity.h
+++ b/LPTestTarget/LPServerEntity.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@interface LPServerEntity : NSManagedObject
+
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *address;
+@property(nonatomic, assign) NSInteger lastPing;
+
+@end

--- a/LPTestTarget/LPServerEntity.m
+++ b/LPTestTarget/LPServerEntity.m
@@ -1,0 +1,24 @@
+#import "LPServerEntity.h"
+
+@implementation LPServerEntity
+
+@dynamic name;
+@dynamic address;
+@dynamic lastPing;
+
+// Apple does not recommend overriding description and accessing entity
+// properties.  We are trying to catch these exceptions and _not_ crash.
+//
+// The exception here is test the JSON serialization code.
+- (NSString *) description {
+  if ([self isFault]) {
+    @throw [NSException exceptionWithName:@"MyCoreDataException"
+     reason:@"called description when object is a fault"
+                                 userInfo:@{}];
+  }
+  return [super description];
+//  return [NSString stringWithFormat:@"<LPServerEntity %@ %@ %@ %@>",
+//          self.objectID, self.name, self.address, @(self.lastPing)];
+}
+
+@end

--- a/LPTestTarget/LPTestTarget.xcdatamodeld/XCTest.xcdatamodel/contents
+++ b/LPTestTarget/LPTestTarget.xcdatamodeld/XCTest.xcdatamodel/contents
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14D136" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
-    <entity name="Server" syncable="YES">
+    <entity name="Server" representedClassName="LPServerEntity" syncable="YES">
         <attribute name="address" attributeType="String" defaultValueString="localhost" indexed="YES" syncable="YES"/>
         <attribute name="lastPing" attributeType="Integer 64" defaultValueString="-1" indexed="YES" syncable="YES"/>
         <attribute name="name" attributeType="String" indexed="YES" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Server" positionX="-63" positionY="-18" width="128" height="30"/>
+        <element name="Server" positionX="-63" positionY="-18" width="128" height="90"/>
     </elements>
 </model>

--- a/LPTestTarget/LPTestTarget.xcdatamodeld/XCTest.xcdatamodel/contents
+++ b/LPTestTarget/LPTestTarget.xcdatamodeld/XCTest.xcdatamodel/contents
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14D136" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="Server" syncable="YES">
+        <attribute name="address" attributeType="String" defaultValueString="localhost" indexed="YES" syncable="YES"/>
+        <attribute name="lastPing" attributeType="Integer 64" defaultValueString="-1" indexed="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" indexed="YES" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Server" positionX="-63" positionY="-18" width="128" height="30"/>
+    </elements>
+</model>

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -4,6 +4,8 @@
 
 #import "LPCJSONSerializer.h"
 #import "LPJSONRepresentation.h"
+#import "AppDelegate.h"
+#import <CoreData/CoreData.h>
 
 @interface LPCJSONSerializer (LPXCTEST)
 
@@ -66,6 +68,7 @@ describe(@"LPCJSONSerializer", ^{
   __block NSData *data;
   __block NSData *mockData;
   __block id mock;
+
   before(^{
     serializer = [LPCJSONSerializer serializer];
     error = nil;
@@ -370,6 +373,29 @@ describe(@"LPCJSONSerializer", ^{
       expect(actual).to.equal(expected);
       expect(error).to.equal(nil);
       [mock verify];
+    });
+  });
+
+  describe(@"Handling NSManagedObjects", ^{
+     __block NSManagedObjectContext *context;
+    before(^{
+      AppDelegate *delegate = (AppDelegate *)[[UIApplication sharedApplication]
+                                              delegate];
+      context = delegate.managedObjectContext;
+      [context reset];
+      NSError *coreDataSaveError = nil;
+      BOOL success = [context save:&coreDataSaveError];
+      if (!success) {
+        NSLog(@"%@", coreDataSaveError);
+        abort();
+      }
+    });
+
+    it(@"#isNSManagedObject:", ^{
+      NSManagedObject *server =
+      [NSEntityDescription insertNewObjectForEntityForName:@"Server"
+                                    inManagedObjectContext:context];
+      expect([serializer isNSManagedObject:server]).to.equal(YES);
     });
   });
 });

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -3,11 +3,132 @@
 #endif
 
 #import "LPCJSONSerializer.h"
+#import "LPJSONRepresentation.h"
+
+@interface LPJsonifiable : NSObject <LPJSONRepresentation>
+
+@end
+
+@implementation LPJsonifiable
+
+- (NSData *) JSONDataRepresentation {
+  return [[NSString stringWithFormat:@"data"]
+          dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+@end
 
 SpecBegin(LPCJSONSerializer)
 
 describe(@"LPCJSONSerializer", ^{
 
+  describe(@"#serializeObject:error:", ^{
+
+    __block LPCJSONSerializer *serializer;
+    __block NSError *error;
+    __block NSData *data;
+    __block NSData *mockData;
+    __block id mock;
+    before(^{
+      serializer = [LPCJSONSerializer serializer];
+      error = nil;
+      mockData = [[NSString stringWithFormat:@"data"]
+                  dataUsingEncoding:NSUTF8StringEncoding];
+      mock = OCMPartialMock(serializer);
+    });
+
+    describe(@"valid JSON objects", ^{
+      it(@"NSNull", ^{
+        [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
+                                                    error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:[NSNull null] error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+
+      it(@"NSNumber", ^{
+        [[[mock expect] andReturn:mockData] serializeNumber:OCMOCK_ANY
+                                                      error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:@(1) error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+
+      it(@"NSString", ^{
+        [[[mock stub] andReturn:mockData] serializeString:OCMOCK_ANY
+                                                    error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:@"Right on!" error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+
+      });
+
+      it(@"NSDictionary", ^{
+        [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
+                                                          error:[OCMArg setTo:nil]];
+
+        data = [mock serializeObject:@{} error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+
+      it(@"NSArray", ^{
+        [[[mock expect] andReturn:mockData] serializeArray:OCMOCK_ANY
+                                                     error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:@[] error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+
+      it(@"NSDate", ^{
+        [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
+                                                      error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:[NSDate date] error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+
+      it(@"responds to JSONDataRepresentation", ^{
+        LPJsonifiable *json = [LPJsonifiable new];
+        mock = OCMPartialMock(json);
+        [[[mock expect] andReturn:mockData] JSONDataRepresentation];
+        data = [serializer serializeObject:mock error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+    });
+
+    describe(@"nil and NULL", ^{
+      it(@"nil", ^{
+
+      });
+
+      it(@"NULL", ^{
+
+      });
+    });
+
+    describe(@"arbitrary NSObjects", ^{
+      it(@"NSObject", ^{
+
+      });
+
+      it(@"UIView", ^{
+
+      });
+
+      it(@"NSManagedObject", ^{
+
+      });
+    });
+  });
 });
 
 SpecEnd

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -35,6 +35,69 @@ describe(@"LPCJSONSerializer", ^{
     mock = OCMPartialMock(serializer);
   });
 
+  describe(@"#isValidJSONObject:", ^{
+    describe(@"returns true for", ^{
+      describe(@"NSNull, nil, and NULL", ^{
+        it(@"NSNull", ^{
+          expect([serializer isValidJSONObject:[NSNull null]]).to.equal(YES);
+        });
+
+        it(@"nil", ^{
+          expect([serializer isValidJSONObject:nil]).to.equal(YES);
+        });
+
+        it(@"NULL", ^{
+          expect([serializer isValidJSONObject:NULL]).to.equal(YES);
+        });
+      });
+
+      it(@"NSNumber", ^{
+        expect([serializer isValidJSONObject:@(1)]).to.equal(YES);
+      });
+
+      it(@"NSString", ^{
+        expect([serializer isValidJSONObject:@"Hey!"]).to.equal(YES);
+      });
+
+      it(@"NSArray", ^{
+        expect([serializer isValidJSONObject:@[]]).to.equal(YES);
+      });
+
+      it(@"NSDictionary", ^{
+        expect([serializer isValidJSONObject:@{}]).to.equal(YES);
+      });
+
+      it(@"NSData", ^{
+        expect([serializer isValidJSONObject:[[NSData alloc] init]]).to.equal(YES);
+      });
+
+      it(@"NSDate", ^{
+        expect([serializer isValidJSONObject:[NSDate date]]).to.equal(YES);
+      });
+
+      it(@"responds to JSONDataRepresentation", ^{
+        LPJsonifiable *json = [LPJsonifiable new];
+        expect([serializer isValidJSONObject:json]).to.equal(YES);
+      });
+    });
+
+    describe(@"returns false for", ^{
+      it(@"NSObject", ^{
+        expect([serializer isValidJSONObject:[NSObject new]]).to.equal(NO);
+      });
+
+      it(@"UIView", ^{
+        UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
+        expect([serializer isValidJSONObject:view]).to.equal(NO);
+      });
+
+      it(@"NSManagedObject", ^{
+
+      });
+    });
+
+  });
+
   describe(@"#serializeObject:error:", ^{
 
     describe(@"valid JSON objects", ^{

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -85,6 +85,15 @@ describe(@"LPCJSONSerializer", ^{
         expect(error).to.equal(nil);
       });
 
+      it(@"NSData", ^{
+        [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
+                                                      error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:[[NSData alloc] init] error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
+      });
+
       it(@"NSDate", ^{
         [[[mock expect] andReturn:mockData] serializeDate:OCMOCK_ANY
                                                     error:[OCMArg setTo:nil]];

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -153,7 +153,7 @@ describe(@"LPCJSONSerializer", ^{
     describe(@"valid JSON objects", ^{
       it(@"NSNull", ^{
         [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
         data = [mock serializeObject:[NSNull null] error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -162,7 +162,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NSNumber", ^{
         [[[mock expect] andReturn:mockData] serializeNumber:OCMOCK_ANY
-                                                      error:[OCMArg setTo:nil]];
+                                                      error:[OCMArg setTo:error]];
         data = [mock serializeObject:@(1) error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -171,7 +171,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NSString", ^{
         [[[mock stub] andReturn:mockData] serializeString:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
         data = [mock serializeObject:@"Right on!" error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -181,7 +181,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NSArray", ^{
         [[[mock expect] andReturn:mockData] serializeArray:OCMOCK_ANY
-                                                     error:[OCMArg setTo:nil]];
+                                                     error:[OCMArg setTo:error]];
         data = [mock serializeObject:@[] error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -190,7 +190,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NSDictionary", ^{
         [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
-                                                          error:[OCMArg setTo:nil]];
+                                                          error:[OCMArg setTo:error]];
 
         data = [mock serializeObject:@{} error:&error];
         [mock verify];
@@ -200,7 +200,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NSData", ^{
         [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
-                                                      error:[OCMArg setTo:nil]];
+                                                      error:[OCMArg setTo:error]];
         data = [mock serializeObject:[[NSData alloc] init] error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -209,7 +209,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NSDate", ^{
         [[[mock expect] andReturn:mockData] serializeDate:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
         data = [mock serializeObject:[NSDate date] error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -230,7 +230,7 @@ describe(@"LPCJSONSerializer", ^{
     describe(@"nil and NULL", ^{
       it(@"nil", ^{
         [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
         data = [mock serializeObject:nil error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -239,7 +239,7 @@ describe(@"LPCJSONSerializer", ^{
 
       it(@"NULL", ^{
         [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
         data = [mock serializeObject:NULL error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -265,7 +265,7 @@ describe(@"LPCJSONSerializer", ^{
 
   it(@"#serializeDate:error:", ^{
     [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
-                                                  error:[OCMArg setTo:nil]];
+                                                  error:[OCMArg setTo:error]];
     data = [mock serializeDate:[NSDate date] error:&error];
     [mock verify];
     expect(data).to.beIdenticalTo(mockData);
@@ -325,7 +325,7 @@ describe(@"LPCJSONSerializer", ^{
     it(@"description selector returns nil", ^{
       LPHasNilDescription *hasNil = [LPHasNilDescription new];
       [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
-                                                  error:[OCMArg setTo:nil]];
+                                                  error:[OCMArg setTo:error]];
       data = [mock serializeInvalidJSONObject:hasNil error:&error];
       expect(data).to.beIdenticalTo(mockData);
       expect(error).to.equal(nil);
@@ -334,7 +334,7 @@ describe(@"LPCJSONSerializer", ^{
 
     it(@"description is non-nil", ^{
       [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
 
       NSObject *object = [NSObject new];
       data = [mock serializeInvalidJSONObject:object error:&error];
@@ -572,7 +572,7 @@ describe(@"LPCJSONSerializer", ^{
 
     it(@"serializes the dictionary", ^{
       [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
-                                                        error:[OCMArg setTo:nil]];
+                                                        error:[OCMArg setTo:error]];
 
       NSString *actual = [mock stringByEnsuringSerializationOfDictionary:@{}];
       [mock verify];
@@ -602,7 +602,7 @@ describe(@"LPCJSONSerializer", ^{
 
     it(@"serializes the array", ^{
       [[[mock expect] andReturn:mockData] serializeArray:OCMOCK_ANY
-                                                   error:[OCMArg setTo:nil]];
+                                                   error:[OCMArg setTo:error]];
 
       NSString *actual = [mock stringByEnsuringSerializationOfArray:@[]];
       [mock verify];
@@ -628,7 +628,7 @@ describe(@"LPCJSONSerializer", ^{
       BOOL yes = YES;
       [[[mock expect] andReturnValue:OCMOCK_VALUE(yes)] isValidJSONObject:object];
       [[[mock expect] andReturn:mockData] serializeObject:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
+                                                    error:[OCMArg setTo:error]];
 
       NSString *actual = [mock stringByEnsuringSerializationOfObject:object];
       [mock verify];
@@ -640,7 +640,7 @@ describe(@"LPCJSONSerializer", ^{
       BOOL no = NO;
       [[[mock expect] andReturnValue:OCMOCK_VALUE(no)] isValidJSONObject:object];
       [[[mock expect] andReturn:mockData] serializeInvalidJSONObject:OCMOCK_ANY
-                                                               error:[OCMArg setTo:nil]];
+                                                               error:[OCMArg setTo:error]];
 
       NSString *actual = [mock stringByEnsuringSerializationOfObject:object];
       [mock verify];

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -14,6 +14,7 @@
 - (BOOL) isNSManagedObject:(id) object;
 - (SEL) descriptionSelector;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
+- (BOOL)isValidJSONObject:(id)inObject;
 
 @end
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -22,6 +22,7 @@
 - (NSData *) serializeDictionary:(NSDictionary *) inDictionary error:(NSError **) outError;
 - (NSData *) serializeArray:(NSArray *) inArray error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
+- (NSData *) serializeObject:(id)inObject error:(NSError **) outError;
 
 - (NSString *) stringByDecodingNSData:(NSData *) data;
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -21,6 +21,8 @@
 - (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
 
+- (NSString *) stringByDecodingNSData:(NSData *) data;
+
 @end
 
 @interface LPJsonifiable : NSObject <LPJSONRepresentation>
@@ -525,6 +527,23 @@ describe(@"LPCJSONSerializer", ^{
       expect([actual rangeOfString:@"\"object\":\"<NSObject"].location).notTo.equal(NSNotFound);
       expect([actual rangeOfString:@"\"view\":\"<UIView"].location).notTo.equal(NSNotFound);
       expect(error).to.equal(nil);
+    });
+  });
+
+  describe(@"#stringByDecodingNSData:", ^{
+    it(@"can handle nil data argument", ^{
+      NSString *actual = [serializer stringByDecodingNSData:nil];
+      expect(actual).to.equal(@"null");
+    });
+
+    it(@"can handle NULL data argument", ^{
+      NSString *actual = [serializer stringByDecodingNSData:NULL];
+      expect(actual).to.equal(@"null");
+    });
+
+    it(@"can handle arbitrary data", ^{
+      NSString *actual = [serializer stringByDecodingNSData:mockData];
+      expect(actual).to.equal(@"mock data");
     });
   });
 });

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -578,6 +578,29 @@ describe(@"LPCJSONSerializer", ^{
       [mock verify];
       expect(actual).to.equal(@"mock data");
     });
+
+    describe(@"unable to serialze", ^{
+      it(@"there was no error", ^{
+        id object = @{};
+        [[[mock expect] andReturn:nil] serializeDictionary:OCMOCK_ANY
+                                                     error:[OCMArg setTo:nil]];
+
+        NSString *actual = [mock stringByEnsuringSerializationOfDictionary:object];
+        [mock verify];
+        expect([actual rangeOfString:@"Invalid JSON for "].location).notTo.equal(NSNotFound);
+      });
+
+      it (@"there was an error", ^{
+        id object = @{};
+        error = [NSError errorWithDomain:@"Domain" code:1 userInfo:@{}];
+        [[[mock expect] andReturn:nil] serializeDictionary:OCMOCK_ANY
+                                                error:[OCMArg setTo:error]];
+
+        NSString *actual = [mock stringByEnsuringSerializationOfDictionary:object];
+        [mock verify];
+        expect([actual rangeOfString:@"Invalid JSON for "].location).notTo.equal(NSNotFound);
+      });
+    });
   });
 
   describe(@"#stringByEnsuringSerializationOfArray:", ^{
@@ -607,6 +630,29 @@ describe(@"LPCJSONSerializer", ^{
       NSString *actual = [mock stringByEnsuringSerializationOfArray:@[]];
       [mock verify];
       expect(actual).to.equal(@"mock data");
+    });
+
+    describe(@"unable to serialze", ^{
+      it(@"there was no error", ^{
+        id object = @[];
+        [[[mock expect] andReturn:nil] serializeArray:OCMOCK_ANY
+                                                error:[OCMArg setTo:nil]];
+
+        NSString *actual = [mock stringByEnsuringSerializationOfArray:object];
+        [mock verify];
+        expect([actual rangeOfString:@"Invalid JSON for "].location).notTo.equal(NSNotFound);
+      });
+
+      it (@"there was an error", ^{
+        id object = @[];
+        error = [NSError errorWithDomain:@"Domain" code:1 userInfo:@{}];
+        [[[mock expect] andReturn:nil] serializeArray:OCMOCK_ANY
+                                                error:[OCMArg setTo:error]];
+
+        NSString *actual = [mock stringByEnsuringSerializationOfArray:object];
+        [mock verify];
+        expect([actual rangeOfString:@"Invalid JSON for "].location).notTo.equal(NSNotFound);
+      });
     });
   });
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -66,20 +66,20 @@ describe(@"LPCJSONSerializer", ^{
 
       });
 
-      it(@"NSDictionary", ^{
-        [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
-                                                          error:[OCMArg setTo:nil]];
-
-        data = [mock serializeObject:@{} error:&error];
+      it(@"NSArray", ^{
+        [[[mock expect] andReturn:mockData] serializeArray:OCMOCK_ANY
+                                                     error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:@[] error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
         expect(error).to.equal(nil);
       });
 
-      it(@"NSArray", ^{
-        [[[mock expect] andReturn:mockData] serializeArray:OCMOCK_ANY
-                                                     error:[OCMArg setTo:nil]];
-        data = [mock serializeObject:@[] error:&error];
+      it(@"NSDictionary", ^{
+        [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
+                                                          error:[OCMArg setTo:nil]];
+
+        data = [mock serializeObject:@{} error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
         expect(error).to.equal(nil);

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -116,11 +116,21 @@ describe(@"LPCJSONSerializer", ^{
 
     describe(@"nil and NULL", ^{
       it(@"nil", ^{
-
+        [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
+                                                    error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:nil error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
       });
 
       it(@"NULL", ^{
-
+        [[[mock expect] andReturn:mockData] serializeNull:OCMOCK_ANY
+                                                    error:[OCMArg setTo:nil]];
+        data = [mock serializeObject:NULL error:&error];
+        [mock verify];
+        expect(data).to.beIdenticalTo(mockData);
+        expect(error).to.equal(nil);
       });
     });
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -546,6 +546,24 @@ describe(@"LPCJSONSerializer", ^{
       expect(actual).to.equal(@"mock data");
     });
   });
+
+  describe(@"#stringByEnsuringSerializationOfDictionary:", ^{
+    it(@"can handling being passed a non-dictionary instance", ^{
+      id array = @[@(1), @(2), @(3)];
+      NSString *actual = [serializer stringByEnsuringSerializationOfDictionary:array];
+      expect(actual).notTo.equal(nil);
+      expect(actual.length).notTo.equal(0);
+    });
+
+    it(@"serializes the dictionary", ^{
+      [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
+                                                        error:[OCMArg setTo:nil]];
+
+      NSString *actual = [mock stringByEnsuringSerializationOfDictionary:@{}];
+      [mock verify];
+      expect(actual).to.equal(@"mock data");
+    });
+  });
 });
 
 SpecEnd

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -9,12 +9,17 @@
 
 @interface LPCJSONSerializer (LPXCTEST)
 
+- (BOOL)isValidJSONObject:(id)inObject;
 - (Class) classForNSManagedObject;
 - (BOOL) isCoreDataStackAvailable;
 - (BOOL) isNSManagedObject:(id) object;
 - (SEL) descriptionSelector;
+
+- (NSData *) serializeNull:(NSNull *) inNull error:(NSError **) outError;
+- (NSData *) serializeNumber:(NSNumber *) inNumber error:(NSError **) outError;
+- (NSData *) serializeString:(NSString *) inString error:(NSError **) outError;
+- (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
-- (BOOL)isValidJSONObject:(id)inObject;
 
 @end
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -44,6 +44,19 @@
 
 @end
 
+@interface LPDescriptionRaisesException : NSObject
+
+@end
+
+@implementation LPDescriptionRaisesException
+
+- (NSString *) description {
+  @throw [NSException exceptionWithName:@"An exception"
+                                 reason:@"just because" userInfo:@{}];
+}
+
+@end
+
 SpecBegin(LPCJSONSerializer)
 
 describe(@"LPCJSONSerializer", ^{
@@ -342,12 +355,12 @@ describe(@"LPCJSONSerializer", ^{
     });
 
     it(@"NSManagedObject", ^{
-      NSObject *object = [NSObject new];
+      LPDescriptionRaisesException *object = [LPDescriptionRaisesException new];
       BOOL yes = YES;
       [[[mock expect] andReturnValue:OCMOCK_VALUE(yes)] isCoreDataStackAvailable];
       [[[mock expect] andReturnValue:OCMOCK_VALUE(yes)] isNSManagedObject:object];
       NSString *expected = [NSString stringWithFormat:@"\"%@\"",
-                            [NSString stringWithFormat:LPJSONSerializerNSManageObjectFormatString,
+                            [NSString stringWithFormat:LPJSONSerializerNSManageObjectDescriptionFaultFormatString,
                              NSStringFromClass([object class])]];
 
       data = [mock serializeInvalidJSONObject:object error:&error];

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -5,6 +5,13 @@
 #import "LPCJSONSerializer.h"
 #import "LPJSONRepresentation.h"
 
+@interface LPCJSONSerializer (LPXCTEST)
+
+- (Class) classForNSManagedObject;
+- (BOOL) isCoreDataStackAvailable;
+
+@end
+
 @interface LPJsonifiable : NSObject <LPJSONRepresentation>
 
 @end
@@ -219,6 +226,20 @@ describe(@"LPCJSONSerializer", ^{
     [mock verify];
     expect(data).to.beIdenticalTo(mockData);
     expect(error).to.equal(nil);
+  });
+
+  describe(@"#isCoreDataStackAvailable", ^{
+    it(@"returns YES when stack is available", ^{
+      [[[mock expect] andReturn:[self class] ] classForNSManagedObject];
+      expect([mock isCoreDataStackAvailable]).to.equal(YES);
+      [mock verify];
+    });
+
+    it(@"returns NO when stack is not available", ^{
+      [[[mock expect] andReturn:nil] classForNSManagedObject];
+      expect([mock isCoreDataStackAvailable]).to.equal(NO);
+      [mock verify];
+    });
   });
 });
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -281,12 +281,18 @@ describe(@"LPCJSONSerializer", ^{
     it(@"does not respond to description selector", ^{
       SEL mockSelector = NSSelectorFromString(@"noSuchSelector");
       [[[mock expect] andReturnValue:OCMOCK_VALUE(mockSelector)] descriptionSelector];
-      [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
-                                                    error:[OCMArg setTo:nil]];
-
       NSObject *object = [NSObject new];
+
+      NSString *expected = [NSString stringWithFormat:@"\"%@\"",
+                            [NSString stringWithFormat:LPJSONSerializerDoesNotRespondToDescriptionFormatString,
+                             NSStringFromClass([object class])]];
       data = [mock serializeInvalidJSONObject:object error:&error];
-      expect(data).to.beIdenticalTo(mockData);
+
+      NSString *actual = [[NSString alloc] initWithBytes:[data bytes]
+                                                  length:[data length]
+                                                encoding:NSUTF8StringEncoding];
+
+      expect(actual).to.equal(expected);
       expect(error).to.equal(nil);
       [mock verify];
     });

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -22,20 +22,20 @@ SpecBegin(LPCJSONSerializer)
 
 describe(@"LPCJSONSerializer", ^{
 
-  describe(@"#serializeObject:error:", ^{
+  __block LPCJSONSerializer *serializer;
+  __block NSError *error;
+  __block NSData *data;
+  __block NSData *mockData;
+  __block id mock;
+  before(^{
+    serializer = [LPCJSONSerializer serializer];
+    error = nil;
+    mockData = [[NSString stringWithFormat:@"data"]
+                dataUsingEncoding:NSUTF8StringEncoding];
+    mock = OCMPartialMock(serializer);
+  });
 
-    __block LPCJSONSerializer *serializer;
-    __block NSError *error;
-    __block NSData *data;
-    __block NSData *mockData;
-    __block id mock;
-    before(^{
-      serializer = [LPCJSONSerializer serializer];
-      error = nil;
-      mockData = [[NSString stringWithFormat:@"data"]
-                  dataUsingEncoding:NSUTF8StringEncoding];
-      mock = OCMPartialMock(serializer);
-    });
+  describe(@"#serializeObject:error:", ^{
 
     describe(@"valid JSON objects", ^{
       it(@"NSNull", ^{
@@ -86,8 +86,8 @@ describe(@"LPCJSONSerializer", ^{
       });
 
       it(@"NSDate", ^{
-        [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
-                                                      error:[OCMArg setTo:nil]];
+        [[[mock expect] andReturn:mockData] serializeDate:OCMOCK_ANY
+                                                    error:[OCMArg setTo:nil]];
         data = [mock serializeObject:[NSDate date] error:&error];
         [mock verify];
         expect(data).to.beIdenticalTo(mockData);
@@ -128,6 +128,15 @@ describe(@"LPCJSONSerializer", ^{
 
       });
     });
+  });
+
+  it(@"#serializeDate:error:", ^{
+    [[[mock expect] andReturn:mockData] serializeString:OCMOCK_ANY
+                                                  error:[OCMArg setTo:nil]];
+    data = [mock serializeDate:[NSDate date] error:&error];
+    [mock verify];
+    expect(data).to.beIdenticalTo(mockData);
+    expect(error).to.equal(nil);
   });
 });
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -135,12 +135,7 @@ describe(@"LPCJSONSerializer", ^{
         UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
         expect([serializer isValidJSONObject:view]).to.equal(NO);
       });
-
-      it(@"NSManagedObject", ^{
-
-      });
     });
-
   });
 
   describe(@"#serializeObject:error:", ^{
@@ -242,17 +237,18 @@ describe(@"LPCJSONSerializer", ^{
       });
     });
 
-    describe(@"arbitrary NSObjects", ^{
+    describe(@"Returns NULL when object is invalid JSON object", ^{
       it(@"NSObject", ^{
-
+        data = [serializer serializeObject:[NSObject new] error:&error];
+        expect(data).to.equal(NULL);
+        expect(error).notTo.equal(nil);
       });
 
       it(@"UIView", ^{
-
-      });
-
-      it(@"NSManagedObject", ^{
-
+        data = [serializer serializeObject:[[UIView alloc] initWithFrame:CGRectZero]
+                                     error:&error];
+        expect(data).to.equal(NULL);
+        expect(error).notTo.equal(nil);
       });
     });
   });

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -336,7 +336,21 @@ describe(@"LPCJSONSerializer", ^{
     });
 
     it(@"NSManagedObject", ^{
+      NSObject *object = [NSObject new];
+      BOOL yes = YES;
+      [[[mock expect] andReturnValue:OCMOCK_VALUE(yes)] isCoreDataStackAvailable];
+      [[[mock expect] andReturnValue:OCMOCK_VALUE(yes)] isNSManagedObject:object];
+      NSString *expected = [NSString stringWithFormat:@"\"%@\"",
+                            [NSString stringWithFormat:LPJSONSerializerNSManageObjectFormatString,
+                             NSStringFromClass([object class])]];
 
+      data = [mock serializeInvalidJSONObject:object error:&error];
+      NSString *actual = [[NSString alloc] initWithBytes:[data bytes]
+                                                  length:[data length]
+                                                encoding:NSUTF8StringEncoding];
+      expect(actual).to.equal(expected);
+      expect(error).to.equal(nil);
+      [mock verify];
     });
   });
 });

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -1,0 +1,13 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPCJSONSerializer.h"
+
+SpecBegin(LPCJSONSerializer)
+
+describe(@"LPCJSONSerializer", ^{
+
+});
+
+SpecEnd

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -566,6 +566,24 @@ describe(@"LPCJSONSerializer", ^{
       expect(actual).to.equal(@"mock data");
     });
   });
+
+  describe(@"#stringByEnsuringSerializationOfArray:", ^{
+    it(@"can handling being passed a non-array instance", ^{
+      id dictionary = @{@"array" : @[@(1), @(2), @(3)]};
+      NSString *actual = [serializer stringByEnsuringSerializationOfArray:dictionary];
+      expect(actual).notTo.equal(nil);
+      expect(actual.length).notTo.equal(0);
+    });
+
+    it(@"serializes the array", ^{
+      [[[mock expect] andReturn:mockData] serializeArray:OCMOCK_ANY
+                                                   error:[OCMArg setTo:nil]];
+
+      NSString *actual = [mock stringByEnsuringSerializationOfArray:@[]];
+      [mock verify];
+      expect(actual).to.equal(@"mock data");
+    });
+  });
 });
 
 SpecEnd

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -9,6 +9,7 @@
 
 - (Class) classForNSManagedObject;
 - (BOOL) isCoreDataStackAvailable;
+- (SEL) descriptionSelector;
 
 @end
 
@@ -240,6 +241,10 @@ describe(@"LPCJSONSerializer", ^{
       expect([mock isCoreDataStackAvailable]).to.equal(NO);
       [mock verify];
     });
+  });
+
+  it(@"descriptionSelector", ^{
+    expect([serializer descriptionSelector]).to.equal(@selector(description));
   });
 });
 

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -19,8 +19,8 @@
 - (NSData *) serializeNumber:(NSNumber *) inNumber error:(NSError **) outError;
 - (NSData *) serializeString:(NSString *) inString error:(NSError **) outError;
 - (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
-- (NSData *)serializeDictionary:(NSDictionary *)inDictionary error:(NSError **)outError;
-
+- (NSData *) serializeDictionary:(NSDictionary *) inDictionary error:(NSError **) outError;
+- (NSData *) serializeArray:(NSArray *) inArray error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
 
 - (NSString *) stringByDecodingNSData:(NSData *) data;
@@ -557,6 +557,18 @@ describe(@"LPCJSONSerializer", ^{
       expect(actual.length).notTo.equal(0);
     });
 
+    it(@"can handle nil argument", ^{
+      NSString *actual = [serializer stringByEnsuringSerializationOfDictionary:nil];
+      expect(actual).notTo.equal(nil);
+      expect(actual.length).notTo.equal(0);
+    });
+
+    it(@"can handle NULL argument", ^{
+      NSString *actual = [serializer stringByEnsuringSerializationOfDictionary:NULL];
+      expect(actual).notTo.equal(nil);
+      expect(actual.length).notTo.equal(0);
+    });
+
     it(@"serializes the dictionary", ^{
       [[[mock expect] andReturn:mockData] serializeDictionary:OCMOCK_ANY
                                                         error:[OCMArg setTo:nil]];
@@ -571,6 +583,18 @@ describe(@"LPCJSONSerializer", ^{
     it(@"can handling being passed a non-array instance", ^{
       id dictionary = @{@"array" : @[@(1), @(2), @(3)]};
       NSString *actual = [serializer stringByEnsuringSerializationOfArray:dictionary];
+      expect(actual).notTo.equal(nil);
+      expect(actual.length).notTo.equal(0);
+    });
+
+    it(@"can handle nil argument", ^{
+      NSString *actual = [serializer stringByEnsuringSerializationOfArray:nil];
+      expect(actual).notTo.equal(nil);
+      expect(actual.length).notTo.equal(0);
+    });
+
+    it(@"can handle NULL argument", ^{
+      NSString *actual = [serializer stringByEnsuringSerializationOfArray:NULL];
       expect(actual).notTo.equal(nil);
       expect(actual.length).notTo.equal(0);
     });

--- a/XCTest/Tests/JSON/LPCJSONSerializerTest.m
+++ b/XCTest/Tests/JSON/LPCJSONSerializerTest.m
@@ -19,6 +19,8 @@
 - (NSData *) serializeNumber:(NSNumber *) inNumber error:(NSError **) outError;
 - (NSData *) serializeString:(NSString *) inString error:(NSError **) outError;
 - (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
+- (NSData *)serializeDictionary:(NSDictionary *)inDictionary error:(NSError **)outError;
+
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
 
 - (NSString *) stringByDecodingNSData:(NSData *) data;

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -538,6 +538,7 @@
 		F50CBFCE1A040669004AC9DA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F50CBFCD1A040669004AC9DA /* UIKit.framework */; };
 		F50CBFCF1A040707004AC9DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
 		F50E42791AA86D36003DB030 /* libSpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50E42711AA86D36003DB030 /* libSpecta.a */; };
+		F532C19B1AFD28970024DA55 /* LPCJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F537397318E5200C004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F537397418E52014004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F537398D18E5253B004133FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -1027,6 +1028,7 @@
 		F50E42761AA86D36003DB030 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSharedExampleGroups.h; sourceTree = "<group>"; };
 		F50E42771AA86D36003DB030 /* SPTSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSpec.h; sourceTree = "<group>"; };
 		F50E42781AA86D36003DB030 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCJSONSerializerTest.m; sourceTree = "<group>"; };
 		F537398C18E5253B004133FA /* version */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = version; sourceTree = BUILT_PRODUCTS_DIR; };
 		F537399918E6E0BE004133FA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "lp-simple-example.html"; sourceTree = "<group>"; };
@@ -1694,6 +1696,14 @@
 			name = ScrollToMark;
 			sourceTree = "<group>";
 		};
+		F532C1991AFD28970024DA55 /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+				F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */,
+			);
+			path = JSON;
+			sourceTree = "<group>";
+		};
 		F537399818E6E0BE004133FA /* VersionTool */ = {
 			isa = PBXGroup;
 			children = (
@@ -1722,6 +1732,7 @@
 				F50CBF761A03F69A004AC9DA /* LPTestToolsStandup.m */,
 				F5C224E41AD47403001DB4FA /* Operations */,
 				F5C224E61AD47403001DB4FA /* Routes */,
+				F532C1991AFD28970024DA55 /* JSON */,
 				F5A33A481AC009B600224639 /* WebViewQuery */,
 				F5543F201ABF7D7000E1A0BF /* Utils */,
 			);
@@ -2984,6 +2995,7 @@
 				F50CBFB01A0405B2004AC9DA /* LPAsyncPlaybackRoute.m in Sources */,
 				F50CBFC41A0405CE004AC9DA /* UIScriptParser.m in Sources */,
 				F50CBFAD1A0405B2004AC9DA /* LPRecordRoute.m in Sources */,
+				F532C19B1AFD28970024DA55 /* LPCJSONSerializerTest.m in Sources */,
 				F50CBF971A04058C004AC9DA /* LPOperation.m in Sources */,
 				F5C224C71ACDF299001DB4FA /* LPWKWebViewRuntimeLoader.m in Sources */,
 				F50CBFA11A0405B2004AC9DA /* LPKeychainRoute.m in Sources */,

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		F532C1DE1AFF4F080024DA55 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F532C1DD1AFF4F080024DA55 /* CoreData.framework */; };
 		F532C1E31AFF4F250024DA55 /* LPCoreDataStack.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */; };
 		F532C1E41AFF4F250024DA55 /* LPTestTarget.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F532C1E11AFF4F240024DA55 /* LPTestTarget.xcdatamodeld */; };
+		F532C1E71AFF6A2D0024DA55 /* LPServerEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C1E61AFF6A2D0024DA55 /* LPServerEntity.m */; };
 		F537397318E5200C004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F537397418E52014004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F537398D18E5253B004133FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -1036,6 +1037,8 @@
 		F532C1DF1AFF4F240024DA55 /* LPCoreDataStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCoreDataStack.h; sourceTree = "<group>"; };
 		F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCoreDataStack.m; sourceTree = "<group>"; };
 		F532C1E21AFF4F250024DA55 /* XCTest.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = XCTest.xcdatamodel; sourceTree = "<group>"; };
+		F532C1E51AFF6A2D0024DA55 /* LPServerEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPServerEntity.h; sourceTree = "<group>"; };
+		F532C1E61AFF6A2D0024DA55 /* LPServerEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPServerEntity.m; sourceTree = "<group>"; };
 		F537398C18E5253B004133FA /* version */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = version; sourceTree = BUILT_PRODUCTS_DIR; };
 		F537399918E6E0BE004133FA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "lp-simple-example.html"; sourceTree = "<group>"; };
@@ -1844,6 +1847,8 @@
 		F59CA46E1A82EF40007A2F38 /* LPTestTarget */ = {
 			isa = PBXGroup;
 			children = (
+				F532C1E51AFF6A2D0024DA55 /* LPServerEntity.h */,
+				F532C1E61AFF6A2D0024DA55 /* LPServerEntity.m */,
 				F532C1DF1AFF4F240024DA55 /* LPCoreDataStack.h */,
 				F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */,
 				F532C1E11AFF4F240024DA55 /* LPTestTarget.xcdatamodeld */,
@@ -3152,6 +3157,7 @@
 				F59CA47B1A82EF40007A2F38 /* SecondViewController.m in Sources */,
 				F532C1E31AFF4F250024DA55 /* LPCoreDataStack.m in Sources */,
 				F59CA4751A82EF40007A2F38 /* AppDelegate.m in Sources */,
+				F532C1E71AFF6A2D0024DA55 /* LPServerEntity.m in Sources */,
 				F59CA4781A82EF40007A2F38 /* FirstViewController.m in Sources */,
 				F532C1E41AFF4F250024DA55 /* LPTestTarget.xcdatamodeld in Sources */,
 				F59CA4721A82EF40007A2F38 /* main.m in Sources */,

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -539,6 +539,9 @@
 		F50CBFCF1A040707004AC9DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
 		F50E42791AA86D36003DB030 /* libSpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50E42711AA86D36003DB030 /* libSpecta.a */; };
 		F532C19B1AFD28970024DA55 /* LPCJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F532C1DE1AFF4F080024DA55 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F532C1DD1AFF4F080024DA55 /* CoreData.framework */; };
+		F532C1E31AFF4F250024DA55 /* LPCoreDataStack.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */; };
+		F532C1E41AFF4F250024DA55 /* LPTestTarget.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F532C1E11AFF4F240024DA55 /* LPTestTarget.xcdatamodeld */; };
 		F537397318E5200C004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F537397418E52014004133FA /* LPVersionRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B153F55A15949F3D00867E12 /* LPVersionRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F537398D18E5253B004133FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -1029,6 +1032,10 @@
 		F50E42771AA86D36003DB030 /* SPTSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSpec.h; sourceTree = "<group>"; };
 		F50E42781AA86D36003DB030 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Specta.h"; sourceTree = "<group>"; };
 		F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCJSONSerializerTest.m; sourceTree = "<group>"; };
+		F532C1DD1AFF4F080024DA55 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		F532C1DF1AFF4F240024DA55 /* LPCoreDataStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCoreDataStack.h; sourceTree = "<group>"; };
+		F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCoreDataStack.m; sourceTree = "<group>"; };
+		F532C1E21AFF4F250024DA55 /* XCTest.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = XCTest.xcdatamodel; sourceTree = "<group>"; };
 		F537398C18E5253B004133FA /* version */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = version; sourceTree = BUILT_PRODUCTS_DIR; };
 		F537399918E6E0BE004133FA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "lp-simple-example.html"; sourceTree = "<group>"; };
@@ -1240,6 +1247,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F532C1DE1AFF4F080024DA55 /* CoreData.framework in Frameworks */,
 				F55185571AC3866300CE06DC /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1304,6 +1312,7 @@
 		B121E79614B6D9FB0034C6A9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F532C1DD1AFF4F080024DA55 /* CoreData.framework */,
 				F5A33A721AC01E8E00224639 /* WebKit.framework */,
 				F50CBFCD1A040669004AC9DA /* UIKit.framework */,
 				B17E757A15D434D00066550B /* CFNetwork.framework */,
@@ -1835,6 +1844,9 @@
 		F59CA46E1A82EF40007A2F38 /* LPTestTarget */ = {
 			isa = PBXGroup;
 			children = (
+				F532C1DF1AFF4F240024DA55 /* LPCoreDataStack.h */,
+				F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */,
+				F532C1E11AFF4F240024DA55 /* LPTestTarget.xcdatamodeld */,
 				F5396A6D1AA6056D00D75E78 /* TestResources */,
 				F59CA4731A82EF40007A2F38 /* AppDelegate.h */,
 				F59CA4741A82EF40007A2F38 /* AppDelegate.m */,
@@ -3138,8 +3150,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				F59CA47B1A82EF40007A2F38 /* SecondViewController.m in Sources */,
+				F532C1E31AFF4F250024DA55 /* LPCoreDataStack.m in Sources */,
 				F59CA4751A82EF40007A2F38 /* AppDelegate.m in Sources */,
 				F59CA4781A82EF40007A2F38 /* FirstViewController.m in Sources */,
+				F532C1E41AFF4F250024DA55 /* LPTestTarget.xcdatamodeld in Sources */,
 				F59CA4721A82EF40007A2F38 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4186,6 +4200,19 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		F532C1E11AFF4F240024DA55 /* LPTestTarget.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				F532C1E21AFF4F250024DA55 /* XCTest.xcdatamodel */,
+			);
+			currentVersion = F532C1E21AFF4F250024DA55 /* XCTest.xcdatamodel */;
+			path = LPTestTarget.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = B121E78814B6D9FB0034C6A9 /* Project object */;
 }

--- a/calabash.xcodeproj/xcshareddata/xcschemes/XCTest.xcscheme
+++ b/calabash.xcodeproj/xcshareddata/xcschemes/XCTest.xcscheme
@@ -76,15 +76,6 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F50CBF5D1A03F222004AC9DA"
-            BuildableName = "XCTest.xctest"
-            BlueprintName = "XCTest"
-            ReferencedContainer = "container:calabash.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -30,7 +30,7 @@
 #import <Foundation/Foundation.h>
 
 extern NSString *const LPJSONSerializerNSManageObjectFormatString;
-
+extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
 @interface LPCJSONSerializer : NSObject {
 }

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -44,6 +44,7 @@
 - (NSData *)serializeString:(NSString *)inString error:(NSError **)outError;
 - (NSData *)serializeArray:(NSArray *)inArray error:(NSError **)outError;
 - (NSData *)serializeDictionary:(NSDictionary *)inDictionary error:(NSError **)outError;
+- (NSData *)serializeDate:(NSDate *) date error:(NSError **) outError;
 
 @end
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -29,7 +29,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *const LPJSONSerializerNSManageObjectFormatString;
+extern NSString *const LPJSONSerializerNSManageObjectDescriptionFaultFormatString;
 extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
 @interface LPCJSONSerializer : NSObject {

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -37,7 +37,6 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 + (LPCJSONSerializer *)serializer;
 
 /// Take any JSON compatible object (generally NSNull, NSNumber, NSString, NSArray and NSDictionary) and produce an NSData containing the serialized JSON.
-- (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
 - (NSString *) stringByEnsuringSerializationOfObject:(id) object;
 - (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -38,8 +38,7 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
 /// Take any JSON compatible object (generally NSNull, NSNumber, NSString, NSArray and NSDictionary) and produce an NSData containing the serialized JSON.
 - (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
-
-- (NSData *)serializeArray:(NSArray *)inArray error:(NSError **)outError;
+- (NSString *) stringByEnsuringSerilizationOfObject:(id) object;
 - (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -40,6 +40,7 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 - (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
 
 - (NSData *)serializeArray:(NSArray *)inArray error:(NSError **)outError;
+- (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;
 
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -29,6 +29,9 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString *const LPJSONSerializerNSManageObjectFormatString;
+
+
 @interface LPCJSONSerializer : NSObject {
 }
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -39,12 +39,8 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 /// Take any JSON compatible object (generally NSNull, NSNumber, NSString, NSArray and NSDictionary) and produce an NSData containing the serialized JSON.
 - (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
 
-- (NSData *)serializeNull:(NSNull *)inNull error:(NSError **)outError;
-- (NSData *)serializeNumber:(NSNumber *)inNumber error:(NSError **)outError;
-- (NSData *)serializeString:(NSString *)inString error:(NSError **)outError;
 - (NSData *)serializeArray:(NSArray *)inArray error:(NSError **)outError;
 - (NSData *)serializeDictionary:(NSDictionary *)inDictionary error:(NSError **)outError;
-- (NSData *)serializeDate:(NSDate *) date error:(NSError **) outError;
 
 @end
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -40,7 +40,6 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 - (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
 
 - (NSData *)serializeArray:(NSArray *)inArray error:(NSError **)outError;
-- (NSData *)serializeDictionary:(NSDictionary *)inDictionary error:(NSError **)outError;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;
 
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -36,7 +36,27 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
 + (LPCJSONSerializer *)serializer;
 
-/// Take any JSON compatible object (generally NSNull, NSNumber, NSString, NSArray and NSDictionary) and produce an NSData containing the serialized JSON.
+// Natively encodes JSON compatible objects:
+// * NSNull, nil, NULL
+// * NSNumber
+// * NSString
+// * NSArray
+// * NSDictionary
+// * NSData
+// * NSDate - part of Apple's JavaScript JSON API.
+//
+// For invalid JSON object, it calls `description` on the object and encodes
+// the result as a string.
+//
+// When `object` is an NSManagedObject, special care is taken when calling
+// `description` because developers will often override (against Apple's advice)
+// `description` which can result in faults.  If the object is an instance of
+// NSManagedObject, catch the exception and report the problem as part of the
+// JSON object.
+//
+// @todo We should be bubbling exceptional cases up to the response and marking
+// it as producing invalid JSON.  Otherwise the user may never see that there
+// is a potential problem in their app.
 - (NSString *) stringByEnsuringSerializationOfObject:(id) object;
 - (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -32,12 +32,9 @@
 extern NSString *const LPJSONSerializerNSManageObjectDescriptionFaultFormatString;
 extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
-@interface LPCJSONSerializer : NSObject {
-}
+@interface LPCJSONSerializer : NSObject
 
 + (LPCJSONSerializer *)serializer;
-
-- (BOOL)isValidJSONObject:(id)inObject;
 
 /// Take any JSON compatible object (generally NSNull, NSNumber, NSString, NSArray and NSDictionary) and produce an NSData containing the serialized JSON.
 - (NSData *)serializeObject:(id)inObject error:(NSError **)outError;

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -41,6 +41,7 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
 - (NSData *)serializeArray:(NSArray *)inArray error:(NSError **)outError;
 - (NSData *)serializeDictionary:(NSDictionary *)inDictionary error:(NSError **)outError;
+- (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;
 
 @end
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -38,7 +38,7 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 
 /// Take any JSON compatible object (generally NSNull, NSNumber, NSString, NSArray and NSDictionary) and produce an NSData containing the serialized JSON.
 - (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
-- (NSString *) stringByEnsuringSerilizationOfObject:(id) object;
+- (NSString *) stringByEnsuringSerializationOfObject:(id) object;
 - (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -40,6 +40,7 @@ static NSData *kTrue = NULL;
 
 @interface LPCJSONSerializer ()
 
+- (BOOL)isValidJSONObject:(id)inObject;
 - (Class) classForNSManagedObject;
 - (BOOL) isCoreDataStackAvailable;
 - (BOOL) isNSManagedObject:(id) object;

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -100,7 +100,7 @@ static NSData *kTrue = NULL;
     {
     NSData *theResult = NULL;
 
-    if ([inObject isKindOfClass:[NSNull class]])
+    if ([inObject isKindOfClass:[NSNull class]] || inObject == NULL || inObject == nil)
         {
         theResult = [self serializeNull:inObject error:outError];
         }

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -52,6 +52,8 @@ static NSData *kTrue = NULL;
 - (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
 
+- (NSString *) stringByDecodingNSData:(NSData *) data;
+
 @end
 
 @implementation LPCJSONSerializer
@@ -443,6 +445,17 @@ static NSData *kTrue = NULL;
     return [self serializeNull:[NSNull null] error:outError];
   }
   return [self serializeString:description error:outError];
+}
+
+- (NSString *) stringByDecodingNSData:(NSData *) data {
+  NSData *dataGuard = data;
+  if (!data) {
+    dataGuard = [self serializeNull:[NSNull null] error:nil];
+  }
+
+  return [[[NSString alloc] initWithBytes:[dataGuard bytes]
+                                   length:[dataGuard length]
+                                 encoding:NSUTF8StringEncoding] autorelease];
 }
 
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -30,6 +30,7 @@
 #import "LPCJSONSerializer.h"
 #import "LPISO8601DateFormatter.h"
 #import "LPJSONRepresentation.h"
+#import <objc/runtime.h>
 
 NSString *const LPJSONSerializerNSManageObjectDescriptionFaultFormatString = @"Calling 'description' on '%@' (an instance of NSManagedObject) caused a fault - this is probably a bug in your application.";
 NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString = @"'%@': does not respond to selector 'description' - this is probably a bug in your application.";

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -127,26 +127,7 @@ static NSData *kTrue = NULL;
         }
     else if ([inObject isKindOfClass:[NSDate class]])
     {
-        
-        static LPISO8601DateFormatter *dateFormat = nil;
-        if (dateFormat == nil)
-        {
-            dateFormat = [[LPISO8601DateFormatter alloc] init];
-            [dateFormat setIncludeTime:YES];
-        }
-
-        
-        
-       
-        NSString *str = [dateFormat stringFromDate:(NSDate*)inObject];
-        NSRange rangeButLastTwo = NSMakeRange(0, [str length]-2);
-        NSRange rangeLastTwo = NSMakeRange([str length]-2, 2);
-        
-        NSString *firstPart = [str substringWithRange:rangeButLastTwo];
-        NSString *lastPart = [str substringWithRange:rangeLastTwo];
-        
-        str = [NSString stringWithFormat:@"%@:%@",firstPart,lastPart];
-        theResult = [self serializeString:str error:outError];
+        theResult = [self serializeDate:(NSDate *)inObject error:outError];
     }
     else if ([inObject respondsToSelector:@selector(JSONDataRepresentation)])
         {
@@ -366,5 +347,23 @@ static NSData *kTrue = NULL;
 
     return(theData);
     }
+
+- (NSData *)serializeDate:(NSDate *)date error:(NSError **)outError{
+  static LPISO8601DateFormatter *dateFormat = nil;
+  if (dateFormat == nil) {
+    dateFormat = [[LPISO8601DateFormatter alloc] init];
+    [dateFormat setIncludeTime:YES];
+  }
+
+  NSString *str = [dateFormat stringFromDate:date];
+  NSRange rangeButLastTwo = NSMakeRange(0, [str length]-2);
+  NSRange rangeLastTwo = NSMakeRange([str length]-2, 2);
+
+  NSString *firstPart = [str substringWithRange:rangeButLastTwo];
+  NSString *lastPart = [str substringWithRange:rangeLastTwo];
+
+  str = [NSString stringWithFormat:@"%@:%@",firstPart,lastPart];
+  return [self serializeString:str error:outError];
+}
 
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -45,6 +45,11 @@ static NSData *kTrue = NULL;
 - (BOOL) isCoreDataStackAvailable;
 - (BOOL) isNSManagedObject:(id) object;
 - (SEL) descriptionSelector;
+
+- (NSData *) serializeNull:(NSNull *) inNull error:(NSError **) outError;
+- (NSData *) serializeNumber:(NSNumber *) inNumber error:(NSError **) outError;
+- (NSData *) serializeString:(NSString *) inString error:(NSError **) outError;
+- (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
 
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -458,4 +458,31 @@ static NSData *kTrue = NULL;
                                  encoding:NSUTF8StringEncoding] autorelease];
 }
 
+- (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary {
+  if (![dictionary isKindOfClass:[NSDictionary class]]) {
+    NSString *className = NSStringFromClass([dictionary class]);
+    NSLog(@"Expected NSDictionary but found instance of '%@'.\nCannot serialize object.",
+          className);
+    NSString *json = [NSString stringWithFormat:@"Cannot serialize instance of '%@' as a dictionary.",
+                      className];
+    NSData *data = [self serializeString:json error:nil];
+    return [self stringByDecodingNSData:data];
+  }
+
+  NSError *error = nil;
+  NSData *data = [self serializeDictionary:dictionary error:&error];
+  if (!data) {
+    NSString *className = NSStringFromClass([dictionary class]);
+    if (error) {
+      NSLog(@"Unable to serialize dictionary '%@'.\n%@", className, error);
+    } else {
+      NSLog(@"Unable to serialize dictionary '%@'", className);
+    }
+    data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
+            dataUsingEncoding:NSUTF8StringEncoding];
+  }
+
+  return [self stringByDecodingNSData:data];
+}
+
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -40,6 +40,7 @@ static NSData *kTrue = NULL;
 
 - (Class) classForNSManagedObject;
 - (BOOL) isCoreDataStackAvailable;
+- (SEL) descriptionSelector;
 
 @end
 
@@ -385,4 +386,7 @@ static NSData *kTrue = NULL;
   }
 }
 
+- (SEL) descriptionSelector {
+  return @selector(description);
+}
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -36,6 +36,13 @@ static NSData *kNULL = NULL;
 static NSData *kFalse = NULL;
 static NSData *kTrue = NULL;
 
+@interface LPCJSONSerializer ()
+
+- (Class) classForNSManagedObject;
+- (BOOL) isCoreDataStackAvailable;
+
+@end
+
 @implementation LPCJSONSerializer
 
 + (void)initialize
@@ -368,6 +375,18 @@ static NSData *kTrue = NULL;
 
   str = [NSString stringWithFormat:@"%@:%@",firstPart,lastPart];
   return [self serializeString:str error:outError];
+}
+
+- (Class) classForNSManagedObject {
+  return objc_getClass("NSManagedObject");
+}
+
+- (BOOL) isCoreDataStackAvailable {
+  if ([self classForNSManagedObject]) {
+    return YES;
+  } else {
+    return NO;
+  }
 }
 
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -32,6 +32,7 @@
 #import "LPJSONRepresentation.h"
 
 NSString *const LPJSONSerializerNSManageObjectFormatString = @"'%@' is an NSManagedObject - description withheld for safety";
+NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString = @"'%@': does not respond to selector 'description'";
 
 static NSData *kNULL = NULL;
 static NSData *kFalse = NULL;
@@ -405,7 +406,7 @@ static NSData *kTrue = NULL;
   }
 
   if (![object respondsToSelector:[self descriptionSelector]]) {
-    NSString *str = [NSString stringWithFormat:@"'%@': does not respond to selector 'description'",
+    NSString *str = [NSString stringWithFormat:LPJSONSerializerDoesNotRespondToDescriptionFormatString,
                      NSStringFromClass([object class])];
     return [self serializeString:str error:outError];
   }

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -29,8 +29,9 @@
 
 #import "LPCJSONSerializer.h"
 #import "LPISO8601DateFormatter.h"
-
 #import "LPJSONRepresentation.h"
+
+NSString *const LPJSONSerializerNSManageObjectFormatString = @"'%@' is an NSManagedObject - description withheld for safety";
 
 static NSData *kNULL = NULL;
 static NSData *kFalse = NULL;
@@ -397,6 +398,12 @@ static NSData *kTrue = NULL;
 }
 
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError {
+  if ([self isCoreDataStackAvailable] && [self isNSManagedObject:object]) {
+    NSString *str = [NSString stringWithFormat:LPJSONSerializerNSManageObjectFormatString,
+                     NSStringFromClass([object class])];
+    return [self serializeString:str error:outError];
+  }
+
   if (![object respondsToSelector:[self descriptionSelector]]) {
     NSString *str = [NSString stringWithFormat:@"'%@': does not respond to selector 'description'",
                      NSStringFromClass([object class])];

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -144,10 +144,6 @@ static NSData *kTrue = NULL;
         {
         theResult = [inObject JSONDataRepresentation];
         }
-    else if ([inObject isKindOfClass:[UIView class]]) 
-       {
-           theResult = [self serializeString:[inObject description] error:outError];
-       }
     else
         {
         if (outError)

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -51,6 +51,7 @@ static NSData *kTrue = NULL;
 - (NSData *) serializeNumber:(NSNumber *) inNumber error:(NSError **) outError;
 - (NSData *) serializeString:(NSString *) inString error:(NSError **) outError;
 - (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
+- (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
 
 - (NSString *) stringByDecodingNSData:(NSData *) data;

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -486,4 +486,31 @@ static NSData *kTrue = NULL;
   return [self stringByDecodingNSData:data];
 }
 
+- (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array {
+  if (![array isKindOfClass:[NSArray class]]) {
+    NSString *className = NSStringFromClass([array class]);
+    NSLog(@"Expected NSArray but found instance of '%@'.\nCannot serialize object.",
+          className);
+    NSString *json = [NSString stringWithFormat:@"Cannot serialize instance of '%@' as an array.",
+                      className];
+    NSData *data = [self serializeString:json error:nil];
+    return [self stringByDecodingNSData:data];
+  }
+
+  NSError *error = nil;
+  NSData *data = [self serializeArray:array error:&error];
+  if (!data) {
+    NSString *className = NSStringFromClass([array class]);
+    if (error) {
+      NSLog(@"Unable to serialize array '%@'.\n%@", className, error);
+    } else {
+      NSLog(@"Unable to serialize array '%@'", className);
+    }
+    data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
+            dataUsingEncoding:NSUTF8StringEncoding];
+  }
+
+  return [self stringByDecodingNSData:data];
+}
+
 @end

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -31,8 +31,8 @@
 #import "LPISO8601DateFormatter.h"
 #import "LPJSONRepresentation.h"
 
-NSString *const LPJSONSerializerNSManageObjectDescriptionFaultFormatString = @"Calling 'description' on '%@' (an instance of NSManagedObject) caused a fault - this is probably a bug.";
-NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString = @"'%@': does not respond to selector 'description'";
+NSString *const LPJSONSerializerNSManageObjectDescriptionFaultFormatString = @"Calling 'description' on '%@' (an instance of NSManagedObject) caused a fault - this is probably a bug in your application.";
+NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString = @"'%@': does not respond to selector 'description' - this is probably a bug in your application.";
 
 static NSData *kNULL = NULL;
 static NSData *kFalse = NULL;

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -62,7 +62,7 @@ static NSData *kTrue = NULL;
     
 - (BOOL)isValidJSONObject:(id)inObject
     {
-    if ([inObject isKindOfClass:[NSNull class]])
+    if ([inObject isKindOfClass:[NSNull class]] || inObject == NULL || inObject == nil)
         {
         return(YES);
         }
@@ -83,6 +83,10 @@ static NSData *kTrue = NULL;
         return(YES);
         }
     else if ([inObject isKindOfClass:[NSData class]])
+        {
+        return(YES);
+        }
+    else if ([inObject isKindOfClass:[NSDate class]])
         {
         return(YES);
         }

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -308,7 +308,12 @@ static NSData *kTrue = NULL;
     NSUInteger i = 0;
     while ((theValue = [theEnumerator nextObject]) != NULL)
         {
-        NSData *theValueData = [self serializeObject:theValue error:outError];
+        NSData *theValueData = nil;
+        if ([self isValidJSONObject:theValue]) {
+          theValueData = [self serializeObject:theValue error:outError];
+        } else {
+          theValueData = [self serializeInvalidJSONObject:theValue error:outError];
+        }
         if (theValueData == NULL)
             {
             return(NULL);
@@ -341,7 +346,12 @@ static NSData *kTrue = NULL;
             {
             return(NULL);
             }
-        NSData *theValueData = [self serializeObject:theValue error:outError];
+        NSData *theValueData = nil;
+          if ([self isValidJSONObject:theValue]) {
+            theValueData = [self serializeObject:theValue error:outError];
+          } else {
+            theValueData = [self serializeInvalidJSONObject:theValue error:outError];
+          }
         if (theValueData == NULL)
             {
             return(NULL);

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -513,4 +513,27 @@ static NSData *kTrue = NULL;
   return [self stringByDecodingNSData:data];
 }
 
+- (NSString *) stringByEnsuringSerializationOfObject:(id) object {
+  NSData *data = nil;
+  NSError *error = nil;
+  if ([self isValidJSONObject:object]) {
+    data = [self serializeObject:object error:&error];
+  } else {
+    data = [self serializeInvalidJSONObject:object error:&error];
+  }
+
+  if (!data) {
+    NSString *className = NSStringFromClass([object class]);
+    if (error) {
+      NSLog(@"Unable to serialize object '%@'.\n%@", className, error);
+    } else {
+      NSLog(@"Unable to serialize object '%@'", className);
+    }
+    data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
+            dataUsingEncoding:NSUTF8StringEncoding];
+  }
+
+  return [self stringByDecodingNSData:data];
+}
+
 @end

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -79,17 +79,9 @@
 }
 
 + (NSString *) serializeArray:(NSArray *) array {
-  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
-  NSError *error = nil;
-  NSData *d = [s serializeArray:array error:&error];
-  if (error) {
-    NSLog(@"Unable to serialize arrayy (%@), %@", error, array);
-  }
-  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
-                                         encoding:NSUTF8StringEncoding];
-  return res;
+  LPCJSONSerializer *serializer = [LPCJSONSerializer serializer];
+  return [serializer stringByEnsuringSerializationOfArray:array];
 }
-
 
 + (NSArray *) deserializeArray:(NSString *) string {
   LPCJSONDeserializer *ds = [LPCJSONDeserializer deserializer];

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -63,15 +63,8 @@
 }
 
 + (NSString *) serializeDictionary:(NSDictionary *) dictionary {
-  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
-  NSError *error = nil;
-  NSData *d = [s serializeDictionary:dictionary error:&error];
-  if (error) {
-    NSLog(@"Unable to serialize dictionary (%@), %@", error, dictionary);
-  }
-  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
-                                         encoding:NSUTF8StringEncoding];
-  return res;
+  LPCJSONSerializer *serializer = [LPCJSONSerializer serializer];
+  return [serializer stringByEnsuringSerializationOfDictionary:dictionary];
 }
 
 + (NSDictionary *) deserializeDictionary:(NSString *) string {

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -94,19 +94,10 @@
   return res;
 }
 
-
 + (NSString *) serializeObject:(id) obj {
-  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
-  NSError *error = nil;
-  NSData *d = [s serializeObject:obj error:&error];
-  if (error) {
-    NSLog(@"Unable to serialize object (%@), %@", error, [obj description]);
-  }
-  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
-                                         encoding:NSUTF8StringEncoding];
-  return res;
+  LPCJSONSerializer *serializer = [LPCJSONSerializer serializer];
+  return [serializer stringByEnsuringSerializationOfObject:obj];
 }
-
 
 + (id) jsonifyObject:(id) object {
   return [self jsonifyObject:object fullDump:NO];
@@ -158,12 +149,7 @@
     return viewJson;
   }
 
-  LPCJSONSerializer *s = [LPCJSONSerializer serializer];
-  NSError *error = nil;
-  if (![s serializeObject:object error:&error] || error) {
-    return [object description];
-  }
-  return object;
+  return [LPJSONUtils serializeObject:object];
 }
 
 + (NSMutableDictionary *) dictionaryByEncodingView:(id) object {


### PR DESCRIPTION
### Motivation

I was interacting with the Keychain API the other day and discovered an error on the server when trying to encode (to JSON) the output of one of the public Keychain API calls.  The result was a RuntimeError in the client.

The public Keychain API method returned an NSDictionary and one of the elements in that array was not a valid JSON object.

The error is occuring because of the the way `LPJSONUtils` is interacting with the LPJSONSerializer.

This was the common pattern:

```objective-c
 LPCJSONSerializer *s = [LPCJSONSerializer serializer];
  NSError *error = nil;
  NSData *d = [s serializeObject:obj error:&error];
  if (error) {
    NSLog(@"Unable to serialize object (%@), %@", error, [obj description]);
  }
  NSString *res = [[NSString alloc] initWithBytes:[d bytes] length:[d length]
                                         encoding:NSUTF8StringEncoding];
  return res;
```

1. The existence of `error` should not be used to branch; classes are allowed to scribble on errors passed by reference.  The LPJSONSerializer does not scribble, but Apple's APIs can and do.
2. `NSData` is `NULL` because `serializeObject:` could not serialize the object.  This causes `res` to be `"null"` which is not valid JSON.

The end result is JSON parse error.

```
JSON::ParserError: A JSON text must at least contain two octets!
```

@krukow On Friday afternoon, I was able to generate a server crash related to this issue, but now I cannot reproduce.  I will keep searching.

