### PR TITLE
Refactor: rename LPLog => LPLogger

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		B1058E2C197F00C000B4A57B /* LPTouchUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */; };
 		B1058E2F197F00C000B4A57B /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		B1058E33197F00C000B4A57B /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
-		B1058E35197F00C000B4A57B /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		B1058E35197F00C000B4A57B /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		B1058E40197F00C000B4A57B /* CalabashServer.h in Headers */ = {isa = PBXBuildFile; fileRef = B184FD8814B6DAE1002A744C /* CalabashServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1058E4B197F00C000B4A57B /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B17E757A15D434D00066550B /* CFNetwork.framework */; };
 		B1058E4C197F00C000B4A57B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -160,7 +160,7 @@
 		B15BF9E119ABB1DE00B38577 /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		B15BF9E219ABB1DE00B38577 /* LPTouchUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */; };
 		B15BF9E319ABB1DE00B38577 /* LPEnv.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD74189A82DF00F8DF87 /* LPEnv.m */; };
-		B15BF9E419ABB1DE00B38577 /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		B15BF9E419ABB1DE00B38577 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		B15BF9E519ABB1DE00B38577 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8C14B6DAFB002A744C /* LPCDataScanner.m */; };
 		B15BF9E619ABB1DE00B38577 /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		B15BF9E719ABB1EB00B38577 /* LPI.mm in Sources */ = {isa = PBXBuildFile; fileRef = B184FDBD14B6DB2B002A744C /* LPI.mm */; };
@@ -239,7 +239,7 @@
 		B15BFA3319ABB2B100B38577 /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		B15BFA3419ABB2B100B38577 /* LPTouchUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */; };
 		B15BFA3519ABB2B100B38577 /* LPEnv.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD74189A82DF00F8DF87 /* LPEnv.m */; };
-		B15BFA3619ABB2B100B38577 /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		B15BFA3619ABB2B100B38577 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		B15BFA3719ABB2B100B38577 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8C14B6DAFB002A744C /* LPCDataScanner.m */; };
 		B15BFA3819ABB2B100B38577 /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		B15BFA3A19ABB2B100B38577 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -321,7 +321,7 @@
 		B1D5BDBB19A23BCE0070E8CE /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDBC19A23BCE0070E8CE /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
 		B1D5BDBD19A23BCE0070E8CE /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; };
-		B1D5BDBE19A23BCE0070E8CE /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		B1D5BDBE19A23BCE0070E8CE /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		B1D5BDBF19A23BCE0070E8CE /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		B1D5BDC019A23BCE0070E8CE /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDC119A23BCE0070E8CE /* LPLocationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CED0FA183E9551004793B9 /* LPLocationRoute.m */; };
@@ -437,7 +437,7 @@
 		F5091C1B18C4E1D700C85307 /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C1D18C4E1D700C85307 /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
 		F5091C1E18C4E1D700C85307 /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; };
-		F5091C1F18C4E1D700C85307 /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		F5091C1F18C4E1D700C85307 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		F5091C2018C4E1D700C85307 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		F5091C2118C4E1D700C85307 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C2218C4E1D700C85307 /* LPLocationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CED0FA183E9551004793B9 /* LPLocationRoute.m */; };
@@ -525,7 +525,7 @@
 		F50CBFC71A0405E9004AC9DA /* LPJSONUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0D14B6DB2B002A744C /* LPJSONUtils.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFC81A0405E9004AC9DA /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		F50CBFC91A0405E9004AC9DA /* LPEnv.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD74189A82DF00F8DF87 /* LPEnv.m */; };
-		F50CBFCA1A0405E9004AC9DA /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		F50CBFCA1A0405E9004AC9DA /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		F50CBFCB1A0405E9004AC9DA /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8C14B6DAFB002A744C /* LPCDataScanner.m */; };
 		F50CBFCC1A0405E9004AC9DA /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		F50CBFCE1A040669004AC9DA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F50CBFCD1A040669004AC9DA /* UIKit.framework */; };
@@ -686,7 +686,7 @@
 		F5821A3918C4E27400293508 /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A3B18C4E27400293508 /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
 		F5821A3C18C4E27400293508 /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; };
-		F5821A3D18C4E27400293508 /* LPLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLog.m */; };
+		F5821A3D18C4E27400293508 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
 		F5821A3E18C4E27400293508 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		F5821A3F18C4E27400293508 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A4018C4E27400293508 /* LPLocationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CED0FA183E9551004793B9 /* LPLocationRoute.m */; };
@@ -919,8 +919,8 @@
 		B12A04011511546F002FA032 /* LPInterpolateRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInterpolateRoute.m; sourceTree = "<group>"; };
 		B12DCD73189A82DF00F8DF87 /* LPEnv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPEnv.h; sourceTree = "<group>"; };
 		B12DCD74189A82DF00F8DF87 /* LPEnv.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPEnv.m; sourceTree = "<group>"; };
-		B12DCD77189A833000F8DF87 /* LPLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPLog.h; sourceTree = "<group>"; };
-		B12DCD78189A833000F8DF87 /* LPLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPLog.m; sourceTree = "<group>"; };
+		B12DCD77189A833000F8DF87 /* LPLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPLogger.h; sourceTree = "<group>"; };
+		B12DCD78189A833000F8DF87 /* LPLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPLogger.m; sourceTree = "<group>"; };
 		B12DCD84189A997B00F8DF87 /* LPDebugRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDebugRoute.m; sourceTree = "<group>"; };
 		B12DCD86189A998400F8DF87 /* LPDebugRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDebugRoute.h; sourceTree = "<group>"; };
 		B13B29231627389500433F6C /* LPISO8601DateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPISO8601DateFormatter.h; sourceTree = "<group>"; };
@@ -1655,8 +1655,8 @@
 				B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */,
 				B12DCD73189A82DF00F8DF87 /* LPEnv.h */,
 				B12DCD74189A82DF00F8DF87 /* LPEnv.m */,
-				B12DCD77189A833000F8DF87 /* LPLog.h */,
-				B12DCD78189A833000F8DF87 /* LPLog.m */,
+				B12DCD77189A833000F8DF87 /* LPLogger.h */,
+				B12DCD78189A833000F8DF87 /* LPLogger.m */,
 				F566308A1A39B09C00DEA0C0 /* LPInfoPlist.h */,
 				F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */,
 				F5F600411A7C69760020637D /* LPInvoker.h */,
@@ -2533,7 +2533,7 @@
 				B1058E2F197F00C000B4A57B /* LPReflectUtils.m in Sources */,
 				B1058E33197F00C000B4A57B /* UIScriptASTVisibility.m in Sources */,
 				F5A33A591AC00D1300224639 /* UIWebView+LPWebView.m in Sources */,
-				B1058E35197F00C000B4A57B /* LPLog.m in Sources */,
+				B1058E35197F00C000B4A57B /* LPLogger.m in Sources */,
 				F57C18071B29E5A900B5572F /* LPRecordRoute.m in Sources */,
 				B11358581981B053004B16F4 /* LPScrollToMarkOperation.m in Sources */,
 				B113585D1981B053004B16F4 /* LPDatePickerOperation.m in Sources */,
@@ -2651,7 +2651,7 @@
 				B15BF9E119ABB1DE00B38577 /* LPReflectUtils.m in Sources */,
 				B15BF9E219ABB1DE00B38577 /* LPTouchUtils.m in Sources */,
 				B15BF9E319ABB1DE00B38577 /* LPEnv.m in Sources */,
-				B15BF9E419ABB1DE00B38577 /* LPLog.m in Sources */,
+				B15BF9E419ABB1DE00B38577 /* LPLogger.m in Sources */,
 				B15BF9E519ABB1DE00B38577 /* LPCDataScanner.m in Sources */,
 				89F2EFE51B2243D500958052 /* LPIntrospectionRoute.m in Sources */,
 				B15BF9E619ABB1DE00B38577 /* CalabashServer.m in Sources */,
@@ -2752,7 +2752,7 @@
 				B15BFA3319ABB2B100B38577 /* LPReflectUtils.m in Sources */,
 				B15BFA3419ABB2B100B38577 /* LPTouchUtils.m in Sources */,
 				B15BFA3519ABB2B100B38577 /* LPEnv.m in Sources */,
-				B15BFA3619ABB2B100B38577 /* LPLog.m in Sources */,
+				B15BFA3619ABB2B100B38577 /* LPLogger.m in Sources */,
 				B15BFA3719ABB2B100B38577 /* LPCDataScanner.m in Sources */,
 				89F2EFE61B2243D500958052 /* LPIntrospectionRoute.m in Sources */,
 				B15BFA3819ABB2B100B38577 /* CalabashServer.m in Sources */,
@@ -2847,7 +2847,7 @@
 				B1D5BDBB19A23BCE0070E8CE /* LPSliderOperation.m in Sources */,
 				B1D5BDBC19A23BCE0070E8CE /* UIScriptASTVisibility.m in Sources */,
 				B1D5BDBD19A23BCE0070E8CE /* LPCollectionViewScrollToItemOperation.m in Sources */,
-				B1D5BDBE19A23BCE0070E8CE /* LPLog.m in Sources */,
+				B1D5BDBE19A23BCE0070E8CE /* LPLogger.m in Sources */,
 				B1D5BDBF19A23BCE0070E8CE /* LPAppPropertyRoute.m in Sources */,
 				B1D5BDC019A23BCE0070E8CE /* LPQueryLogRoute.m in Sources */,
 				B1D5BDC119A23BCE0070E8CE /* LPLocationRoute.m in Sources */,
@@ -2948,7 +2948,7 @@
 				F5091C1B18C4E1D700C85307 /* LPSliderOperation.m in Sources */,
 				F5091C1D18C4E1D700C85307 /* UIScriptASTVisibility.m in Sources */,
 				F5091C1E18C4E1D700C85307 /* LPCollectionViewScrollToItemOperation.m in Sources */,
-				F5091C1F18C4E1D700C85307 /* LPLog.m in Sources */,
+				F5091C1F18C4E1D700C85307 /* LPLogger.m in Sources */,
 				F5091C2018C4E1D700C85307 /* LPAppPropertyRoute.m in Sources */,
 				F5091C2118C4E1D700C85307 /* LPQueryLogRoute.m in Sources */,
 				F5091C2218C4E1D700C85307 /* LPLocationRoute.m in Sources */,
@@ -3005,7 +3005,7 @@
 				F5C224E11AD473F0001DB4FA /* LPInfoPlistTest.m in Sources */,
 				F50CBF9D1A040599004AC9DA /* LPScrollToMarkOperation.m in Sources */,
 				B15369FC1A32620A0093923F /* LPUIASharedElementChannel.m in Sources */,
-				F50CBFCA1A0405E9004AC9DA /* LPLog.m in Sources */,
+				F50CBFCA1A0405E9004AC9DA /* LPLogger.m in Sources */,
 				F50CBF8B1A04056F004AC9DA /* LPHTTPDynamicFileResponse.m in Sources */,
 				F5C224E31AD473F0001DB4FA /* LPTouchUtilsTest.m in Sources */,
 				F5C224DB1AD472B1001DB4FA /* LPInvokerTest.m in Sources */,
@@ -3181,7 +3181,7 @@
 				F5821A3918C4E27400293508 /* LPSliderOperation.m in Sources */,
 				F5821A3B18C4E27400293508 /* UIScriptASTVisibility.m in Sources */,
 				F5821A3C18C4E27400293508 /* LPCollectionViewScrollToItemOperation.m in Sources */,
-				F5821A3D18C4E27400293508 /* LPLog.m in Sources */,
+				F5821A3D18C4E27400293508 /* LPLogger.m in Sources */,
 				F5821A3E18C4E27400293508 /* LPAppPropertyRoute.m in Sources */,
 				F5821A3F18C4E27400293508 /* LPQueryLogRoute.m in Sources */,
 				F5821A4018C4E27400293508 /* LPLocationRoute.m in Sources */,

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		B1058E2C197F00C000B4A57B /* LPTouchUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */; };
 		B1058E2F197F00C000B4A57B /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		B1058E33197F00C000B4A57B /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
-		B1058E35197F00C000B4A57B /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		B1058E35197F00C000B4A57B /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1058E40197F00C000B4A57B /* CalabashServer.h in Headers */ = {isa = PBXBuildFile; fileRef = B184FD8814B6DAE1002A744C /* CalabashServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1058E4B197F00C000B4A57B /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B17E757A15D434D00066550B /* CFNetwork.framework */; };
 		B1058E4C197F00C000B4A57B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -160,7 +160,7 @@
 		B15BF9E119ABB1DE00B38577 /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		B15BF9E219ABB1DE00B38577 /* LPTouchUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */; };
 		B15BF9E319ABB1DE00B38577 /* LPEnv.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD74189A82DF00F8DF87 /* LPEnv.m */; };
-		B15BF9E419ABB1DE00B38577 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		B15BF9E419ABB1DE00B38577 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9E519ABB1DE00B38577 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8C14B6DAFB002A744C /* LPCDataScanner.m */; };
 		B15BF9E619ABB1DE00B38577 /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		B15BF9E719ABB1EB00B38577 /* LPI.mm in Sources */ = {isa = PBXBuildFile; fileRef = B184FDBD14B6DB2B002A744C /* LPI.mm */; };
@@ -239,7 +239,7 @@
 		B15BFA3319ABB2B100B38577 /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		B15BFA3419ABB2B100B38577 /* LPTouchUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0F14B6DB2B002A744C /* LPTouchUtils.m */; };
 		B15BFA3519ABB2B100B38577 /* LPEnv.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD74189A82DF00F8DF87 /* LPEnv.m */; };
-		B15BFA3619ABB2B100B38577 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		B15BFA3619ABB2B100B38577 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BFA3719ABB2B100B38577 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8C14B6DAFB002A744C /* LPCDataScanner.m */; };
 		B15BFA3819ABB2B100B38577 /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		B15BFA3A19ABB2B100B38577 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B121E79714B6D9FB0034C6A9 /* Foundation.framework */; };
@@ -321,7 +321,7 @@
 		B1D5BDBB19A23BCE0070E8CE /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDBC19A23BCE0070E8CE /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
 		B1D5BDBD19A23BCE0070E8CE /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; };
-		B1D5BDBE19A23BCE0070E8CE /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		B1D5BDBE19A23BCE0070E8CE /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDBF19A23BCE0070E8CE /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		B1D5BDC019A23BCE0070E8CE /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDC119A23BCE0070E8CE /* LPLocationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CED0FA183E9551004793B9 /* LPLocationRoute.m */; };
@@ -437,7 +437,7 @@
 		F5091C1B18C4E1D700C85307 /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C1D18C4E1D700C85307 /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
 		F5091C1E18C4E1D700C85307 /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; };
-		F5091C1F18C4E1D700C85307 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		F5091C1F18C4E1D700C85307 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C2018C4E1D700C85307 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		F5091C2118C4E1D700C85307 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C2218C4E1D700C85307 /* LPLocationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CED0FA183E9551004793B9 /* LPLocationRoute.m */; };
@@ -525,7 +525,7 @@
 		F50CBFC71A0405E9004AC9DA /* LPJSONUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE0D14B6DB2B002A744C /* LPJSONUtils.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFC81A0405E9004AC9DA /* LPReflectUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B1296FC215DC1F5B005DDF5C /* LPReflectUtils.m */; };
 		F50CBFC91A0405E9004AC9DA /* LPEnv.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD74189A82DF00F8DF87 /* LPEnv.m */; };
-		F50CBFCA1A0405E9004AC9DA /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		F50CBFCA1A0405E9004AC9DA /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFCB1A0405E9004AC9DA /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8C14B6DAFB002A744C /* LPCDataScanner.m */; };
 		F50CBFCC1A0405E9004AC9DA /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		F50CBFCE1A040669004AC9DA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F50CBFCD1A040669004AC9DA /* UIKit.framework */; };
@@ -686,7 +686,7 @@
 		F5821A3918C4E27400293508 /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A3B18C4E27400293508 /* UIScriptASTVisibility.m in Sources */ = {isa = PBXBuildFile; fileRef = B1B19DC716D162CF00D3D80B /* UIScriptASTVisibility.m */; };
 		F5821A3C18C4E27400293508 /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; };
-		F5821A3D18C4E27400293508 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; };
+		F5821A3D18C4E27400293508 /* LPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD78189A833000F8DF87 /* LPLogger.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A3E18C4E27400293508 /* LPAppPropertyRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08516EE63A000AE4D40 /* LPAppPropertyRoute.m */; };
 		F5821A3F18C4E27400293508 /* LPQueryLogRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1EBF08716EE63A000AE4D40 /* LPQueryLogRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5821A4018C4E27400293508 /* LPLocationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CED0FA183E9551004793B9 /* LPLocationRoute.m */; };

--- a/calabash/Classes/FranklyServer/Routes/LPDebugRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPDebugRoute.m
@@ -7,7 +7,7 @@
 //
 
 #import "LPDebugRoute.h"
-#import "LPLog.h"
+#import "LPLogger.h"
 
 @implementation LPDebugRoute
 
@@ -19,10 +19,10 @@
 - (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
   if ([method isEqualToString:@"POST"]) {
     NSString *requiredLogLevel = [data valueForKey:@"level"];
-    [LPLog setLevelFromString:requiredLogLevel];
+    [LPLogger setLevelFromString:requiredLogLevel];
   }
 
-  NSString *currentLogLevel = [LPLog currentLevelString];
+  NSString *currentLogLevel = [LPLogger currentLevelString];
   NSArray *resultsArray;
   if (!currentLogLevel) {
     resultsArray = @[];

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -10,7 +10,7 @@
 #import "LPOperation.h"
 #import "LPTouchUtils.h"
 #import "LPOrientationOperation.h"
-#import "LPLog.h"
+#import "LPLogger.h"
 #import "LPJSONUtils.h"
 #import "LPHTTPDataResponse.h"
 #import "LPDevice.h"
@@ -141,7 +141,7 @@
       @"details" : @""
       };
   }
-  [LPLog debug:@"Map results %@", resultDict];
+  [LPLogger debug:@"Map results %@", resultDict];
 
   return resultDict;
 }

--- a/calabash/Classes/Utils/LPLogger.h
+++ b/calabash/Classes/Utils/LPLogger.h
@@ -10,7 +10,7 @@
 
 typedef enum {LPLogLevelDebug = 1, LPLogLevelInfo = 5, LPLogLevelError = 10} LPLogLevel;
 
-@interface LPLog : NSObject
+@interface LPLogger : NSObject
 
 + (LPLogLevel) currentLevel;
 

--- a/calabash/Classes/Utils/LPLogger.h
+++ b/calabash/Classes/Utils/LPLogger.h
@@ -8,11 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum {LPLogLevelDebug = 1, LPLogLevelInfo = 5, LPLogLevelError = 10} LPLogLevel;
+typedef enum {LPLoggerLevelDebug = 1, LPLoggerLevelInfo = 5, LPLoggerLevelError = 10} LPLoggerLevel;
 
 @interface LPLogger : NSObject
 
-+ (LPLogLevel) currentLevel;
++ (LPLoggerLevel) currentLevel;
 
 + (NSString *) currentLevelString;
 

--- a/calabash/Classes/Utils/LPLogger.h
+++ b/calabash/Classes/Utils/LPLogger.h
@@ -8,7 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum {LPLoggerLevelDebug = 1, LPLoggerLevelInfo = 5, LPLoggerLevelError = 10} LPLoggerLevel;
+typedef enum : NSUInteger {
+  LPLoggerLevelDebug = 1,
+  LPLoggerLevelInfo = 5,
+  LPLoggerLevelError = 10
+} LPLoggerLevel;
 
 @interface LPLogger : NSObject
 

--- a/calabash/Classes/Utils/LPLogger.m
+++ b/calabash/Classes/Utils/LPLogger.m
@@ -9,10 +9,15 @@
 #import "LPLogger.h"
 #import "LPEnv.h"
 
+@interface LPLogger ()
 
-@implementation LPLogger {
-  LPLoggerLevel _logLevel;
-}
+@property(assign, atomic, readonly) LPLoggerLevel logLevel;
+
+@end
+
+@implementation LPLogger
+
+@synthesize logLevel = _logLevel;
 
 + (LPLogger *) sharedLog {
   static LPLogger *sharedLog = nil;

--- a/calabash/Classes/Utils/LPLogger.m
+++ b/calabash/Classes/Utils/LPLogger.m
@@ -6,31 +6,31 @@
 //  Copyright (c) 2014 Xamarin. All rights reserved.
 //
 
-#import "LPLog.h"
+#import "LPLogger.h"
 #import "LPEnv.h"
 
 
-@implementation LPLog {
+@implementation LPLogger {
   LPLogLevel _logLevel;
 }
 
-+ (LPLog *) sharedLog {
-  static LPLog *sharedLog = nil;
++ (LPLogger *) sharedLog {
+  static LPLogger *sharedLog = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    sharedLog = [[LPLog alloc] init];
+    sharedLog = [[LPLogger alloc] init];
   });
   return sharedLog;
 }
 
 
 + (LPLogLevel) currentLevel {
-  return [[LPLog sharedLog] currentLevel];
+  return [[LPLogger sharedLog] currentLevel];
 }
 
 
 + (void) setLevelFromString:(NSString *) logLevel {
-  [[LPLog sharedLog] setLevelFromString:logLevel];
+  [[LPLogger sharedLog] setLevelFromString:logLevel];
 }
 
 
@@ -51,7 +51,7 @@
 
 
 + (NSString *) currentLevelString {
-  switch ([LPLog currentLevel]) {
+  switch ([LPLogger currentLevel]) {
     case LPLogLevelDebug:return @"debug";
     case LPLogLevelInfo:return @"info";
     case LPLogLevelError:return @"error";
@@ -76,7 +76,7 @@
 
 //Not 100% sure if this va_* is necessary
 + (void) debug:(NSString *) formatString, ...; {
-  if (![[LPLog sharedLog] shouldLogAtLevel:LPLogLevelDebug]) {return;}
+  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLogLevelDebug]) {return;}
   va_list args;
   va_start(args, formatString);
   NSLogv(formatString, args);
@@ -85,7 +85,7 @@
 
 
 + (void) info:(NSString *) formatString, ... {
-  if (![[LPLog sharedLog] shouldLogAtLevel:LPLogLevelInfo]) {return;}
+  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLogLevelInfo]) {return;}
   va_list args;
   va_start(args, formatString);
   NSLogv(formatString, args);
@@ -94,7 +94,7 @@
 
 
 + (void) error:(NSString *) formatString, ... {
-  if (![[LPLog sharedLog] shouldLogAtLevel:LPLogLevelError]) {return;}
+  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLogLevelError]) {return;}
   va_list args;
   va_start(args, formatString);
   NSLogv(formatString, args);

--- a/calabash/Classes/Utils/LPLogger.m
+++ b/calabash/Classes/Utils/LPLogger.m
@@ -11,7 +11,7 @@
 
 
 @implementation LPLogger {
-  LPLogLevel _logLevel;
+  LPLoggerLevel _logLevel;
 }
 
 + (LPLogger *) sharedLog {
@@ -24,7 +24,7 @@
 }
 
 
-+ (LPLogLevel) currentLevel {
++ (LPLoggerLevel) currentLevel {
   return [[LPLogger sharedLog] currentLevel];
 }
 
@@ -36,25 +36,25 @@
 
 - (void) setLevelFromString:(NSString *) logLevel {
   if ([@"debug" isEqualToString:[logLevel lowercaseString]]) {
-    _logLevel = LPLogLevelDebug;
+    _logLevel = LPLoggerLevelDebug;
   } else if ([@"info" isEqualToString:[logLevel lowercaseString]]) {
-    _logLevel = LPLogLevelInfo;
+    _logLevel = LPLoggerLevelInfo;
   } else if ([@"error" isEqualToString:[logLevel lowercaseString]]) {
-    _logLevel = LPLogLevelError;
+    _logLevel = LPLoggerLevelError;
   }
 }
 
 
-- (LPLogLevel) currentLevel {
+- (LPLoggerLevel) currentLevel {
   return _logLevel;
 }
 
 
 + (NSString *) currentLevelString {
   switch ([LPLogger currentLevel]) {
-    case LPLogLevelDebug:return @"debug";
-    case LPLogLevelInfo:return @"info";
-    case LPLogLevelError:return @"error";
+    case LPLoggerLevelDebug:return @"debug";
+    case LPLoggerLevelInfo:return @"info";
+    case LPLoggerLevelError:return @"error";
     default:return nil;
   }
 }
@@ -63,20 +63,20 @@
 - (id) init {
   self = [super init];
   if (self) {
-    _logLevel = [LPEnv calabashDebugEnabled] ? LPLogLevelDebug : LPLogLevelInfo;
+    _logLevel = [LPEnv calabashDebugEnabled] ? LPLoggerLevelDebug : LPLoggerLevelInfo;
   }
   return self;
 }
 
 
-- (BOOL) shouldLogAtLevel:(LPLogLevel) level {
+- (BOOL) shouldLogAtLevel:(LPLoggerLevel) level {
   return (level >= _logLevel);
 }
 
 
 //Not 100% sure if this va_* is necessary
 + (void) debug:(NSString *) formatString, ...; {
-  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLogLevelDebug]) {return;}
+  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLoggerLevelDebug]) {return;}
   va_list args;
   va_start(args, formatString);
   NSLogv(formatString, args);
@@ -85,7 +85,7 @@
 
 
 + (void) info:(NSString *) formatString, ... {
-  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLogLevelInfo]) {return;}
+  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLoggerLevelInfo]) {return;}
   va_list args;
   va_start(args, formatString);
   NSLogv(formatString, args);
@@ -94,7 +94,7 @@
 
 
 + (void) error:(NSString *) formatString, ... {
-  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLogLevelError]) {return;}
+  if (![[LPLogger sharedLog] shouldLogAtLevel:LPLoggerLevelError]) {return;}
   va_list args;
   va_start(args, formatString);
   NSLogv(formatString, args);

--- a/calabash/Classes/Utils/LPLogger.m
+++ b/calabash/Classes/Utils/LPLogger.m
@@ -1,3 +1,7 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 //
 //  LPLog.m
 //  calabash

--- a/calabash/Classes/Utils/LPSharedUIATextField.m
+++ b/calabash/Classes/Utils/LPSharedUIATextField.m
@@ -8,7 +8,7 @@
 
 #import "LPSharedUIATextField.h"
 #import "LPJSONUtils.h"
-#import "LPLog.h"
+#import "LPLogger.h"
 
 const NSString *LPSharedUIATextFieldId = @"__calabash_uia_channel";
 const NSString *LPSharedUIATextFieldSyncRequest =  @"{\"type\":\"syncRequest\"}";
@@ -65,7 +65,7 @@ const NSString *LPSharedUIATextFieldSyncRequest =  @"{\"type\":\"syncRequest\"}"
 }
 
 -(void)setText:(NSString *)newText {
-  [LPLog debug:@"LPSharedUIATextField set value called: %@",newText];
+  [LPLogger debug:@"LPSharedUIATextField set value called: %@",newText];
   NSString *oldText = self.text;
   if (oldText == newText || [newText isEqualToString:self.text]) {
     return;
@@ -76,7 +76,7 @@ const NSString *LPSharedUIATextFieldSyncRequest =  @"{\"type\":\"syncRequest\"}"
     [super setText:newText];
   }
   if (self.currentMessage) {
-    [LPLog debug:@"LPSharedUIATextField handle event %@", self.currentMessage];
+    [LPLogger debug:@"LPSharedUIATextField handle event %@", self.currentMessage];
     [self handleUIACommandEvent];
   }
 
@@ -88,7 +88,7 @@ const NSString *LPSharedUIATextFieldSyncRequest =  @"{\"type\":\"syncRequest\"}"
     if ([self currentMessageIsSynchronizationDone]) {
       [LPSharedUIATextField cancelPreviousPerformRequestsWithTarget:self];
       [self detachFromKeyWindow];
-      [LPLog debug:@"LPSharedUIATextField Synchronization with UIAutomation done"];
+      [LPLogger debug:@"LPSharedUIATextField Synchronization with UIAutomation done"];
       self.currentMessage = nil;
       [self setText:nil];
       self.isSynchronizing = NO;
@@ -99,7 +99,7 @@ const NSString *LPSharedUIATextFieldSyncRequest =  @"{\"type\":\"syncRequest\"}"
   else if ([self currentMessageIsResponse]) {
     NSDictionary *message = [self.currentMessage retain];
     [self setText:nil];
-    [LPLog debug:@"LPSharedUIATextField sending response to delegate %@", message];
+    [LPLogger debug:@"LPSharedUIATextField sending response to delegate %@", message];
     [self.uiaDelegate sharedUIATextField:self didReceiveUIAResponse:message];
     [message release];
   }
@@ -118,14 +118,14 @@ const NSString *LPSharedUIATextFieldSyncRequest =  @"{\"type\":\"syncRequest\"}"
 }
 
 -(void)synchronizeWithUIAutomation {
-  [LPLog debug:@"LPSharedUIATextField synchronizing with UIAutomation..."];
+  [LPLogger debug:@"LPSharedUIATextField synchronizing with UIAutomation..."];
   self.isSynchronizing = YES;
   [self setText:(NSString*)LPSharedUIATextFieldSyncRequest];
   [self attachToKeyWindow];
   [self performSelector:@selector(synchronizeWithUIAutomationTimedOut) withObject:nil afterDelay:20];
 }
 -(void)synchronizeWithUIAutomationTimedOut {
-  [LPLog debug:@"LPSharedUIATextField synchronizing with UIAutomation timed out... Aborting..."];
+  [LPLogger debug:@"LPSharedUIATextField synchronizing with UIAutomation timed out... Aborting..."];
   self.isSynchronized = NO;
   self.isSynchronizing = NO;
   [self detachFromKeyWindow];

--- a/calabash/Classes/Utils/LPUIASharedElementChannel.m
+++ b/calabash/Classes/Utils/LPUIASharedElementChannel.m
@@ -6,7 +6,7 @@
 //
 
 #import "LPUIASharedElementChannel.h"
-#import "LPLog.h"
+#import "LPLogger.h"
 #import "LPJSONUtils.h"
 
 @implementation LPUIASharedElementChannel {
@@ -44,12 +44,12 @@
 - (void) runAutomationCommand:(NSString *) command then:(UIACommandHandler) resultHandler {
   if ([self initializeSharedTextField]) {
     dispatch_async(_uiaQueue, ^{
-      [LPLog debug: @"Waiting for synchronization with UIAutomation..."];
+      [LPLogger debug: @"Waiting for synchronization with UIAutomation..."];
       LPSharedUIATextField *sharedElement = [LPSharedUIATextField sharedTextField];
       while (!sharedElement.isSynchronized) {
         [NSThread sleepForTimeInterval:0.1];
       }
-      [LPLog debug:@"LPUIASharedElementChannel synchronized..."];
+      [LPLogger debug:@"LPUIASharedElementChannel synchronized..."];
       dispatch_async(dispatch_get_main_queue(), ^{
         [self doRunAutomationCommand:command then:resultHandler];
       });
@@ -63,9 +63,9 @@
 -(void)doRunAutomationCommand:(NSString*)command then:(UIACommandHandler) resultHandler {
   self.currentHandler = resultHandler;
   dispatch_async(_uiaQueue, ^{
-    [LPLog debug: @"LPUIASharedElementChannel request execution of command: %@", command];
+    [LPLogger debug: @"LPUIASharedElementChannel request execution of command: %@", command];
     [self requestExecutionOf:command];
-    [LPLog debug: @"LPUIASharedElementChannel requested execution of command: %@... Awaiting response", command];
+    [LPLogger debug: @"LPUIASharedElementChannel requested execution of command: %@... Awaiting response", command];
   });
 }
 
@@ -84,14 +84,14 @@
 -(void)sharedUIATextField:(LPSharedUIATextField*) uiaTextField
     didReceiveUIAResponse:(NSDictionary*)uiaResponse {
   dispatch_async(_uiaQueue, ^{
-    [LPLog debug: @"LPUIASharedElementChannel sharedUIATextField:didReceiveUIAResponse: %@", uiaResponse];
+    [LPLogger debug: @"LPUIASharedElementChannel sharedUIATextField:didReceiveUIAResponse: %@", uiaResponse];
     if (uiaResponse) {
       _scriptIndex++;
     }
     else {
-      [LPLog error: @"Error did not get a response at index %@", @(_scriptIndex)];
-      [LPLog error: @"Server current index: %lu",(unsigned long) _scriptIndex];
-      [LPLog error: @"Current shared element data: %@", [self rawSharedElementData]];
+      [LPLogger error: @"Error did not get a response at index %@", @(_scriptIndex)];
+      [LPLogger error: @"Server current index: %lu",(unsigned long) _scriptIndex];
+      [LPLogger error: @"Current shared element data: %@", [self rawSharedElementData]];
     }
     dispatch_async(dispatch_get_main_queue(), ^{
       self.currentHandler(uiaResponse);


### PR DESCRIPTION
### Motivation

It looks like we will be able to use CocoaLumberjack.  I have a local branch that demonstrates this.  The LPLog class clashes with my strategy for including CocoaLumberjack.

Why do we want CocoaLumberjack in the server?  

* Our current CocoaHttpServer and CocoaAsyncSocket files are wildly out of date - last updated in 2011. Xcode 7 revealed dozens of deprecated calls in these files.  Both of these repos use CocoaLumberjack.  The upgrade path will be easier if we can use CocoaLumberjack.
* CocoaLumberjack is a _fantastic_ logging framework - we could do some very cool things with it.