### PR TITLE
XCTests need a way to compare iOS versions

### DIFF
--- a/XCTest/Tests/LPiOSVersionInlines.h
+++ b/XCTest/Tests/LPiOSVersionInlines.h
@@ -1,0 +1,28 @@
+NS_INLINE NSString* lp_sys_version() {
+  static dispatch_once_t onceToken;
+  static NSString *shared  = nil;
+  dispatch_once(&onceToken, ^{
+    shared = [[UIDevice currentDevice] systemVersion];
+  });
+  return shared;
+}
+
+NS_INLINE BOOL lp_ios_version_eql(NSString* v) {
+  return [lp_sys_version() compare:v options:NSNumericSearch] == NSOrderedSame;
+}
+
+NS_INLINE BOOL lp_ios_version_gt(NSString* v) {
+  return [lp_sys_version() compare:v options:NSNumericSearch] == NSOrderedDescending;
+}
+
+NS_INLINE BOOL lp_ios_version_gte(NSString* v) {
+  return [lp_sys_version() compare:v options:NSNumericSearch] != NSOrderedAscending;
+}
+
+NS_INLINE BOOL lp_ios_version_lt(NSString* v) {
+  return [lp_sys_version() compare:v options:NSNumericSearch] == NSOrderedAscending;
+}
+
+NS_INLINE BOOL lp_ios_version_lte(NSString* v) {
+  return [lp_sys_version() compare:v options:NSNumericSearch] != NSOrderedDescending;
+}

--- a/XCTest/Tests/LPiOSVersionInlinesTest.m
+++ b/XCTest/Tests/LPiOSVersionInlinesTest.m
@@ -1,0 +1,78 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPiOSVersionInlines.h"
+
+@interface LPiOSVersionInlinesTest : XCTestCase
+
+@end
+
+@implementation LPiOSVersionInlinesTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+// Do inlining and dispatch_once help performance?  Yes.
+
+// 0.133 seconds
+//- (void)testPerformanceNotInlined {
+//  // This is an example of a performance test case.
+//  [self measureBlock:^{
+//    for (NSInteger i = 0; i < 100000; i++) {
+//      [[UIDevice currentDevice] systemVersion];
+//    }
+//  }];
+//}
+
+// 0.005 seconds
+//- (void)testPerformanceInlined {
+//  // This is an example of a performance test case.
+//  [self measureBlock:^{
+//    for (NSInteger i = 0; i < 100000; i++) {
+//      lp_sys_version();
+//    }
+//  }];
+//}
+
+@end
+
+SpecBegin(LPiOSVersionInlines)
+
+describe(@"LPiOSVersionInlines", ^{
+  it(@"iOS version", ^{
+    expect(lp_sys_version()).notTo.equal(nil);
+  });
+
+  it(@"==", ^{
+    expect(lp_ios_version_eql(@"some version")).to.equal(NO);
+    expect(lp_ios_version_eql([[UIDevice currentDevice] systemVersion])).to.equal(YES);
+  });
+
+  it(@">", ^{
+    expect(lp_ios_version_gt(@"1.0")).to.equal(YES);
+    expect(lp_ios_version_gt(@"100.0")).to.equal(NO);
+  });
+
+  it(@">=", ^{
+    expect(lp_ios_version_gte(@"1.0")).to.equal(YES);
+    expect(lp_ios_version_gte(@"100.0")).to.equal(NO);
+  });
+
+  it(@"<", ^{
+    expect(lp_ios_version_lt(@"100.0")).to.equal(YES);
+    expect(lp_ios_version_lt(@"1.0")).to.equal(NO);
+  });
+
+  it(@"<=", ^{
+    expect(lp_ios_version_lte(@"100.0")).to.equal(YES);
+    expect(lp_ios_version_lte(@"1.0")).to.equal(NO);
+  });
+});
+
+SpecEnd

--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -72,43 +72,6 @@ describe(@"LPDevice", ^{
     expect([device system]).notTo.beNil();
   });
 
-  it(@"#systemVersion", ^{
-    LPDevice *device = [[LPDevice alloc] init_private];
-    expect([device iOSVersion]).notTo.beNil();
-  });
-
-  describe(@"#isLessThanIOS8", ^{
-
-    __block LPDevice *device;
-    __block id mockDevice;
-
-    before(^{
-      device = [[LPDevice alloc] init_private];
-      mockDevice = OCMPartialMock(device);
-    });
-
-    it(@"true for iOS < 8.0", ^{
-      [[[mockDevice expect] andReturn:@"7.1"] iOSVersion];
-
-      expect([mockDevice isLessThaniOS8]).to.equal(YES);
-      [mockDevice verify];
-    });
-
-    it(@"false for iOS = 8.0", ^{
-      [[[mockDevice expect] andReturn:@"8.0"] iOSVersion];
-
-      expect([mockDevice isLessThaniOS8]).to.equal(NO);
-      [mockDevice verify];
-    });
-
-    it(@"false for iOS > 8.0", ^{
-      [[[mockDevice expect] andReturn:@"9.0"] iOSVersion];
-
-      expect([mockDevice isLessThaniOS8]).to.equal(NO);
-      [mockDevice verify];
-    });
-  });
-
   it(@"#model", ^{
     LPDevice *device = [[LPDevice alloc] init_private];
     expect([device model]).notTo.beNil();

--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -88,10 +88,6 @@
   return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
 }
 
-- (BOOL) isLessThanIOS8 {
-  return [[LPDevice sharedDevice] isLessThaniOS8];
-}
-
 #pragma mark - dictionary:setObject:forKey:whenTarget:respondsTo:
 
 - (void) testDictionarySetObjectForKeyWhenTargetRespondsToYesAndNil {
@@ -179,7 +175,7 @@
 
   NSDictionary *dict = [LPJSONUtils dictionaryByEncodingView:view];
 
-  if([self isLessThanIOS8]) {
+  if (lp_ios_version_lte(@"8.0")) {
     XCTAssertEqualObjects(dict[@"accessibilityElement"], @(1));
   } else {
     XCTAssertEqualObjects(dict[@"accessibilityElement"], @(0));
@@ -289,11 +285,13 @@
   XCTAssertEqualObjects(dict[@"frame"][@"height"], @(CGRectGetHeight([view frame])));
   XCTAssertEqual(((NSDictionary *)[dict objectForKey:@"rect"]).count, 6);
   XCTAssertEqualObjects(dict[@"rect"][@"x"], @(CGRectGetMinX([view frame])));
-  if ([self isLessThanIOS8]) {
+
+  if (lp_ios_version_lte(@"8.0")) {
     expect(dict[@"rect"][@"y"]).to.beCloseToWithin(84.5, 0.001);// @(CGRectGetMinY([view frame])));
   } else {
     XCTAssertEqualObjects(dict[@"rect"][@"y"], @(CGRectGetMinY([view frame])));
   }
+
   XCTAssertEqualObjects(dict[@"rect"][@"width"], @(CGRectGetWidth([view frame])));
   XCTAssertEqualObjects(dict[@"rect"][@"height"], @(CGRectGetHeight([view frame])));
 
@@ -309,6 +307,7 @@
   } else {
     XCTFail(@"Expected device to be an iPhone 6, 6+, 4in, or 3.5in or an iPad");
   }
+
   XCTAssertEqualObjects(dict[@"value"], [NSNull null]);
   XCTAssertEqualObjects(dict[@"visible"], @(0));
   XCTAssertEqual([dict count], 11);
@@ -466,11 +465,12 @@
   UISlider *view = [[UISlider alloc] initWithFrame:frame];
   NSDictionary *dict = [LPJSONUtils dictionaryByEncodingView:view];
 
-  if ([self isLessThanIOS8]) {
+  if (lp_ios_version_lte(@"8.0")) {
     XCTAssertEqualObjects(dict[@"accessibilityElement"], @(1));
   } else {
     XCTAssertEqualObjects(dict[@"accessibilityElement"], @(0));
   }
+
   XCTAssertEqualObjects(dict[@"alpha"], @(1));
   XCTAssertEqualObjects(dict[@"class"], NSStringFromClass([view class]));
   XCTAssertEqualObjects(dict[@"description"], [view description]);

--- a/XCTest/Tests/WebViewQuery/LPIsWebViewTest.m
+++ b/XCTest/Tests/WebViewQuery/LPIsWebViewTest.m
@@ -31,7 +31,7 @@ describe(@".isWebView", ^{
       });
 
       it(@"is a WKWebView", ^{
-        if ([[LPDevice sharedDevice] isLessThaniOS8]) {
+        if (lp_ios_version_lt(@"8.0")) {
           // nop for iOS < 8.0
         } else {
           Class klass = objc_getClass("WKWebView");
@@ -41,7 +41,7 @@ describe(@".isWebView", ^{
       });
 
       it(@"is a subclass of WKWebView", ^{
-        if ([[LPDevice sharedDevice] isLessThaniOS8]) {
+        if (lp_ios_version_lt(@"8.0")) {
           // nop for iOS < 8.0
         } else {
           Class klass = objc_getClass("WKWebView");

--- a/XCTest/Tests/WebViewQuery/LPWKWebViewRuntimeLoaderTest.m
+++ b/XCTest/Tests/WebViewQuery/LPWKWebViewRuntimeLoaderTest.m
@@ -136,7 +136,7 @@ describe(@"LPWKWebViewRuntimeLoaderTest", ^{
     });
 
     it(@"Implementation has been loaded by CalabashServer.start", ^{
-      if([[LPDevice sharedDevice] isLessThaniOS8]) {
+      if (lp_ios_version_lt(@"8.0")) {
         // nop for iOS < 8
       } else {
         LPWKWebViewRuntimeLoader *loader = [LPWKWebViewRuntimeLoader shared];

--- a/XCTest/Tests/WebViewQuery/WKWebView+LPWebViewTest.m
+++ b/XCTest/Tests/WebViewQuery/WKWebView+LPWebViewTest.m
@@ -75,7 +75,7 @@ SpecBegin(WKWebView_LPWebViewTest)
 
 describe(@"WKWebView+LPWebView", ^{
 
-  if([[LPDevice sharedDevice] isLessThaniOS8]) {
+  if (lp_ios_version_lt(@"8.0")) {
     // nop for iOS < 8
   } else {
 

--- a/XCTest/tests.pch
+++ b/XCTest/tests.pch
@@ -19,4 +19,5 @@
 
 #import <objc/runtime.h>
 
+#import "LPiOSVersionInlines.h"
 #endif

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		F50CBFCE1A040669004AC9DA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F50CBFCD1A040669004AC9DA /* UIKit.framework */; };
 		F50CBFCF1A040707004AC9DA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
 		F50E42791AA86D36003DB030 /* libSpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50E42711AA86D36003DB030 /* libSpecta.a */; };
+		F514ACCC1B341557004ACFEE /* LPiOSVersionInlinesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F514ACCB1B341557004ACFEE /* LPiOSVersionInlinesTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F532C19B1AFD28970024DA55 /* LPCJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F532C1DE1AFF4F080024DA55 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F532C1DD1AFF4F080024DA55 /* CoreData.framework */; };
 		F532C1E31AFF4F250024DA55 /* LPCoreDataStack.m in Sources */ = {isa = PBXBuildFile; fileRef = F532C1E01AFF4F240024DA55 /* LPCoreDataStack.m */; };
@@ -1057,6 +1058,8 @@
 		F50E42761AA86D36003DB030 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSharedExampleGroups.h; sourceTree = "<group>"; };
 		F50E42771AA86D36003DB030 /* SPTSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTSpec.h; sourceTree = "<group>"; };
 		F50E42781AA86D36003DB030 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		F514ACCA1B3413D8004ACFEE /* LPiOSVersionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPiOSVersionInlines.h; sourceTree = "<group>"; };
+		F514ACCB1B341557004ACFEE /* LPiOSVersionInlinesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPiOSVersionInlinesTest.m; sourceTree = "<group>"; };
 		F532C19A1AFD28970024DA55 /* LPCJSONSerializerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCJSONSerializerTest.m; sourceTree = "<group>"; };
 		F532C1DD1AFF4F080024DA55 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		F532C1DF1AFF4F240024DA55 /* LPCoreDataStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCoreDataStack.h; sourceTree = "<group>"; };
@@ -1759,6 +1762,8 @@
 			isa = PBXGroup;
 			children = (
 				F50CBFD01A040788004AC9DA /* tests.pch */,
+				F514ACCA1B3413D8004ACFEE /* LPiOSVersionInlines.h */,
+				F514ACCB1B341557004ACFEE /* LPiOSVersionInlinesTest.m */,
 				F50CBF761A03F69A004AC9DA /* LPTestToolsStandup.m */,
 				F5C224E41AD47403001DB4FA /* Operations */,
 				F5C224E61AD47403001DB4FA /* Routes */,
@@ -2968,6 +2973,7 @@
 				F50CBF991A04058C004AC9DA /* LPScrollOperation.m in Sources */,
 				F50CBF9B1A04058C004AC9DA /* LPSetTextOperation.m in Sources */,
 				F50CBFA91A0405B2004AC9DA /* LPGenericAsyncRoute.m in Sources */,
+				F514ACCC1B341557004ACFEE /* LPiOSVersionInlinesTest.m in Sources */,
 				F50CBF8D1A04056F004AC9DA /* LPHTTPRedirectResponse.m in Sources */,
 				F50CBFB31A0405B2004AC9DA /* LPVersionRoute.m in Sources */,
 				F5543F311ABF7DF500E1A0BF /* LPPluginLoader.m in Sources */,

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -15,13 +15,11 @@
 @property(copy, nonatomic, readonly) NSString *system;
 @property(copy, nonatomic, readonly) NSString *model;
 @property(copy, nonatomic, readonly) NSString *formFactor;
-@property(copy, nonatomic, readonly) NSString *iOSVersion;
 
 + (LPDevice *) sharedDevice;
 
 - (BOOL) simulator;
 - (BOOL) iPhone6;
 - (BOOL) iPhone6Plus;
-- (BOOL) isLessThaniOS8;
 
 @end

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -29,7 +29,6 @@
 @synthesize system = _system;
 @synthesize model = _model;
 @synthesize formFactor = _formFactor;
-@synthesize iOSVersion = _iOSVersion;
 
 - (id) init {
   @throw [NSException exceptionWithName:@"Cannot call init"
@@ -124,17 +123,6 @@
   uname(&systemInfo);
   _system = @(systemInfo.machine);
   return _system;
-}
-
-- (NSString *) iOSVersion {
-  if (_iOSVersion) { return _iOSVersion; }
-  _iOSVersion = [[UIDevice currentDevice] systemVersion];
-  return _iOSVersion;
-}
-
-- (BOOL) isLessThaniOS8 {
-  NSString *version = self.iOSVersion;
-  return [version compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending;
 }
 
 - (NSString *) model {


### PR DESCRIPTION
### Motivation

As part of **XCTests should pass when run against any target simulator or device.** #184 I added two methods to LPDevice:

* - (NSString *) iOSVersion
* - (BOOL) lessThanIOS8

I don't want to encourage the use of iOS version comparison in the server.  We do this in one place in `LPUIAUserPrefsChannel` where we must know the iOS version to understand the iOS Simulator environment.

I've replaced the two methods from LPDevice with inline C functions that can do equality and inequality comparisons.

Why do I need this?

The behavior of the server is different iOS versions.  My iOS 9 testing is demonstrating that I need to know the iOS version to write good tests.