### PR TITLE
XCTests should pass when run against any target simulator or device.

### DIFF
--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -72,6 +72,43 @@ describe(@"LPDevice", ^{
     expect([device system]).notTo.beNil();
   });
 
+  it(@"#systemVersion", ^{
+    LPDevice *device = [[LPDevice alloc] init_private];
+    expect([device iOSVersion]).notTo.beNil();
+  });
+
+  describe(@"#isLessThanIOS8", ^{
+
+    __block LPDevice *device;
+    __block id mockDevice;
+
+    before(^{
+      device = [[LPDevice alloc] init_private];
+      mockDevice = OCMPartialMock(device);
+    });
+
+    it(@"true for iOS < 8.0", ^{
+      [[[mockDevice expect] andReturn:@"7.1"] iOSVersion];
+
+      expect([mockDevice isLessThaniOS8]).to.equal(YES);
+      [mockDevice verify];
+    });
+
+    it(@"false for iOS = 8.0", ^{
+      [[[mockDevice expect] andReturn:@"8.0"] iOSVersion];
+
+      expect([mockDevice isLessThaniOS8]).to.equal(NO);
+      [mockDevice verify];
+    });
+
+    it(@"false for iOS > 8.0", ^{
+      [[[mockDevice expect] andReturn:@"9.0"] iOSVersion];
+
+      expect([mockDevice isLessThaniOS8]).to.equal(NO);
+      [mockDevice verify];
+    });
+  });
+
   it(@"#model", ^{
     LPDevice *device = [[LPDevice alloc] init_private];
     expect([device model]).notTo.beNil();

--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -296,8 +296,19 @@
   }
   XCTAssertEqualObjects(dict[@"rect"][@"width"], @(CGRectGetWidth([view frame])));
   XCTAssertEqualObjects(dict[@"rect"][@"height"], @(CGRectGetHeight([view frame])));
-  XCTAssertEqualObjects(dict[@"rect"][@"center_x"], @(CGRectGetMidX([view frame])));
-  XCTAssertEqualObjects(dict[@"rect"][@"center_y"], @(106.75));
+
+  if ([self isIphone6Plus]) {
+    expect(dict[@"rect"][@"center_x"]).to.beCloseToWithin(82.93, 0.001);
+    XCTAssertEqualObjects(dict[@"rect"][@"center_y"], @(138.32));
+  } else if ([self isIphone6]) {
+    expect(dict[@"rect"][@"center_x"]).to.beCloseToWithin(75.0, 0.001);
+    expect(dict[@"rect"][@"center_y"]).to.beCloseToWithin(125.1, 0.001);
+  } else if ([self isIphone4in] || [self isIphone35in] || [self isIpad]) {
+    XCTAssertEqualObjects(dict[@"rect"][@"center_x"], @(CGRectGetMidX([view frame])));
+    expect(dict[@"rect"][@"center_y"]).to.beCloseToWithin(106.75, 0.001);
+  } else {
+    XCTFail(@"Expected device to be an iPhone 6, 6+, 4in, or 3.5in or an iPad");
+  }
   XCTAssertEqualObjects(dict[@"value"], [NSNull null]);
   XCTAssertEqualObjects(dict[@"visible"], @(0));
   XCTAssertEqual([dict count], 11);
@@ -337,8 +348,20 @@
   XCTAssertEqualObjects(dict[@"rect"][@"y"], @(CGRectGetMinY([view frame])));
   XCTAssertEqualObjects(dict[@"rect"][@"width"], @(CGRectGetWidth([view frame])));
   XCTAssertEqualObjects(dict[@"rect"][@"height"], @(CGRectGetHeight([view frame])));
-  XCTAssertEqualObjects(dict[@"rect"][@"center_x"], @(CGRectGetMidX([view frame])));
-  XCTAssertEqualObjects(dict[@"rect"][@"center_y"], @(CGRectGetMidY([view frame])));
+
+  if ([self isIphone6Plus]) {
+    expect(dict[@"rect"][@"center_x"]).to.beCloseToWithin(82.93, 0.001);
+    expect(dict[@"rect"][@"center_y"]).to.beCloseToWithin(112.41, 0.001);
+  } else if ([self isIphone6]) {
+    expect(dict[@"rect"][@"center_x"]).to.beCloseToWithin(75.0, 0.001);
+    expect(dict[@"rect"][@"center_y"]).to.beCloseToWithin(101.66, 0.001);
+  } else if ([self isIphone4in] || [self isIphone35in] || [self isIpad]) {
+    XCTAssertEqualObjects(dict[@"rect"][@"center_x"], @(CGRectGetMidX([view frame])));
+    XCTAssertEqualObjects(dict[@"rect"][@"center_y"], @(CGRectGetMidY([view frame])));
+  } else {
+    XCTFail(@"Expected device to be an iPhone 6, 6+, 4in, or 3.5in or an iPad");
+  }
+
   XCTAssertEqualObjects(dict[@"value"], [NSNull null]);
   XCTAssertEqualObjects(dict[@"visible"], @(1));
   XCTAssertEqual([dict count], 11);

--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -88,6 +88,10 @@
   return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
 }
 
+- (BOOL) isLessThanIOS8 {
+  return [[LPDevice sharedDevice] isLessThaniOS8];
+}
+
 #pragma mark - dictionary:setObject:forKey:whenTarget:respondsTo:
 
 - (void) testDictionarySetObjectForKeyWhenTargetRespondsToYesAndNil {
@@ -175,7 +179,11 @@
 
   NSDictionary *dict = [LPJSONUtils dictionaryByEncodingView:view];
 
-  XCTAssertEqualObjects(dict[@"accessibilityElement"], @(0));
+  if([self isLessThanIOS8]) {
+    XCTAssertEqualObjects(dict[@"accessibilityElement"], @(1));
+  } else {
+    XCTAssertEqualObjects(dict[@"accessibilityElement"], @(0));
+  }
   XCTAssertEqualObjects(dict[@"alpha"], @(1));
   XCTAssertEqualObjects(dict[@"class"], NSStringFromClass([view class]));
   XCTAssertEqualObjects(dict[@"description"], [view description]);
@@ -281,7 +289,11 @@
   XCTAssertEqualObjects(dict[@"frame"][@"height"], @(CGRectGetHeight([view frame])));
   XCTAssertEqual(((NSDictionary *)[dict objectForKey:@"rect"]).count, 6);
   XCTAssertEqualObjects(dict[@"rect"][@"x"], @(CGRectGetMinX([view frame])));
-  XCTAssertEqualObjects(dict[@"rect"][@"y"], @(CGRectGetMinY([view frame])));
+  if ([self isLessThanIOS8]) {
+    expect(dict[@"rect"][@"y"]).to.beCloseToWithin(84.5, 0.001);// @(CGRectGetMinY([view frame])));
+  } else {
+    XCTAssertEqualObjects(dict[@"rect"][@"y"], @(CGRectGetMinY([view frame])));
+  }
   XCTAssertEqualObjects(dict[@"rect"][@"width"], @(CGRectGetWidth([view frame])));
   XCTAssertEqualObjects(dict[@"rect"][@"height"], @(CGRectGetHeight([view frame])));
   XCTAssertEqualObjects(dict[@"rect"][@"center_x"], @(CGRectGetMidX([view frame])));
@@ -431,7 +443,11 @@
   UISlider *view = [[UISlider alloc] initWithFrame:frame];
   NSDictionary *dict = [LPJSONUtils dictionaryByEncodingView:view];
 
-  XCTAssertEqualObjects(dict[@"accessibilityElement"], @(0));
+  if ([self isLessThanIOS8]) {
+    XCTAssertEqualObjects(dict[@"accessibilityElement"], @(1));
+  } else {
+    XCTAssertEqualObjects(dict[@"accessibilityElement"], @(0));
+  }
   XCTAssertEqualObjects(dict[@"alpha"], @(1));
   XCTAssertEqualObjects(dict[@"class"], NSStringFromClass([view class]));
   XCTAssertEqualObjects(dict[@"description"], [view description]);

--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -4,6 +4,7 @@
 
 #import "LPJSONUtils.h"
 #import "LPTouchUtils.h"
+#import "LPDevice.h"
 
 @interface LPXCTestSliderWithText : UISlider
 
@@ -49,6 +50,12 @@
 
 @interface LPJSONUtilsTest : XCTestCase
 
+- (BOOL) isIphone6;
+- (BOOL) isIphone6Plus;
+- (BOOL) isIphone4in;
+- (BOOL) isIphone35in;
+- (BOOL) isIpad;
+
 @end
 
 @implementation LPJSONUtilsTest
@@ -59,6 +66,26 @@
 
 - (void)tearDown {
   [super tearDown];
+}
+
+- (BOOL) isIphone6 {
+  return [[LPDevice sharedDevice] iPhone6];
+}
+
+- (BOOL) isIphone6Plus {
+  return [[LPDevice sharedDevice] iPhone6Plus];
+}
+
+- (BOOL) isIphone4in {
+  return [LPTouchUtils is4InchDevice];
+}
+
+- (BOOL) isIphone35in {
+  return [LPTouchUtils isThreeAndAHalfInchDevice];
+}
+
+- (BOOL) isIpad {
+  return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
 }
 
 #pragma mark - dictionary:setObject:forKey:whenTarget:respondsTo:

--- a/XCTest/Tests/Utils/LPPluginLoaderTest.m
+++ b/XCTest/Tests/Utils/LPPluginLoaderTest.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "LPPluginLoader.h"
+#import "LPDevice.h"
 
 @interface LPPluginLoader (LPXCTEST)
 
@@ -81,17 +82,25 @@ describe(@"LPPluginLoader", ^{
     });
 
     it(@"returns true when dylib is loaded", ^{
-      NSBundle *main = [NSBundle mainBundle];
-      NSString *path = [main pathForResource:@"examplePlugin" ofType:@"dylib"];
-      expect(path).notTo.equal(nil);
-      expect([loader loadDylibAtPath:path]).to.equal(YES);
+      if ([[LPDevice sharedDevice] simulator]) {
+        NSBundle *main = [NSBundle mainBundle];
+        NSString *path = [main pathForResource:@"examplePlugin" ofType:@"dylib"];
+        expect(path).notTo.equal(nil);
+        expect([loader loadDylibAtPath:path]).to.equal(YES);
+      } else {
+        // nop for devices because the dylibs are not signed.
+      }
     });
   });
 
   describe(@"#loadCalabashPlugins", ^{
     it(@"returns true if all plug-ins were loaded", ^{
-      LPPluginLoader *loader = [LPPluginLoader new];
-      expect([loader loadCalabashPlugins]).to.equal(YES);
+      if ([[LPDevice sharedDevice] simulator]) {
+        LPPluginLoader *loader = [LPPluginLoader new];
+        expect([loader loadCalabashPlugins]).to.equal(YES);
+      } else {
+        // nop for devices because the dylibs are not signed.
+      }
     });
 
     it(@"returns false if a plug fails to load", ^{

--- a/XCTest/Tests/WebViewQuery/LPIsWebViewTest.m
+++ b/XCTest/Tests/WebViewQuery/LPIsWebViewTest.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "LPIsWebView.h"
+#import "LPDevice.h"
 
 @interface LPIsWebView (LPXCTEST)
 
@@ -30,16 +31,24 @@ describe(@".isWebView", ^{
       });
 
       it(@"is a WKWebView", ^{
-        Class klass = objc_getClass("WKWebView");
-        id obj = [[klass alloc] initWithFrame:CGRectZero];
-        expect([LPIsWebView isWebView:obj]).to.equal(YES);
+        if ([[LPDevice sharedDevice] isLessThaniOS8]) {
+          // nop for iOS < 8.0
+        } else {
+          Class klass = objc_getClass("WKWebView");
+          id obj = [[klass alloc] initWithFrame:CGRectZero];
+          expect([LPIsWebView isWebView:obj]).to.equal(YES);
+        }
       });
 
       it(@"is a subclass of WKWebView", ^{
-        Class klass = objc_getClass("WKWebView");
-        Class subclass = objc_allocateClassPair(klass, "MyWKWebView", 0);
-        id obj = [[subclass alloc] initWithFrame:CGRectZero];
-        expect([LPIsWebView isWebView:obj]).to.equal(YES);
+        if ([[LPDevice sharedDevice] isLessThaniOS8]) {
+          // nop for iOS < 8.0
+        } else {
+          Class klass = objc_getClass("WKWebView");
+          Class subclass = objc_allocateClassPair(klass, "MyWKWebView", 0);
+          id obj = [[subclass alloc] initWithFrame:CGRectZero];
+          expect([LPIsWebView isWebView:obj]).to.equal(YES);
+        }
       });
     });
 

--- a/XCTest/Tests/WebViewQuery/LPWKWebViewRuntimeLoaderTest.m
+++ b/XCTest/Tests/WebViewQuery/LPWKWebViewRuntimeLoaderTest.m
@@ -9,6 +9,8 @@
 #import "LPInvoker.h"
 #import "LPWebViewProtocol.h"
 #import "LPJSONUtils.h"
+#import "LPCJSONDeserializer.h"
+#import "LPDevice.h"
 
 
 @interface LPWKWebViewRuntimeLoader (LPXCTest)
@@ -134,8 +136,12 @@ describe(@"LPWKWebViewRuntimeLoaderTest", ^{
     });
 
     it(@"Implementation has been loaded by CalabashServer.start", ^{
-      LPWKWebViewRuntimeLoader *loader = [LPWKWebViewRuntimeLoader shared];
-      expect(loader.state).to.equal(LPWKWebViewDidImplementProtocol);
+      if([[LPDevice sharedDevice] isLessThaniOS8]) {
+        // nop for iOS < 8
+      } else {
+        LPWKWebViewRuntimeLoader *loader = [LPWKWebViewRuntimeLoader shared];
+        expect(loader.state).to.equal(LPWKWebViewDidImplementProtocol);
+      }
     });
   });
 

--- a/XCTest/Tests/WebViewQuery/LPWKWebViewRuntimeLoaderTest.m
+++ b/XCTest/Tests/WebViewQuery/LPWKWebViewRuntimeLoaderTest.m
@@ -247,11 +247,24 @@ describe(@"LPWKWebViewRuntimeLoaderTest", ^{
       expect(actual).to.equal(@"Received javascript: string!");
 
       // error
+
+      // The error string can come back with its keys in an order, so it makes
+      // checking for equality impossible.
       actual = [LPWKWebViewMethodInvoker stringByInvokingSelector:sel
                                                            target:obj
                                                          argument:@"error"];
+      NSData *actualData = [actual dataUsingEncoding:NSUTF8StringEncoding];
+
       NSString *expected = @"{\"error\":\"Another day, another misunderstood JavaScript programmer.\",\"javascript\":\"error\"}";
-      expect(actual).to.equal(expected);
+      NSData *expectedData = [expected dataUsingEncoding:NSUTF8StringEncoding];
+
+      LPCJSONDeserializer *parser = [LPCJSONDeserializer new];
+
+      NSDictionary *actualDict = [parser deserializeAsDictionary:actualData error:nil];
+      NSDictionary *expectedDict = [parser deserializeAsDictionary:expectedData error:nil];
+
+      expect(actualDict[@"error"]).to.equal(expectedDict[@"error"]);
+      expect(actualDict[@"javascript"]).to.equal(expectedDict[@"javascript"]);
     });
   });
 

--- a/XCTest/Tests/WebViewQuery/WKWebView+LPWebViewTest.m
+++ b/XCTest/Tests/WebViewQuery/WKWebView+LPWebViewTest.m
@@ -6,6 +6,8 @@
 #import "LPJSONUtils.h"
 #import <WebKit/WebKit.h>
 #import "LPWebViewProtocol.h"
+#import "LPCJSONDeserializer.h"
+#import "LPDevice.h"
 
 @interface WKWebView (LPXCTEST)
 
@@ -73,224 +75,249 @@ SpecBegin(WKWebView_LPWebViewTest)
 
 describe(@"WKWebView+LPWebView", ^{
 
-  describe(@"helper methods", ^{
-    __block WKWebView *webView;
-    before(^{ webView = [[WKWebView alloc] initWithFrame:CGRectZero]; });
+  if([[LPDevice sharedDevice] isLessThaniOS8]) {
+    // nop for iOS < 8
+  } else {
 
-    it(@"#lpStringFromDate:", ^{
-      NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-      [formatter setDateFormat:LPWKWebViewISO8601DateFormat];
-      NSString *expectedDateString = @"2015-03-26 16:39:06 +0100";
-      NSDate *expected = [formatter dateFromString:expectedDateString];
-      NSString *actualDateString = [webView lpStringWithDate:expected];
-      NSDate *actual = [formatter dateFromString:actualDateString];
-      expect([actual compare:expected]).to.equal(NSOrderedSame);
-    });
+    describe(@"helper methods", ^{
+      __block WKWebView *webView;
+      before(^{ webView = [[WKWebView alloc] initWithFrame:CGRectZero]; });
 
-    it(@"lpStringFromDictionary:", ^{
-      NSDictionary *dict = @{@"one" : @(1),
-                             @"two" : @(2),
-                             @"three" : @(3)};
-      NSString *expected = [LPJSONUtils serializeDictionary:dict];
-      NSString *actual = [webView lpStringWithDictionary:dict];
-      expect(actual).to.equal(expected);
-    });
-
-    it(@"lpStringFromArray:", ^{
-      NSArray *arr = @[@(1), @(2), @(3)];
-      NSString *expected = [LPJSONUtils serializeArray:arr];
-      NSString *actual = [webView lpStringWithArray:arr];
-      expect(actual).to.equal(expected);
-    });
-  });
-
-  describe(@"#calabashStringByEvaulatingJavaScript:", ^{
-
-    __block WKWebView *webView;
-    __block SEL mockSel;
-    __block LPMockEvaluator *evaluator;
-    __block NSString *expected;
-    __block NSString *actual;
-    __block id viewMock;
-
-    before(^{
-      webView = [[WKWebView alloc] initWithFrame:CGRectZero];
-      mockSel = @selector(mockEvaluateJavascript:completionHandler:);
-    });
-
-
-    describe(@"can report errors", ^{
-      it(@"when javascript is not nil", ^{
-        evaluator = [[LPMockEvaluator alloc] initWithResult:nil raise:YES];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        actual = [viewMock calabashStringByEvaluatingJavaScript:@"invalid javascript"];
-        expected = @"{\"error\":\"Another day, another misunderstood JavaScript programmer.\",\"javascript\":\"invalid javascript\"}";
-        expect(actual).to.equal(expected);
-      });
-
-      it(@"when javascript is nil", ^{
-        evaluator = [[LPMockEvaluator alloc] initWithResult:nil raise:YES];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        actual = [viewMock calabashStringByEvaluatingJavaScript:nil];
-        expected = @"{\"error\":\"Another day, another misunderstood JavaScript programmer.\",\"javascript\":null}";
-        expect(actual).to.equal(expected);
-      });
-    });
-
-    describe(@"can handle various return types", ^{
-
-      it(@"returns empty string for 'nil'", ^{
-        evaluator = [[LPMockEvaluator alloc] initWithResult:nil];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-        expect(actual).to.equal(@"");
-      });
-
-      it(@"returns empty string for NSNull", ^{
-        evaluator = [[LPMockEvaluator alloc] initWithResult:[NSNull null]];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-        expect(actual).to.equal(@"");
-      });
-
-      it(@"returns a string for NSString", ^{
-        evaluator = [[LPMockEvaluator alloc] initWithResult:@"a string"];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        NSString *actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-        expect(actual).to.equal(@"a string");
-      });
-
-      it(@"returns an iso 8601 string for NSDate", ^{
+      it(@"#lpStringFromDate:", ^{
         NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:LPWKWebViewISO8601DateFormat];
         NSString *expectedDateString = @"2015-03-26 16:39:06 +0100";
-        NSDate *expectedDate = [formatter dateFromString:expectedDateString];
-
-        NSDate *dateToReturn = [formatter dateFromString:expected];
-        evaluator = [[LPMockEvaluator alloc] initWithResult:dateToReturn];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        NSString *actualDateString = [viewMock calabashStringByEvaluatingJavaScript:@""];
-
-        NSDate *actualDate = [formatter dateFromString:actualDateString];
-        expect([actualDate compare:expectedDate]).to.equal(NSOrderedSame);
+        NSDate *expected = [formatter dateFromString:expectedDateString];
+        NSString *actualDateString = [webView lpStringWithDate:expected];
+        NSDate *actual = [formatter dateFromString:actualDateString];
+        expect([actual compare:expected]).to.equal(NSOrderedSame);
       });
 
-      it(@"returns JSON representation of NSDictionary", ^{
+      it(@"lpStringFromDictionary:", ^{
         NSDictionary *dict = @{@"one" : @(1),
                                @"two" : @(2),
                                @"three" : @(3)};
-       expected = [LPJSONUtils serializeDictionary:dict];
-
-        evaluator = [[LPMockEvaluator alloc] initWithResult:dict];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+        NSString *expected = [LPJSONUtils serializeDictionary:dict];
+        NSString *actual = [webView lpStringWithDictionary:dict];
         expect(actual).to.equal(expected);
       });
 
-      it(@"returns JSON representation of NSArray", ^{
+      it(@"lpStringFromArray:", ^{
         NSArray *arr = @[@(1), @(2), @(3)];
-        expected = [LPJSONUtils serializeArray:arr];
-        evaluator = [[LPMockEvaluator alloc] initWithResult:arr];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+        NSString *expected = [LPJSONUtils serializeArray:arr];
+        NSString *actual = [webView lpStringWithArray:arr];
         expect(actual).to.equal(expected);
       });
+    });
 
-      describe(@"returns string for NSNumber", ^{
-        it(@"CGFloat", ^{
-          CGFloat val = 44.5;
-          NSNumber *number = @(val);
-          evaluator = [[LPMockEvaluator alloc] initWithResult:number];
+    describe(@"#calabashStringByEvaulatingJavaScript:", ^{
+
+      __block WKWebView *webView;
+      __block SEL mockSel;
+      __block LPMockEvaluator *evaluator;
+      __block NSString *expected;
+      __block NSString *actual;
+      __block id viewMock;
+
+      before(^{
+        webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+        mockSel = @selector(mockEvaluateJavascript:completionHandler:);
+      });
+
+
+      describe(@"can report errors", ^{
+        it(@"when javascript is not nil", ^{
+          evaluator = [[LPMockEvaluator alloc] initWithResult:nil raise:YES];
           viewMock = [OCMockObject partialMockForObject:webView];
           [[[viewMock stub] andCall:mockSel onObject:evaluator]
            evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          actual = [viewMock calabashStringByEvaluatingJavaScript:@"invalid javascript"];
+          expected = @"{\"error\":\"Another day, another misunderstood JavaScript programmer.\",\"javascript\":\"invalid javascript\"}";
 
-          actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-          expect(actual).to.equal(@"44.5");
+          NSData *actualData = [actual dataUsingEncoding:NSUTF8StringEncoding];
+          NSData *expectedData = [expected dataUsingEncoding:NSUTF8StringEncoding];
+
+          LPCJSONDeserializer *parser = [LPCJSONDeserializer new];
+
+          NSDictionary *actualDict = [parser deserializeAsDictionary:actualData error:nil];
+          NSDictionary *expectedDict = [parser deserializeAsDictionary:expectedData error:nil];
+
+          expect(actualDict[@"error"]).to.equal(expectedDict[@"error"]);
+          expect(actualDict[@"javascript"]).to.equal(expectedDict[@"javascript"]);
         });
 
-        it(@"NSUInteger", ^{
-          NSUInteger val = 44;
-          NSNumber *number = @(val);
-          evaluator = [[LPMockEvaluator alloc] initWithResult:number];
+        it(@"when javascript is nil", ^{
+          evaluator = [[LPMockEvaluator alloc] initWithResult:nil raise:YES];
+          viewMock = [OCMockObject partialMockForObject:webView];
+          [[[viewMock stub] andCall:mockSel onObject:evaluator]
+           evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          actual = [viewMock calabashStringByEvaluatingJavaScript:nil];
+          expected = @"{\"error\":\"Another day, another misunderstood JavaScript programmer.\",\"javascript\":null}";
+
+          NSData *actualData = [actual dataUsingEncoding:NSUTF8StringEncoding];
+          NSData *expectedData = [expected dataUsingEncoding:NSUTF8StringEncoding];
+
+          LPCJSONDeserializer *parser = [LPCJSONDeserializer new];
+
+          NSDictionary *actualDict = [parser deserializeAsDictionary:actualData error:nil];
+          NSDictionary *expectedDict = [parser deserializeAsDictionary:expectedData error:nil];
+
+          expect(actualDict[@"error"]).to.equal(expectedDict[@"error"]);
+          expect(actualDict[@"javascript"]).to.equal(expectedDict[@"javascript"]);
+        });
+      });
+
+      describe(@"can handle various return types", ^{
+
+        it(@"returns empty string for 'nil'", ^{
+          evaluator = [[LPMockEvaluator alloc] initWithResult:nil];
           viewMock = [OCMockObject partialMockForObject:webView];
           [[[viewMock stub] andCall:mockSel onObject:evaluator]
            evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
           actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-          expect(actual).to.equal(@"44");
+          expect(actual).to.equal(@"");
         });
 
-        it(@"NSInteger", ^{
-          NSInteger val = -44;
-          NSNumber *number = @(val);
-          evaluator = [[LPMockEvaluator alloc] initWithResult:number];
+        it(@"returns empty string for NSNull", ^{
+          evaluator = [[LPMockEvaluator alloc] initWithResult:[NSNull null]];
+          viewMock = [OCMockObject partialMockForObject:webView];
+          [[[viewMock stub] andCall:mockSel onObject:evaluator]
+           evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+          expect(actual).to.equal(@"");
+        });
+
+        it(@"returns a string for NSString", ^{
+          evaluator = [[LPMockEvaluator alloc] initWithResult:@"a string"];
           viewMock = [OCMockObject partialMockForObject:webView];
           [[[viewMock stub] andCall:mockSel onObject:evaluator]
            evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
           NSString *actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-          expect(actual).to.equal(@"-44");
+          expect(actual).to.equal(@"a string");
+        });
+
+        it(@"returns an iso 8601 string for NSDate", ^{
+          NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+          [formatter setDateFormat:LPWKWebViewISO8601DateFormat];
+          NSString *expectedDateString = @"2015-03-26 16:39:06 +0100";
+          NSDate *expectedDate = [formatter dateFromString:expectedDateString];
+
+          NSDate *dateToReturn = [formatter dateFromString:expected];
+          evaluator = [[LPMockEvaluator alloc] initWithResult:dateToReturn];
+          viewMock = [OCMockObject partialMockForObject:webView];
+          [[[viewMock stub] andCall:mockSel onObject:evaluator]
+           evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          NSString *actualDateString = [viewMock calabashStringByEvaluatingJavaScript:@""];
+
+          NSDate *actualDate = [formatter dateFromString:actualDateString];
+          expect([actualDate compare:expectedDate]).to.equal(NSOrderedSame);
+        });
+
+        it(@"returns JSON representation of NSDictionary", ^{
+          NSDictionary *dict = @{@"one" : @(1),
+                                 @"two" : @(2),
+                                 @"three" : @(3)};
+          expected = [LPJSONUtils serializeDictionary:dict];
+
+          evaluator = [[LPMockEvaluator alloc] initWithResult:dict];
+          viewMock = [OCMockObject partialMockForObject:webView];
+          [[[viewMock stub] andCall:mockSel onObject:evaluator]
+           evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+          expect(actual).to.equal(expected);
+        });
+
+        it(@"returns JSON representation of NSArray", ^{
+          NSArray *arr = @[@(1), @(2), @(3)];
+          expected = [LPJSONUtils serializeArray:arr];
+          evaluator = [[LPMockEvaluator alloc] initWithResult:arr];
+          viewMock = [OCMockObject partialMockForObject:webView];
+          [[[viewMock stub] andCall:mockSel onObject:evaluator]
+           evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+          expect(actual).to.equal(expected);
+        });
+
+        describe(@"returns string for NSNumber", ^{
+          it(@"CGFloat", ^{
+            CGFloat val = 44.5;
+            NSNumber *number = @(val);
+            evaluator = [[LPMockEvaluator alloc] initWithResult:number];
+            viewMock = [OCMockObject partialMockForObject:webView];
+            [[[viewMock stub] andCall:mockSel onObject:evaluator]
+             evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+
+            actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+            expect(actual).to.equal(@"44.5");
+          });
+
+          it(@"NSUInteger", ^{
+            NSUInteger val = 44;
+            NSNumber *number = @(val);
+            evaluator = [[LPMockEvaluator alloc] initWithResult:number];
+            viewMock = [OCMockObject partialMockForObject:webView];
+            [[[viewMock stub] andCall:mockSel onObject:evaluator]
+             evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+            actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+            expect(actual).to.equal(@"44");
+          });
+
+          it(@"NSInteger", ^{
+            NSInteger val = -44;
+            NSNumber *number = @(val);
+            evaluator = [[LPMockEvaluator alloc] initWithResult:number];
+            viewMock = [OCMockObject partialMockForObject:webView];
+            [[[viewMock stub] andCall:mockSel onObject:evaluator]
+             evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+            NSString *actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+            expect(actual).to.equal(@"-44");
+          });
+        });
+
+        it(@"returns description if all else fails", ^{
+          UIColor *color = [UIColor whiteColor];
+          evaluator = [[LPMockEvaluator alloc] initWithResult:color];
+          viewMock = [OCMockObject partialMockForObject:webView];
+          [[[viewMock stub] andCall:mockSel onObject:evaluator]
+           evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+          NSString *actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
+          NSUInteger idx = [actual rangeOfString:@"UIDeviceWhiteColorSpace"].location;
+          expect(idx).notTo.equal(NSNotFound);
         });
       });
 
-      it(@"returns description if all else fails", ^{
-        UIColor *color = [UIColor whiteColor];
-        evaluator = [[LPMockEvaluator alloc] initWithResult:color];
-        viewMock = [OCMockObject partialMockForObject:webView];
-        [[[viewMock stub] andCall:mockSel onObject:evaluator]
-         evaluateJavaScript:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-        NSString *actual = [viewMock calabashStringByEvaluatingJavaScript:@""];
-        NSUInteger idx = [actual rangeOfString:@"UIDeviceWhiteColorSpace"].location;
-        expect(idx).notTo.equal(NSNotFound);
+      describe(@"can eval actual JavaScript", ^{
+        it(@"returns string for numbers", ^{
+          NSString *actual;
+          actual = [webView calabashStringByEvaluatingJavaScript:@"1 + 2"];
+          expect(actual).to.equal(@"3");
+          actual = [webView calabashStringByEvaluatingJavaScript:@"new Number(4)"];
+          expect(actual).to.equal(@"{}");
+        });
+
+        it(@"returns string for string concat", ^{
+          NSString *javascript = @"eval(\"'a' + 'b'\")";
+          actual = [webView calabashStringByEvaluatingJavaScript:javascript];
+          expect(actual).to.equal(@"ab");
+        });
+
+        it(@"returns JSON representation of arrays", ^{
+          expected = @"[\"a\",\"b\",1]";
+          NSString *javascript = @"['a', 'b', 1]";
+
+          actual = [webView calabashStringByEvaluatingJavaScript:javascript];
+          expect(actual).to.equal(expected);
+        });
+
+        it(@"returns JSON representation of associate arrays", ^{
+          expected =  @"{\"trout\":\"yummy\"}";
+          NSString *javascript = @"var a = {}; var fish = 'trout'; a[fish] = 'yummy'; a;";
+          actual = [webView calabashStringByEvaluatingJavaScript:javascript];
+          expect(actual).to.equal(expected);
+        });
       });
     });
-
-    describe(@"can eval actual JavaScript", ^{
-      it(@"returns string for numbers", ^{
-        NSString *actual;
-        actual = [webView calabashStringByEvaluatingJavaScript:@"1 + 2"];
-        expect(actual).to.equal(@"3");
-        actual = [webView calabashStringByEvaluatingJavaScript:@"new Number(4)"];
-        expect(actual).to.equal(@"{}");
-      });
-
-      it(@"returns string for string concat", ^{
-        NSString *javascript = @"eval(\"'a' + 'b'\")";
-        actual = [webView calabashStringByEvaluatingJavaScript:javascript];
-        expect(actual).to.equal(@"ab");
-      });
-
-      it(@"returns JSON representation of arrays", ^{
-        expected = @"[\"a\",\"b\",1]";
-        NSString *javascript = @"['a', 'b', 1]";
-
-        actual = [webView calabashStringByEvaluatingJavaScript:javascript];
-        expect(actual).to.equal(expected);
-      });
-
-      it(@"returns JSON representation of associate arrays", ^{
-        expected =  @"{\"trout\":\"yummy\"}";
-        NSString *javascript = @"var a = {}; var fish = 'trout'; a[fish] = 'yummy'; a;";
-        actual = [webView calabashStringByEvaluatingJavaScript:javascript];
-        expect(actual).to.equal(expected);
-      });
-    });
-  });
+  }
 });
 
 SpecEnd

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -15,11 +15,13 @@
 @property(copy, nonatomic, readonly) NSString *system;
 @property(copy, nonatomic, readonly) NSString *model;
 @property(copy, nonatomic, readonly) NSString *formFactor;
+@property(copy, nonatomic, readonly) NSString *iOSVersion;
 
 + (LPDevice *) sharedDevice;
 
 - (BOOL) simulator;
 - (BOOL) iPhone6;
 - (BOOL) iPhone6Plus;
+- (BOOL) isLessThaniOS8;
 
 @end

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -29,6 +29,7 @@
 @synthesize system = _system;
 @synthesize model = _model;
 @synthesize formFactor = _formFactor;
+@synthesize iOSVersion = _iOSVersion;
 
 - (id) init {
   @throw [NSException exceptionWithName:@"Cannot call init"
@@ -123,6 +124,17 @@
   uname(&systemInfo);
   _system = @(systemInfo.machine);
   return _system;
+}
+
+- (NSString *) iOSVersion {
+  if (_iOSVersion) { return _iOSVersion; }
+  _iOSVersion = [[UIDevice currentDevice] systemVersion];
+  return _iOSVersion;
+}
+
+- (BOOL) isLessThaniOS8 {
+  NSString *version = self.iOSVersion;
+  return [version compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending;
 }
 
 - (NSString *) model {


### PR DESCRIPTION
### Motivation

Back in January, when I started to LPJSONUtils under test, I wrote some quick and dirty tests that only worked on iOS 8 iPhone 5s devices.  The command-line tool only runs the tests against this simulator.

This bad practice continued when I implemented the runtime loading of WKWebView support.

I was more than a little embarrassed when I tried to explain this to @sapieneptus in Aarhus.

There is still a some behavior that I don't understand yet with respect to how the center point of a rect is determined, but this PR moves me one step closer.

Unfortunately, some tests fail when in landscape mode because the center points do not match expectations.
