### PR TITLE
LPMapRoute: convert to ARC

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -51,7 +51,7 @@
 		B1135846197F1351004B16F4 /* LPCORSResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B1059F0418C546EB005A0262 /* LPCORSResponse.m */; };
 		B1135847197F1390004B16F4 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* GCDAsyncSocket.m */; };
 		B1135848197F1A38004B16F4 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B11358491981AE00004B16F4 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		B11358491981AE00004B16F4 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B11358581981B053004B16F4 /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; };
 		B11358591981B053004B16F4 /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; };
 		B113585A1981B053004B16F4 /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A318B391810094E71E /* LPCollectionViewScrollToItemWithMarkOperation.m */; };
@@ -117,7 +117,7 @@
 		B15BF9C319ABB1DE00B38577 /* LPGenericAsyncRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B16321F315BC1ECD00408364 /* LPGenericAsyncRoute.m */; };
 		B15BF9C419ABB1DE00B38577 /* LPConditionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B163213415BBF13200408364 /* LPConditionRoute.m */; };
 		B15BF9C519ABB1DE00B38577 /* LPInterpolateRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12A04011511546F002FA032 /* LPInterpolateRoute.m */; };
-		B15BF9C619ABB1DE00B38577 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		B15BF9C619ABB1DE00B38577 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9C719ABB1DE00B38577 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		B15BF9C819ABB1DE00B38577 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		B15BF9C919ABB1DE00B38577 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -196,7 +196,7 @@
 		B15BFA1519ABB2B100B38577 /* LPGenericAsyncRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B16321F315BC1ECD00408364 /* LPGenericAsyncRoute.m */; };
 		B15BFA1619ABB2B100B38577 /* LPConditionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B163213415BBF13200408364 /* LPConditionRoute.m */; };
 		B15BFA1719ABB2B100B38577 /* LPInterpolateRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12A04011511546F002FA032 /* LPInterpolateRoute.m */; };
-		B15BFA1819ABB2B100B38577 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		B15BFA1819ABB2B100B38577 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BFA1919ABB2B100B38577 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		B15BFA1A19ABB2B100B38577 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		B15BFA1B19ABB2B100B38577 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -276,7 +276,7 @@
 		B1D5BD9819A23BCE0070E8CE /* LPConditionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B163213415BBF13200408364 /* LPConditionRoute.m */; };
 		B1D5BD9919A23BCE0070E8CE /* LPInterpolateRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12A04011511546F002FA032 /* LPInterpolateRoute.m */; };
 		B1D5BD9A19A23BCE0070E8CE /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
-		B1D5BD9B19A23BCE0070E8CE /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		B1D5BD9B19A23BCE0070E8CE /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9C19A23BCE0070E8CE /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9E19A23BCE0070E8CE /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
@@ -408,7 +408,7 @@
 		F5091BF918C4E1D700C85307 /* LPConditionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B163213415BBF13200408364 /* LPConditionRoute.m */; };
 		F5091BFA18C4E1D700C85307 /* LPInterpolateRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12A04011511546F002FA032 /* LPInterpolateRoute.m */; };
 		F5091BFB18C4E1D700C85307 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
-		F5091BFC18C4E1D700C85307 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		F5091BFC18C4E1D700C85307 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BFD18C4E1D700C85307 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		F5091BFE18C4E1D700C85307 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BFF18C4E1D700C85307 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
@@ -502,7 +502,7 @@
 		F50CBFA91A0405B2004AC9DA /* LPGenericAsyncRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B16321F315BC1ECD00408364 /* LPGenericAsyncRoute.m */; };
 		F50CBFAA1A0405B2004AC9DA /* LPConditionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B163213415BBF13200408364 /* LPConditionRoute.m */; };
 		F50CBFAB1A0405B2004AC9DA /* LPInterpolateRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12A04011511546F002FA032 /* LPInterpolateRoute.m */; };
-		F50CBFAC1A0405B2004AC9DA /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		F50CBFAC1A0405B2004AC9DA /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFAD1A0405B2004AC9DA /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
 		F50CBFAE1A0405B2004AC9DA /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		F50CBFAF1A0405B2004AC9DA /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -641,7 +641,7 @@
 		F5821A1718C4E27400293508 /* LPConditionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B163213415BBF13200408364 /* LPConditionRoute.m */; };
 		F5821A1818C4E27400293508 /* LPInterpolateRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12A04011511546F002FA032 /* LPInterpolateRoute.m */; };
 		F5821A1918C4E27400293508 /* LPRecordRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8B14B6DC7F002A744C /* LPRecordRoute.m */; };
-		F5821A1A18C4E27400293508 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; };
+		F5821A1A18C4E27400293508 /* LPMapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD214B6DB2B002A744C /* LPMapRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A1B18C4E27400293508 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		F5821A1C18C4E27400293508 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A1D18C4E27400293508 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };

--- a/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
@@ -118,7 +118,7 @@ static NSString *const kFaceUp = @"face up";
   } else if ([kStatusBar isEqualToString:firstArg]) {
     return [LPOrientationOperation statusBarOrientation];
   } else {
-    NSLog(@"Warning: feel through conditional for arguments: '[%@]'",
+    NSLog(@"Warning: fell through conditions for arguments: '[%@]'",
             [_arguments componentsJoinedByString:@", "]);
     return nil;
   }

--- a/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
@@ -92,7 +92,7 @@ static NSString *const kFaceUp = @"face up";
 
 
 // _arguments ==> {'device' | 'status_bar'}
-- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
+- (id) performWithTarget:(UIView *) view error:(NSError **) error {
 
   NSUInteger argCount = [_arguments count];
   if (argCount == 0) {

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -73,7 +73,7 @@
 
 - (NSArray *) applyOperation:(NSDictionary *) operation
                      toViews:(NSArray *) views
-                     error:(NSError *__autoreleasing*) error {
+                       error:(NSError *__autoreleasing*) error {
   NSString *operationName = [operation objectForKey:@"method_name"];
 
   if (!operationName) {  return [views copy];  }

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -74,11 +74,13 @@
 - (NSArray *) applyOperation:(NSDictionary *) operation
                      toViews:(NSArray *) views
                      error:(NSError *__autoreleasing*) error {
-  if ([operation objectForKey:@"method_name"] == nil) {
-    return [views copy];
-  }
+  NSString *operationName = [operation objectForKey:@"method_name"];
+
+  if (!operationName) {  return [views copy];  }
+
   LPOperation *op = [LPOperation operationFromDictionary:operation];
   NSMutableArray *finalRes = [NSMutableArray arrayWithCapacity:[views count]];
+
   if (views == nil || views.count == 0) {
     id res = [op performWithTarget:nil error:error];
     if (res != nil) {

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -1,3 +1,6 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
 //
 //  MapRoute.m
 //  Created by Karl Krukow on 13/08/11.
@@ -38,15 +41,14 @@
   NSData *jsonData = [[LPJSONUtils serializeDictionary:response]
                       dataUsingEncoding:NSUTF8StringEncoding];
 
-  return [[[LPHTTPDataResponse alloc] initWithData:jsonData] autorelease];
-#pragma clang diagnostic push
+  return [[LPHTTPDataResponse alloc] initWithData:jsonData];
 }
 
 - (NSArray *) applyOperation:(NSDictionary *) operation
                      toViews:(NSArray *) views
-                     error:(NSError **) error {
+                     error:(NSError *__autoreleasing*) error {
   if ([operation valueForKey:@"method_name"] == nil) {
-    return [[views copy] autorelease];
+    return [views copy];
   }
   LPOperation *op = [LPOperation operationFromDictionary:operation];
   NSMutableArray *finalRes = [NSMutableArray arrayWithCapacity:[views count]];
@@ -113,11 +115,6 @@
   [LPLog debug:@"Map results %@", resultDict];
 
   return resultDict;
-}
-
-- (void) dealloc {
-  _parser = nil;
-  [super dealloc];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -96,16 +96,19 @@
 
   NSDictionary *resultDict = nil;
   if (resultArray) {
-    resultDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                  [LPOrientationOperation statusBarOrientation], @"status_bar_orientation",
-                  resultArray, @"results",
-                  @"SUCCESS", @"outcome",
-                  nil];
+    resultDict =
+    @{
+      @"status_bar_orientation" : [LPOrientationOperation statusBarOrientation],
+      @"results" : resultArray,
+      @"outcome" : @"SUCCESS"
+      };
   } else {
-    resultDict = [NSDictionary dictionaryWithObjectsAndKeys:@"FAILURE", @"outcome",
-                                                            @"", @"reason",
-                                                            @"", @"details",
-                                                            nil];
+    resultDict =
+    @{
+      @"outcome" : @"FAILURE",
+      @"reason" : @"",
+      @"details" : @""
+      };
   }
   [LPLog debug:@"Map results %@", resultDict];
 

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -47,7 +47,6 @@
     return [[views copy] autorelease];
   }
   LPOperation *op = [LPOperation operationFromDictionary:operation];
-  //LPHTTPLogDDLogVerbose(@"Applying operation %@ to views...",op);
   NSMutableArray *finalRes = [NSMutableArray arrayWithCapacity:[views count]];
   if (views == nil) {
     id res = [op performWithTarget:nil error:error];
@@ -56,7 +55,6 @@
     }
   } else {
     for (id view in views) {
-      // if ([view isKindOfClass:[UIView class]] && ![LPTouchUtils isViewVisible:view]) {continue;}
       NSError *err = nil;
       id val = [op performWithTarget:view error:&err];
       if (err) {continue;}
@@ -75,7 +73,6 @@
 
   id scriptObj = [data objectForKey:@"query"];
   NSDictionary *operation = [data objectForKey:@"operation"];
-  //DDLogVerbose(@"MapRoute received command\n%@", data);
   NSArray *result = nil;
   if ([NSNull null] != scriptObj) {
 
@@ -84,7 +81,6 @@
     NSArray *tokens = [self.parser parsedTokens];
     NSLog(@"Map %@, %@ Parsed UIScript as\n%@", method, path, tokens);
 
-    //
     NSArray *allWindows = [LPTouchUtils applicationWindows];
     result = [self.parser evalWith:allWindows];
   } else {

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -74,7 +74,7 @@
 - (NSArray *) applyOperation:(NSDictionary *) operation
                      toViews:(NSArray *) views
                      error:(NSError *__autoreleasing*) error {
-  if ([operation valueForKey:@"method_name"] == nil) {
+  if ([operation objectForKey:@"method_name"] == nil) {
     return [views copy];
   }
   LPOperation *op = [LPOperation operationFromDictionary:operation];

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -48,7 +48,7 @@
   }
   LPOperation *op = [LPOperation operationFromDictionary:operation];
   NSMutableArray *finalRes = [NSMutableArray arrayWithCapacity:[views count]];
-  if (views == nil) {
+  if (views == nil || views.count == 0) {
     id res = [op performWithTarget:nil error:error];
     if (res != nil) {
       [finalRes addObject:res];

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -3,7 +3,6 @@
 //  Created by Karl Krukow on 13/08/11.
 //  Copyright 2011 LessPainful. All rights reserved.
 //
-
 #import "LPMapRoute.h"
 #import "LPOperation.h"
 #import "LPTouchUtils.h"
@@ -14,18 +13,18 @@
 #import "LPDevice.h"
 
 @implementation LPMapRoute
-@synthesize parser = _parser;
 
+@synthesize parser = _parser;
 
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
   return [method isEqualToString:@"POST"];
 }
 
-- (BOOL)canHandlePostForPath:(NSArray *)path {
+- (BOOL) canHandlePostForPath:(NSArray *) path {
   return [@"cal_map" isEqualToString:[path lastObject]];
 }
 
-- (id) handleRequestForPath: (NSArray *)path withConnection:(id)connection {
+- (id) handleRequestForPath:(NSArray *) path withConnection:(id) connection {
   if (![self canHandlePostForPath:path]) {
     return nil;
   }
@@ -33,16 +32,19 @@
 #pragma clang diagnostic ignored "-Wobjc-method-access"
   NSDictionary *data = [LPJSONUtils deserializeDictionary:[connection postDataAsString]];
 
-  NSDictionary *response = [self JSONResponseForMethod:@"POST" URI:@"cal_map" data:data];
-  NSData *jsonData = [[LPJSONUtils serializeDictionary:response] dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary *response = [self JSONResponseForMethod:@"POST"
+                                                   URI:@"cal_map"
+                                                  data:data];
+  NSData *jsonData = [[LPJSONUtils serializeDictionary:response]
+                      dataUsingEncoding:NSUTF8StringEncoding];
 
   return [[[LPHTTPDataResponse alloc] initWithData:jsonData] autorelease];
 #pragma clang diagnostic push
 }
 
-
-
-- (NSArray *) applyOperation:(NSDictionary *) operation toViews:(NSArray *) views error:(NSError **) error {
+- (NSArray *) applyOperation:(NSDictionary *) operation
+                     toViews:(NSArray *) views
+                     error:(NSError **) error {
   if ([operation valueForKey:@"method_name"] == nil) {
     return [[views copy] autorelease];
   }
@@ -68,9 +70,9 @@
   return finalRes;
 }
 
-
-- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
-
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data {
   id scriptObj = [data objectForKey:@"query"];
   NSDictionary *operation = [data objectForKey:@"operation"];
   NSArray *result = nil;
@@ -88,7 +90,8 @@
   }
   self.parser = nil;
   NSError *error = nil;
-  NSArray *resultArray = [self applyOperation:operation toViews:result
+  NSArray *resultArray = [self applyOperation:operation
+                                      toViews:result
                                         error:&error];
 
   NSDictionary *resultDict = nil;
@@ -108,7 +111,6 @@
 
   return resultDict;
 }
-
 
 - (void) dealloc {
   _parser = nil;

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -81,7 +81,7 @@
   LPOperation *op = [LPOperation operationFromDictionary:operation];
   NSMutableArray *finalRes = [NSMutableArray arrayWithCapacity:[views count]];
 
-  if (views == nil || views.count == 0) {
+  if (!views) {
     id res = [op performWithTarget:nil error:error];
     if (res != nil) {
       [finalRes addObject:res];

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -14,7 +14,7 @@
 #import "LPDevice.h"
 
 @implementation LPMapRoute
-@synthesize parser;
+@synthesize parser = _parser;
 
 
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
@@ -111,7 +111,7 @@
 
 
 - (void) dealloc {
-  self.parser = nil;
+  _parser = nil;
   [super dealloc];
 }
 


### PR DESCRIPTION
### Motivation

~~The LPOrientationOperation requires no views.  LPMapRoute was skipping the call to orientation operation because of this.  I don't know what the downstream effects will be.~~

LPMapRoute needed some formatting love and it was a good candidate for converting to ARC.  In the process of converting to ARC, I realized that some of the methods were _only_ for the Frank plug-in.  I documented this and made the Frank calls much safer.

~~I am curious to see how this be476d0 change will affect the server.~~ It was bad.

### Update

+1 for CI and +1 for tests that help you understand the behavior of your software.

The _fix_ was a breaking change.  Now I can see that the behavior that prompted this fix was ultimately caused by a misuse of the server API by the client.
    
```
    ;; Bad
    map_route('/orientation', :orientation, :status_bar)
    
    ;; Good
    map_route(nil, :orientation, :status_bar)
```

This PR still has merit because it cleans up the LPMapRoute file and converts it to ARC.