### PR TITLE
Don't include non-public LPHTTPServer.h in CalabashServer.h

### DIFF
--- a/calabash/Classes/CalabashServer.h
+++ b/calabash/Classes/CalabashServer.h
@@ -1,7 +1,7 @@
 //  Created by Karl Krukow on 11/08/11.
 //  Copyright 2011 LessPainful. All rights reserved.
 
-#import "LPHTTPServer.h"
+#import <Foundation/Foundation.h>
 
 @class LPHTTPServer;
 

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -6,6 +6,7 @@
 //
 
 #import "CalabashServer.h"
+#import "LPHTTPServer.h"
 #import "LPRouter.h"
 #import "LPScreenshotRoute.h"
 #import "LPMapRoute.h"


### PR DESCRIPTION
`LPHTTPServer.h` was included in `CalabashServer.h` even though it is not public. This caused a compilation error when including `CalabashServer.h` from the framework.

Tested using `make framework`.