### PR TITLE
Avoid [NSURL fileSystemRepresentation] on iOS 6

### DIFF
--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -50,7 +50,15 @@
   @"/Developer/Library/PrivateFrameworks/UIAutomation.framework/UIAutomation";
 
   NSURL *url = [NSURL fileURLWithPath:automationLibPath];
-  const char *cFileSystemRep = [url fileSystemRepresentation];
+
+  const char *cFileSystemRep;
+  if ([url respondsToSelector:@selector(fileSystemRepresentation)]) {
+    // iOS > 6
+    cFileSystemRep = [url fileSystemRepresentation];
+  } else {
+    NSString *absolutePath = [url path];
+    cFileSystemRep = [absolutePath cStringUsingEncoding:NSUTF8StringEncoding];
+  }
 
   char *error;
   dlopen(cFileSystemRep, RTLD_LOCAL);

--- a/calabash/Classes/Utils/LPPluginLoader.m
+++ b/calabash/Classes/Utils/LPPluginLoader.m
@@ -36,7 +36,15 @@
   NSURL *url = [NSURL fileURLWithPath:path];
 
   char *error;
-  const char *cFileSystemRep = [url fileSystemRepresentation];
+
+  const char *cFileSystemRep;
+  if ([url respondsToSelector:@selector(fileSystemRepresentation)]) {
+    // iOS > 6
+    cFileSystemRep = [url fileSystemRepresentation];
+  } else {
+    NSString *absolutePath = [url path];
+    cFileSystemRep = [absolutePath cStringUsingEncoding:NSUTF8StringEncoding];
+  }
 
   NSString *pluginName = [path lastPathComponent];
   NSLog(@"Loading Calabash plugin: %@", pluginName);


### PR DESCRIPTION
### Motivation

Causes crashes on iOS 6.