### PR TITLE
Refactor the LPConditionRoute

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -21,11 +21,11 @@
 
 @interface LPConditionRoute () <LPRepeatingTimerProtocol>
 
-@property(nonatomic, assign) NSUInteger maxCount;
-@property(nonatomic, assign) NSUInteger curCount;
-@property(nonatomic, assign) NSUInteger stablePeriod;
-@property(nonatomic, assign) NSUInteger stablePeriodCount;
-@property(nonatomic, assign) NSTimeInterval timerRepeatInterval;
+@property(atomic, assign) NSUInteger maxCount;
+@property(atomic, assign) NSUInteger curCount;
+@property(atomic, assign) NSUInteger stablePeriod;
+@property(atomic, assign) NSUInteger stablePeriodCount;
+@property(atomic, assign) NSTimeInterval timerRepeatInterval;
 @property(atomic, strong) dispatch_source_t repeatingTimer;
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -13,6 +13,7 @@
 #import "LPConditionRoute.h"
 #import "LPOperation.h"
 #import "LPRepeatingTimerProtocol.h"
+#import "LPCocoaLumberjack.h"
 
 #define kLPConditionRouteNoNetworkIndicator @"NO_NETWORK_INDICATOR"
 #define kLPConditionRouteNoneAnimating @"NONE_ANIMATING"

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -75,10 +75,20 @@
   self.done = NO;
   NSString *condition = [self.data objectForKey:@"condition"];
   if (!condition) {
-    NSLog(@"condition not specified");
-    [self failWithMessageFormat:@"condition parameter missing" message:nil];
+    LPLogError(@"Condition not specified");
+    [self failWithMessageFormat:@"Condition parameter missing" message:nil];
     return;
   }
+
+  if (!([condition isEqualToString:kLPConditionRouteNoNetworkIndicator] ||
+        [condition isEqualToString:kLPConditionRouteNoneAnimating])) {
+    LPLogError(@"Expected condition: '%@' or '%@'",
+               kLPConditionRouteNoneAnimating, kLPConditionRouteNoNetworkIndicator);
+    LPLogError(@"Found condition: '%@'", condition);
+    [self failWithMessageFormat:@"Unknown condition '%@'" message:condition];
+    return;
+  }
+
   self.curCount = 0;
 
   NSNumber *timeoutInSecs = [self.data objectForKey:@"timeout"];


### PR DESCRIPTION
### Motivation

We cannot use an NSTimer if we adopt the new CocoaHTTPServer sources.

This PR replaces the NSTimer with a dispatch_* timer.

This dispatch_* approach has been tested against the _old_ CocoaHTTPServer sources.

https://github.com/calabash/ios-smoke-test-app/pull/36

