### PR TITLE
LPJSONUtils fix double quoting of strings in jsonifyObject:

### DIFF
--- a/calabash/Classes/JSON/LPCJSONSerializer.h
+++ b/calabash/Classes/JSON/LPCJSONSerializer.h
@@ -57,6 +57,11 @@ extern NSString *const LPJSONSerializerDoesNotRespondToDescriptionFormatString;
 // @todo We should be bubbling exceptional cases up to the response and marking
 // it as producing invalid JSON.  Otherwise the user may never see that there
 // is a potential problem in their app.
+
+// @todo Remove this from the public API.  The stringByEnsuring* methods should
+//       be the only public interface.
+- (NSData *) serializeObject:(id)inObject error:(NSError **) outError;
+
 - (NSString *) stringByEnsuringSerializationOfObject:(id) object;
 - (NSString *) stringByEnsuringSerializationOfArray:(NSArray *) array;
 - (NSString *) stringByEnsuringSerializationOfDictionary:(NSDictionary *) dictionary;

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -54,7 +54,6 @@ static NSData *kTrue = NULL;
 - (NSData *) serializeDictionary:(NSDictionary *) inDictionary error:(NSError **) outError;
 - (NSData *) serializeArray:(NSArray *) inArray error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
-- (NSData *) serializeObject:(id)inObject error:(NSError **) outError;
 
 - (NSString *) stringByDecodingNSData:(NSData *) data;
 

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -473,16 +473,17 @@ static NSData *kTrue = NULL;
 
   NSError *error = nil;
   NSData *data = [self serializeDictionary:dictionary error:&error];
-  if (!data) {
-    NSString *className = NSStringFromClass([dictionary class]);
-    if (error) {
-      NSLog(@"Unable to serialize dictionary '%@'.\n%@", className, error);
-    } else {
-      NSLog(@"Unable to serialize dictionary '%@'", className);
-    }
-    data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
-            dataUsingEncoding:NSUTF8StringEncoding];
+
+  if (data) { return [self stringByDecodingNSData:data]; }
+
+  NSString *className = NSStringFromClass([dictionary class]);
+  if (error) {
+    NSLog(@"Unable to serialize dictionary '%@'.\n%@", className, error);
+  } else {
+    NSLog(@"Unable to serialize dictionary '%@'", className);
   }
+  data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
+          dataUsingEncoding:NSUTF8StringEncoding];
 
   return [self stringByDecodingNSData:data];
 }
@@ -500,16 +501,17 @@ static NSData *kTrue = NULL;
 
   NSError *error = nil;
   NSData *data = [self serializeArray:array error:&error];
-  if (!data) {
-    NSString *className = NSStringFromClass([array class]);
-    if (error) {
-      NSLog(@"Unable to serialize array '%@'.\n%@", className, error);
-    } else {
-      NSLog(@"Unable to serialize array '%@'", className);
-    }
-    data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
-            dataUsingEncoding:NSUTF8StringEncoding];
+
+  if (data) { return [self stringByDecodingNSData:data]; }
+
+  NSString *className = NSStringFromClass([array class]);
+  if (error) {
+    NSLog(@"Unable to serialize array '%@'.\n%@", className, error);
+  } else {
+    NSLog(@"Unable to serialize array '%@'", className);
   }
+  data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
+          dataUsingEncoding:NSUTF8StringEncoding];
 
   return [self stringByDecodingNSData:data];
 }
@@ -523,16 +525,16 @@ static NSData *kTrue = NULL;
     data = [self serializeInvalidJSONObject:object error:&error];
   }
 
-  if (!data) {
-    NSString *className = NSStringFromClass([object class]);
-    if (error) {
-      NSLog(@"Unable to serialize object '%@'.\n%@", className, error);
-    } else {
-      NSLog(@"Unable to serialize object '%@'", className);
-    }
-    data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
-            dataUsingEncoding:NSUTF8StringEncoding];
+  if (data) { return [self stringByDecodingNSData:data]; }
+
+  NSString *className = NSStringFromClass([object class]);
+  if (error) {
+    NSLog(@"Unable to serialize object '%@'.\n%@", className, error);
+  } else {
+    NSLog(@"Unable to serialize object '%@'", className);
   }
+  data = [[NSString stringWithFormat:@"Invalid JSON for '%@' instance.", className]
+          dataUsingEncoding:NSUTF8StringEncoding];
 
   return [self stringByDecodingNSData:data];
 }

--- a/calabash/Classes/JSON/LPCJSONSerializer.m
+++ b/calabash/Classes/JSON/LPCJSONSerializer.m
@@ -51,8 +51,10 @@ static NSData *kTrue = NULL;
 - (NSData *) serializeNumber:(NSNumber *) inNumber error:(NSError **) outError;
 - (NSData *) serializeString:(NSString *) inString error:(NSError **) outError;
 - (NSData *) serializeDate:(NSDate *) date error:(NSError **) outError;
-- (NSData *)serializeObject:(id)inObject error:(NSError **)outError;
+- (NSData *) serializeDictionary:(NSDictionary *) inDictionary error:(NSError **) outError;
+- (NSData *) serializeArray:(NSArray *) inArray error:(NSError **) outError;
 - (NSData *) serializeInvalidJSONObject:(id) object error:(NSError **) outError;
+- (NSData *) serializeObject:(id)inObject error:(NSError **) outError;
 
 - (NSString *) stringByDecodingNSData:(NSData *) data;
 

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -149,7 +149,29 @@
     return viewJson;
   }
 
-  return object;
+  // Sometimes we don't actually want to return an JSON encoded string because
+  // the object will be passed throught the serializer again and we'd end up
+  // with results like this:
+  //
+  // > query('tabBarButton', :accessibilityLabel)
+  // [
+  // [0] "\"Buttons\"",
+  // [1] "\"Text\"",
+  // [2] "\"Date\"",
+  // [3] "\"Scrolling Views\"",
+  // [4] "\"Sliders\""
+  // ]
+  //
+  // To my eye this is clearly a bug in this method; we should never exit
+  // this method with invalid JSON. Fixing this is beyond the scope of this
+  // pull-request. -jjm
+  LPCJSONSerializer *serializer = [LPCJSONSerializer serializer];
+  NSData *data = [serializer serializeObject:object error:nil];
+  if (!data) {
+    return [object description];
+  } else {
+    return object;
+  }
 }
 
 + (NSMutableDictionary *) dictionaryByEncodingView:(id) object {

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -149,7 +149,7 @@
     return viewJson;
   }
 
-  return [LPJSONUtils serializeObject:object];
+  return object;
 }
 
 + (NSMutableDictionary *) dictionaryByEncodingView:(id) object {


### PR DESCRIPTION
### Motivation

**LPJSONSerializer can encode arbitrary objects** #165  made an unfortunate change in `LPJSONUtils jsonifyObject:` that in some cases strings to become double quoted in query results.

```
> query('tabBarButton', AL)
[
    [0] "\"Buttons\"",
    [1] "\"Text\"",
    [2] "\"Date\"",
    [3] "\"Scrolling Views\"",
    [4] "\"Sliders\""
]
```

The original implementation, before #165 looked like this:

```
 # A bunch of if statements to handle special cases.
 LPCJSONSerializer *s = [LPCJSONSerializer serializer];
 NSError *error = nil;
 if (![s serializeObject:object error:&error] || error) {
   return [object description];
}
return object;
```

That looked like the wrong behavior to me because we were returning a non-JSON object from the method.  It turns out, this behavior is necessary.  I think it is unsafe, but fixing it is beyond the scope of this PR.

FYI/BTW I would have caught this much sooner, but my Jenkins install is misbehaving (fixed).  It was the Xamarin Test Cloud that ultimately caught the error.