### PR TITLE
Ensure backdoors are called on the main thread

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -72,7 +72,7 @@
 		B15BF9C819ABB1DE00B38577 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		B15BF9C919ABB1DE00B38577 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9CA19ABB1DE00B38577 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
-		B15BF9CB19ABB1DE00B38577 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
+		B15BF9CB19ABB1DE00B38577 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9CC19ABB1DE00B38577 /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; };
 		B15BF9CD19ABB1DE00B38577 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9CE19ABB1DE00B38577 /* LPISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B13B29241627389500433F6C /* LPISO8601DateFormatter.m */; };
@@ -144,7 +144,7 @@
 		B1D5BD9C19A23BCE0070E8CE /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9E19A23BCE0070E8CE /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
-		B1D5BD9F19A23BCE0070E8CE /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
+		B1D5BD9F19A23BCE0070E8CE /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDA019A23BCE0070E8CE /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BDA119A23BCE0070E8CE /* LPCDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* LPCDataScanner_Extensions.m */; };
 		B1D5BDA219A23BCE0070E8CE /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; };
@@ -246,7 +246,7 @@
 		F5091BFD18C4E1D700C85307 /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		F5091BFE18C4E1D700C85307 /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BFF18C4E1D700C85307 /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
-		F5091C0018C4E1D700C85307 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
+		F5091C0018C4E1D700C85307 /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C0118C4E1D700C85307 /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091C0218C4E1D700C85307 /* LPCDataScanner_Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDDF14B6DB2B002A744C /* LPCDataScanner_Extensions.m */; };
 		F5091C0318C4E1D700C85307 /* LPCJSONDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9614B6F64A002A744C /* LPCJSONDeserializer.m */; };
@@ -338,7 +338,7 @@
 		F50CBFAE1A0405B2004AC9DA /* LPNoContentResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDD414B6DB2B002A744C /* LPNoContentResponse.m */; };
 		F50CBFAF1A0405B2004AC9DA /* LPScreenshotRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9014B6DD33002A744C /* LPScreenshotRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFB01A0405B2004AC9DA /* LPAsyncPlaybackRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B111321614D5837900982BBC /* LPAsyncPlaybackRoute.m */; };
-		F50CBFB11A0405B2004AC9DA /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; };
+		F50CBFB11A0405B2004AC9DA /* LPBackdoorRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B160E8EE15321D8F00F69E7A /* LPBackdoorRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFB21A0405B2004AC9DA /* LPExitRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 692D779F1657010000DE3E53 /* LPExitRoute.m */; };
 		F50CBFB31A0405B2004AC9DA /* LPVersionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B153F55B15949F3D00867E12 /* LPVersionRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBFB41A0405CE004AC9DA /* LPISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B13B29241627389500433F6C /* LPISO8601DateFormatter.m */; };

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -23,6 +23,10 @@
   NSString *originalSelStr = [data objectForKey:@"selector"];
   NSString *selectorName = originalSelStr;
   if (![originalSelStr hasSuffix:@":"]) {
+    LPLogWarn(@"Selector name is missing a ':'");
+    LPLogWarn(@"All backdoor methods must take at least one argument.");
+    LPLogWarn(@"Appending a ':' to the selector name.");
+    LPLogWarn(@"This will be an error in the future.");
     selectorName = [selectorName stringByAppendingString:@":"];
   }
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -57,36 +57,29 @@
     return  @{ @"result" : result, @"outcome" : @"SUCCESS" };
   } else {
 
-    NSString *details = [NSString stringWithFormat:@"you must define the selector '%@' in your UIApplicationDelegate.",
-                                                   selectorName];
-    NSString *exDecl0 = @"// declaration";
-    NSString *exDecl1 = [NSString stringWithFormat:@"-(id)%@ (id)arg;", selectorName];
-    NSString *exImp0 = @"// implementation";
-    NSString *exImp1 = [NSString stringWithFormat:@"-(id)%@ (id)anArg {",
-                                                  selectorName];
-    NSString *exImp2 = [NSString stringWithFormat:@"  // do custom stuff"];
-    NSString *exImp3 = [NSString stringWithFormat:@"  // return examples"];
-    NSString *exImp4 = [NSString stringWithFormat:@"  return @\"OK\";"];
-    NSString *exImp5 = [NSString stringWithFormat:@"  return [NSArray arrayWithObjects:@\"a\",@\"b\",nil];"];
-    NSString *exImp6 = [NSString stringWithFormat:@"  return nil;"];
-    NSString *exImp7 = [NSString stringWithFormat:@"}"];
-    NSString *usage0 = [NSString stringWithFormat:@"// Ruby usage"];
-    NSString *usage1 = [NSString stringWithFormat:@"backdoor('%@', '<arg>')",
-                                                  selectorName];
+    NSArray *lines =
+    @[
+      @"",
+      [NSString stringWithFormat:@"You must define '%@' in your UIApplicationDelegate.",
+       selectorName],
+      @"",
+      [NSString stringWithFormat:@"// Example"],
+      [NSString stringWithFormat:@"-(NSString *)%@(NSString *)argument {", selectorName],
+      [NSString stringWithFormat:@"  // do stuff here"],
+      [NSString stringWithFormat:@"  return @\"a result\";"],
+      [NSString stringWithFormat:@"}"],
+      @"",
+      @"// Documentation",
+      @"http://developer.xamarin.com/guides/testcloud/calabash/working-with/backdoors/#backdoor_in_iOS",
+      @"",
+      @""
+      ];
 
-    NSArray *exArr = [NSArray arrayWithObjects:details, @"\n", exDecl0, exDecl1,
-                                               @"\n", exImp0, exImp1, exImp2,
-                                               exImp3, exImp4, exImp5, exImp6,
-                                               exImp7, @"\n", usage0, usage1,
-                                               nil];
-    NSString *detailsStr = [exArr componentsJoinedByString:@"\n"];
+    NSString *details = [lines componentsJoinedByString:@"\n"];
 
-    NSString *reasonStr = [NSString stringWithFormat:@"application delegate does not respond to selector '%@'",
-                                                     selectorName];
-    return [NSDictionary dictionaryWithObjectsAndKeys:detailsStr, @"details",
-                                                      reasonStr, @"reason",
-                                                      @"FAILURE", @"outcome",
-                                                      nil];
+    NSString *reason = [NSString stringWithFormat:@"The backdoor: '%@' is undefined.",
+                        selectorName];
+    return  @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
   }
 }
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -10,6 +10,7 @@
 #endif
 
 #import "LPBackdoorRoute.h"
+#import "LPCocoaLumberjack.h"
 
 @implementation LPBackdoorRoute
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -5,6 +5,9 @@
 //  Created by Karl Krukow on 08/04/12.
 //  Copyright (c) 2012 LessPainful. All rights reserved.
 //
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
 
 #import "LPBackdoorRoute.h"
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -27,12 +27,17 @@
   }
 
   SEL selector = NSSelectorFromString(selectorName);
+  id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
+  if ([delegate respondsToSelector:selector]) {
 
-  if ([[[UIApplication sharedApplication] delegate] respondsToSelector:selector]) {
     id argument = [data objectForKey:@"arg"];
-    id result = [[[UIApplication sharedApplication] delegate]
-            performSelector:selector withObject:argument];
-    if (!result) {result = [NSNull null];}
+    id result = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+      result = [delegate performSelector:selector withObject:argument];
+#pragma clang diagnostic pop
+
+    if (!result) { result = [NSNull null]; }
     return [NSDictionary dictionaryWithObjectsAndKeys:result, @"result",
                                                       @"SUCCESS", @"outcome",
                                                       nil];

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -20,30 +20,30 @@
 
 - (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
   NSString *originalSelStr = [data objectForKey:@"selector"];
-  NSString *selStr = originalSelStr;
+  NSString *selectorName = originalSelStr;
   if (![originalSelStr hasSuffix:@":"]) {
-    selStr = [selStr stringByAppendingString:@":"];
+    selectorName = [selectorName stringByAppendingString:@":"];
   }
 
-  SEL sel = NSSelectorFromString(selStr);
+  SEL selector = NSSelectorFromString(selectorName);
 
-  if ([[[UIApplication sharedApplication] delegate] respondsToSelector:sel]) {
-    id arg = [data objectForKey:@"arg"];
-    id res = [[[UIApplication sharedApplication] delegate]
-            performSelector:sel withObject:arg];
-    if (!res) {res = [NSNull null];}
-    return [NSDictionary dictionaryWithObjectsAndKeys:res, @"result",
+  if ([[[UIApplication sharedApplication] delegate] respondsToSelector:selector]) {
+    id argument = [data objectForKey:@"arg"];
+    id result = [[[UIApplication sharedApplication] delegate]
+            performSelector:selector withObject:argument];
+    if (!result) {result = [NSNull null];}
+    return [NSDictionary dictionaryWithObjectsAndKeys:result, @"result",
                                                       @"SUCCESS", @"outcome",
                                                       nil];
   } else {
 
     NSString *details = [NSString stringWithFormat:@"you must define the selector '%@' in your UIApplicationDelegate.",
-                                                   selStr];
+                                                   selectorName];
     NSString *exDecl0 = @"// declaration";
-    NSString *exDecl1 = [NSString stringWithFormat:@"-(id)%@ (id)arg;", selStr];
+    NSString *exDecl1 = [NSString stringWithFormat:@"-(id)%@ (id)arg;", selectorName];
     NSString *exImp0 = @"// implementation";
     NSString *exImp1 = [NSString stringWithFormat:@"-(id)%@ (id)anArg {",
-                                                  selStr];
+                                                  selectorName];
     NSString *exImp2 = [NSString stringWithFormat:@"  // do custom stuff"];
     NSString *exImp3 = [NSString stringWithFormat:@"  // return examples"];
     NSString *exImp4 = [NSString stringWithFormat:@"  return @\"OK\";"];
@@ -52,7 +52,7 @@
     NSString *exImp7 = [NSString stringWithFormat:@"}"];
     NSString *usage0 = [NSString stringWithFormat:@"// Ruby usage"];
     NSString *usage1 = [NSString stringWithFormat:@"backdoor('%@', '<arg>')",
-                                                  selStr];
+                                                  selectorName];
 
     NSArray *exArr = [NSArray arrayWithObjects:details, @"\n", exDecl0, exDecl1,
                                                @"\n", exImp0, exImp1, exImp2,
@@ -62,7 +62,7 @@
     NSString *detailsStr = [exArr componentsJoinedByString:@"\n"];
 
     NSString *reasonStr = [NSString stringWithFormat:@"application delegate does not respond to selector '%@'",
-                                                     selStr];
+                                                     selectorName];
     return [NSDictionary dictionaryWithObjectsAndKeys:detailsStr, @"details",
                                                       reasonStr, @"reason",
                                                       @"FAILURE", @"outcome",

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -50,9 +50,7 @@
     result = (__bridge id)buffer;
 
     if (!result) {result = [NSNull null];}
-    return [NSDictionary dictionaryWithObjectsAndKeys:result, @"result",
-                                                      @"SUCCESS", @"outcome",
-                                                      nil];
+    return  @{ @"result" : result, @"outcome" : @"SUCCESS" };
   } else {
 
     NSString *details = [NSString stringWithFormat:@"you must define the selector '%@' in your UIApplicationDelegate.",


### PR DESCRIPTION
### Motivation

This is the behavior already, but this PR guarantees the behavior.

This is in advance of some server changes (CocoaHTTPServer updates).

This PR has been exhaustively tested by:

https://github.com/calabash/ios-smoke-test-app/blob/master/CalSmokeApp/features/backdoor.feature

### Other changes

1. Converts the LPBackdoor class to ARC.
2. Deprecates the appending of missing ':' to selector names.
3. Improves the details and reason strings that are passed back to the client when selector is unrecognized.

