### PR TITLE
Add Calabash dylib code signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ dylibs:
 	rm -rf calabash-dylibs
 	scripts/make-calabash-dylib.rb sim
 	scripts/make-calabash-dylib.rb device
-	scripts/make-libraries.rb verify-dylibs
+	CERT_CHECKSUM=337976ad9ace375ac06cd8fea2edb0c7276dec2a72d005ca5559a8bbf09c8841 \
+								scripts/make-libraries.rb verify-dylibs
 
 dylib_sim:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Requires Xcode 6 or greater.
 make dylibs
 ```
 
+**NOTE**
+
+If you are a maintainer, you _must_ install the codesign tool
+if you are planning on making a Calabash iOS gem release.
+
+* https://github.com/calabash/calabash-codesign
+
 ### Building to embed in Calabash gem
 
 See the calabash-ios/calabash-cucumber/Rakefile for more details.


### PR DESCRIPTION
### Motivation

We've not been careful about how we code sign the dylibs for release.

Maintainers _must_ follow the install instructions in the README.md here:

* https://github.com/calabash/calabash-codesign

It is painless.  I promise.

@krukow @sapieneptus @TobiasRoikjer 

### Test

```
$ make dylibs
```