### PR TITLE
Version route: add key for CFBundleShortVersionString

### DIFF
--- a/XCTest/Tests/Routes/LPVersionRouteTest.m
+++ b/XCTest/Tests/Routes/LPVersionRouteTest.m
@@ -47,6 +47,10 @@ describe(@"LPVersionRoute", ^{
     it(@"contains form_factor key", ^{
       expect(response[@"form_factor"]).notTo.beNil();
     });
+
+    it(@"contains short_version_string key", ^{
+      expect(response[@"short_version_string"]).notTo.beNil();
+    });
   });
 });
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -144,6 +144,7 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
     @"simulator_device": dev,
     @"simulator": sim,
     @"app_version": [infoPlist stringForVersion],
+    @"short_version_string": [infoPlist stringForShortVersion],
     @"outcome": @"SUCCESS",
     @"iphone_app_emulated_on_ipad": @(isIphoneAppEmulated),
     @"git": git,

--- a/scripts/test/run-ios-simulator-smoke-tests.rb
+++ b/scripts/test/run-ios-simulator-smoke-tests.rb
@@ -77,6 +77,7 @@ Dir.chdir smoke_test_working_dir do
     file.write("source 'https://rubygems.org'\n")
     file.write("gem 'run_loop', :github => 'calabash/run_loop', :branch => 'develop'\n")
     file.write("gem 'calabash-cucumber', :github => 'calabash/calabash-ios', :branch => 'develop'\n")
+    file.write("gem 'pry'\n")
     file.write("gem 'xcpretty', '~> 0.1'\n")
   end
 


### PR DESCRIPTION
### Motivation

**add a new key: 'short_version_string' ('CFBundleShortVersionString') in the version route** https://github.com/calabash/calabash-ios/issues/773