### PR TITLE
Ensure playback happens on the main thread

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		B15BF9B619ABB1DD00B38577 /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; };
 		B15BF9B719ABB1DD00B38577 /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; };
 		B15BF9B819ABB1DD00B38577 /* LPSetTextOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDCB14B6DB2B002A744C /* LPSetTextOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B15BF9B919ABB1DD00B38577 /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; };
+		B15BF9B919ABB1DD00B38577 /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9BA19ABB1DD00B38577 /* LPUIARouteOverUserPrefs.m in Sources */ = {isa = PBXBuildFile; fileRef = B1DDE6CA15C06CB500BBE2BE /* LPUIARouteOverUserPrefs.m */; };
 		B15BF9BB19ABB1DD00B38577 /* LPKeychainRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F55D412118C9130100813F78 /* LPKeychainRoute.m */; };
 		B15BF9BC19ABB1DD00B38577 /* LPDebugRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B12DCD84189A997B00F8DF87 /* LPDebugRoute.m */; };
@@ -131,7 +131,7 @@
 		B1D5BD8F19A23BCE0070E8CE /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; };
 		B1D5BD9019A23BCE0070E8CE /* LPSetTextOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDCB14B6DB2B002A744C /* LPSetTextOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9119A23BCE0070E8CE /* LPUIAUserPrefsChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F279AE183D5B3000A922BC /* LPUIAUserPrefsChannel.m */; };
-		B1D5BD9219A23BCE0070E8CE /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; };
+		B1D5BD9219A23BCE0070E8CE /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD9319A23BCE0070E8CE /* CalabashServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD8714B6DAE1002A744C /* CalabashServer.m */; };
 		B1D5BD9419A23BCE0070E8CE /* LPUIARouteOverUserPrefs.m in Sources */ = {isa = PBXBuildFile; fileRef = B1DDE6CA15C06CB500BBE2BE /* LPUIARouteOverUserPrefs.m */; };
 		B1D5BD9519A23BCE0070E8CE /* LPUserPrefRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1DDE6CC15C06CB500BBE2BE /* LPUserPrefRoute.m */; };
@@ -234,7 +234,7 @@
 		F5091BF118C4E1D700C85307 /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; };
 		F5091BF218C4E1D700C85307 /* LPSetTextOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDCB14B6DB2B002A744C /* LPSetTextOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BF318C4E1D700C85307 /* LPUIAUserPrefsChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F279AE183D5B3000A922BC /* LPUIAUserPrefsChannel.m */; };
-		F5091BF418C4E1D700C85307 /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; };
+		F5091BF418C4E1D700C85307 /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BF518C4E1D700C85307 /* LPUIARouteOverUserPrefs.m in Sources */ = {isa = PBXBuildFile; fileRef = B1DDE6CA15C06CB500BBE2BE /* LPUIARouteOverUserPrefs.m */; };
 		F5091BF618C4E1D700C85307 /* LPUserPrefRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B1DDE6CC15C06CB500BBE2BE /* LPUserPrefRoute.m */; };
 		F5091BF718C4E1D700C85307 /* LPKeyboardRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B16321F715BC200300408364 /* LPKeyboardRoute.m */; };
@@ -317,7 +317,7 @@
 		F50CBF991A04058C004AC9DA /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; };
 		F50CBF9A1A04058C004AC9DA /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; };
 		F50CBF9B1A04058C004AC9DA /* LPSetTextOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDCB14B6DB2B002A744C /* LPSetTextOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		F50CBF9C1A04058C004AC9DA /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; };
+		F50CBF9C1A04058C004AC9DA /* LPRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE8714B6DBAC002A744C /* LPRecorder.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF9D1A040599004AC9DA /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; };
 		F50CBF9E1A040599004AC9DA /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; };
 		F50CBF9F1A040599004AC9DA /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A318B391810094E71E /* LPCollectionViewScrollToItemWithMarkOperation.m */; };

--- a/calabash/Classes/FranklyServer/LPRecorder.h
+++ b/calabash/Classes/FranklyServer/LPRecorder.h
@@ -1,11 +1,7 @@
 #import <Foundation/Foundation.h>
 
-@interface LPRecorder : NSObject {
-  NSMutableArray *eventList;
-  id playbackDelegate;
-  SEL playbackDoneSelector;
-  BOOL _isRecording;
-}
+@interface LPRecorder : NSObject
+
 @property(nonatomic, readonly) BOOL isRecording;
 
 + (LPRecorder *) sharedRecorder;

--- a/calabash/Classes/FranklyServer/LPRecorder.h
+++ b/calabash/Classes/FranklyServer/LPRecorder.h
@@ -11,17 +11,11 @@
 + (LPRecorder *) sharedRecorder;
 
 - (void) record;
-
 - (void) saveToFile:(NSString *) path;
-
 - (NSArray *) events;
-
 - (void) load:(NSArray *) events;
-
 - (void) loadFromFile:(NSString *) path;
-
 - (void) playbackWithDelegate:(id) delegate doneSelector:(SEL) selector;
-
 - (void) stop;
 
 @end

--- a/calabash/Classes/FranklyServer/LPRecorder.h
+++ b/calabash/Classes/FranklyServer/LPRecorder.h
@@ -11,7 +11,8 @@
 - (NSArray *) events;
 - (void) load:(NSArray *) events;
 - (void) loadFromFile:(NSString *) path;
-- (void) playbackWithDelegate:(id) delegate doneSelector:(SEL) selector;
+- (void) playbackWithCallbackDelegate:(id) callbackDelegate
+                         doneSelector:(SEL) selector;
 - (void) stop;
 
 @end

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -65,27 +65,24 @@ static LPRecorder *sharedRecorder = nil;
 }
 
 - (void) record {
-  [_eventList removeAllObjects];
+  [self.eventList removeAllObjects];
 
   NSLog(@"Starting recording");
   _isRecording = YES;
   [[UIApplication sharedApplication] _addRecorder:self];
 }
 
-
 - (NSArray *) events {
   return [NSArray arrayWithArray:_eventList];
 }
 
-
 - (void) saveToFile:(NSString *) path {
   NSLog(@"Saving events to file: %@", path);
 
-  if ([_eventList writeToFile:path atomically:YES]) {
+  if ([self.eventList writeToFile:path atomically:YES]) {
     NSLog(@"succeeded");
   }
 }
-
 
 - (void) stop {
   NSLog(@"Stopping recording");
@@ -93,20 +90,18 @@ static LPRecorder *sharedRecorder = nil;
   [[UIApplication sharedApplication] _removeRecorder:self];
 }
 
-
 - (void) recordApplicationEvent:(NSDictionary *) event {
   NSLog(@"Recorded event: %@", event);
-  [_eventList addObject:event];
+  [self.eventList addObject:event];
 }
 
-
 - (void) load:(NSArray *) events {
-  [_eventList setArray:events];
+  [self.eventList setArray:events];
 }
 
 
 - (void) loadFromFile:(NSString *) path {
-  [_eventList setArray:[NSMutableArray arrayWithContentsOfFile:path]];
+  [self.eventList setArray:[NSMutableArray arrayWithContentsOfFile:path]];
 }
 
 // It is tempting to replace this delegate dance with a block.

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -109,8 +109,9 @@ static LPRecorder *sharedRecorder = nil;
 }
 
 
-- (void) playbackWithDelegate:(id) delegate doneSelector:(SEL) doneSelector {
-  self.playbackDelegate = delegate;
+- (void) playbackWithCallbackDelegate:(id) callbackDelegate
+                         doneSelector:(SEL) doneSelector {
+  self.playbackDelegate = callbackDelegate;
   self.playbackDoneSelector = doneSelector;
 
   LPLogDebug(@"Calling application _playback with [self playbackDone:]");

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -115,17 +115,13 @@ static LPRecorder *sharedRecorder = nil;
   self.playbackDoneSelector = doneSelector;
   NSArray *events = [self events];
 
-  LPLogDebug(@"Calling application _playback with [self playbackDone:]");
-
   if ([[NSThread currentThread] isMainThread]) {
-    LPLogDebug(@"Is main thread. :)");
     [[UIApplication sharedApplication] _playbackEvents:events
                                         atPlaybackRate:1.0f
                                        messageWhenDone:self
                                           withSelector:@selector(finishPlaybackWithDetails:)];
   } else {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      LPLogDebug(@"Is not main thread. :(");
       [[UIApplication sharedApplication] _playbackEvents:events
                                           atPlaybackRate:1.0f
                                          messageWhenDone:self

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -109,24 +109,24 @@ static LPRecorder *sharedRecorder = nil;
   [_eventList setArray:[NSMutableArray arrayWithContentsOfFile:path]];
 }
 
-
 - (void) playbackWithCallbackDelegate:(id) callbackDelegate
                          doneSelector:(SEL) doneSelector {
   self.playbackDelegate = callbackDelegate;
   self.playbackDoneSelector = doneSelector;
+  NSArray *events = [self events];
 
   LPLogDebug(@"Calling application _playback with [self playbackDone:]");
 
   if ([[NSThread currentThread] isMainThread]) {
     LPLogDebug(@"Is main thread. :)");
-    [[UIApplication sharedApplication] _playbackEvents:_eventList
+    [[UIApplication sharedApplication] _playbackEvents:events
                                         atPlaybackRate:1.0f
                                        messageWhenDone:self
                                           withSelector:@selector(finishPlaybackWithDetails:)];
   } else {
     dispatch_sync(dispatch_get_main_queue(), ^{
       LPLogDebug(@"Is not main thread. :(");
-      [[UIApplication sharedApplication] _playbackEvents:_eventList
+      [[UIApplication sharedApplication] _playbackEvents:events
                                           atPlaybackRate:1.0f
                                          messageWhenDone:self
                                             withSelector:@selector(finishPlaybackWithDetails:)];

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -1,6 +1,10 @@
 #import "LPRecorder.h"
 #import "LPCocoaLumberjack.h"
 
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 @interface UIApplication (Recording)
 
 - (void) _addRecorder:(id) recorder;
@@ -34,7 +38,6 @@ static LPRecorder *sharedRecorder = nil;
 @synthesize playbackDoneSelector = _playbackDoneSelector;
 @synthesize isRecording = _isRecording;
 
-
 + (LPRecorder *) sharedRecorder {
   if (sharedRecorder == nil) {
     sharedRecorder = [[super allocWithZone:NULL] init];
@@ -54,14 +57,9 @@ static LPRecorder *sharedRecorder = nil;
 
 // todo dealloc does not playbackDelegate but it retains it
 - (void) dealloc {
-  [_eventList release];
-  if (_playbackDelegate) {
-    [_playbackDelegate release];
-    _playbackDelegate = nil;
-  }
-  [super dealloc];
+  _eventList = nil;
+  _playbackDelegate = nil;
 }
-
 
 - (void) record {
   [_eventList removeAllObjects];

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -136,11 +136,26 @@ static LPRecorder *sharedRecorder = nil;
 }
 
 - (void) finishPlaybackWithDetails:(NSDictionary *)details {
-  LPLogDebug(@"calling %@ on %@",
-             NSStringFromSelector(_playbackDoneSelector),
-             _playbackDelegate);
+  id delegate = self.playbackDelegate;
+  SEL selector = self.playbackDoneSelector;
 
-  [self.playbackDelegate performSelector:self.playbackDoneSelector];
+  NSInvocation *invocation;
+
+  NSMethodSignature *signature;
+  signature = [[delegate class] instanceMethodSignatureForSelector:selector];
+
+  invocation = [NSInvocation invocationWithMethodSignature:signature];
+
+  [invocation setTarget:delegate];
+  [invocation setSelector:selector];
+  [invocation setArgument:&details atIndex:2];
+  [invocation retainArguments];
+
+  // Has void type.
+  [invocation invoke];
+
+  self.playbackDoneSelector = nil;
+  self.playbackDelegate = nil;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -64,7 +64,7 @@ static LPRecorder *sharedRecorder = nil;
 
 
 - (NSArray *) events {
-  return _eventList;
+  return [NSArray arrayWithArray:_eventList];
 }
 
 

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -4,10 +4,14 @@
 @interface UIApplication (Recording)
 
 - (void) _addRecorder:(id) recorder;
-
 - (void) _removeRecorder:(id) recorder;
+- (void) _playbackEvents:(NSArray *) events
+          atPlaybackRate:(float) playbackRate
+         messageWhenDone:(id) target
+            withSelector:(SEL) selector;
 
-- (void) _playbackEvents:(NSArray *) events atPlaybackRate:(float) playbackRate messageWhenDone:(id) target withSelector:(SEL) selector;
+@end
+
 
 @end
 

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -40,9 +40,9 @@ static LPRecorder *sharedRecorder = nil;
 
 - (id) init {
   self = [super init];
-
-  self.eventList = [[NSMutableArray alloc] init];
-
+  if (self) {
+    self.eventList = [[NSMutableArray alloc] init];
+  }
   return self;
 }
 

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -109,12 +109,21 @@ static LPRecorder *sharedRecorder = nil;
   [_eventList setArray:[NSMutableArray arrayWithContentsOfFile:path]];
 }
 
+// It is tempting to replace this delegate dance with a block.
+// The private call to _playbackEvents does pass an dictionary of 'details'.
+// However, none of the 'delegates' consumes those details.
 - (void) playbackWithCallbackDelegate:(id) callbackDelegate
                          doneSelector:(SEL) doneSelector {
   self.playbackDelegate = callbackDelegate;
   self.playbackDoneSelector = doneSelector;
   NSArray *events = [self events];
 
+  // It is tempting to remove this check and just call the block.
+  // For some reason, however, it does not work with the pre Jun 2015
+  // CocoaHTTPServer sources.
+  //
+  // It may be safe to remove this branch _after_ the new CocoaHTTPServer
+  // sources are incorporated.
   if ([[NSThread currentThread] isMainThread]) {
     [[UIApplication sharedApplication] _playbackEvents:events
                                         atPlaybackRate:1.0f

--- a/calabash/Classes/FranklyServer/LPRecorder.m
+++ b/calabash/Classes/FranklyServer/LPRecorder.m
@@ -27,26 +27,27 @@
 // playbackWithDelegate:doneSelector.
 - (void) finishPlaybackWithDetails:(NSDictionary *) details;
 
+- (instancetype) init_private;
 @end
 
 static LPRecorder *sharedRecorder = nil;
 
 @implementation LPRecorder
 
+#pragma mark - Memory Management
+
 @synthesize eventList = _eventList;
 @synthesize playbackDelegate = _playbackDelegate;
 @synthesize playbackDoneSelector = _playbackDoneSelector;
 @synthesize isRecording = _isRecording;
 
-+ (LPRecorder *) sharedRecorder {
-  if (sharedRecorder == nil) {
-    sharedRecorder = [[super allocWithZone:NULL] init];
-  }
-  return sharedRecorder;
+- (instancetype) init {
+  @throw [NSException exceptionWithName:@"Cannot call init"
+                                 reason:@"This is a singleton class"
+                               userInfo:nil];
 }
 
-
-- (id) init {
+- (instancetype) init_private {
   self = [super init];
   if (self) {
     _eventList = [[NSMutableArray alloc] init];
@@ -54,11 +55,13 @@ static LPRecorder *sharedRecorder = nil;
   return self;
 }
 
-
-// todo dealloc does not playbackDelegate but it retains it
-- (void) dealloc {
-  _eventList = nil;
-  _playbackDelegate = nil;
++ (LPRecorder *) sharedRecorder {
+  static LPRecorder *shared = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    shared = [[LPRecorder alloc] init_private];
+  });
+  return shared;
 }
 
 - (void) record {

--- a/calabash/Classes/FranklyServer/Routes/LPAsyncPlaybackRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPAsyncPlaybackRoute.m
@@ -155,9 +155,10 @@
 
 
 - (void) play:(NSArray *) events {
-  [[LPRecorder sharedRecorder] load:self.events];
-  [[LPRecorder sharedRecorder]
-          playbackWithDelegate:self doneSelector:@selector(playbackDone:)];
+  LPRecorder *recorder = [LPRecorder sharedRecorder];
+  [recorder load:self.events];
+  [recorder playbackWithCallbackDelegate:self
+                            doneSelector:@selector(playbackDone:)];
 }
 
 

--- a/calabash/Classes/FranklyServer/Routes/LPInterpolateRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPInterpolateRoute.m
@@ -117,9 +117,10 @@
 
 
 - (void) play:(NSArray *) events {
-  [[LPRecorder sharedRecorder] load:self.events];
-  [[LPRecorder sharedRecorder]
-          playbackWithDelegate:self doneSelector:@selector(playbackDone:)];
+  LPRecorder *recorder = [LPRecorder sharedRecorder];
+  [recorder load:self.events];
+  [recorder playbackWithCallbackDelegate:self
+                            doneSelector:@selector(playbackDone:)];
 }
 
 

--- a/calabash/Classes/FranklyServer/Routes/LPKeyboardRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPKeyboardRoute.m
@@ -107,7 +107,7 @@
   _playbackDone = NO;
   [[LPRecorder sharedRecorder] load:_events];
   [[LPRecorder sharedRecorder]
-          playbackWithDelegate:self doneSelector:@selector(playbackDone:)];
+          playbackWithCallbackDelegate:self doneSelector:@selector(playbackDone:)];
 }
 
 //-(void) waitUntilPlaybackDone {

--- a/calabash/Classes/FranklyServer/Routes/LPRecordRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPRecordRoute.m
@@ -64,10 +64,10 @@
 
   NSString *error = nil;
 
-  NSData *plistData = [NSPropertyListSerialization dataFromPropertyList:[[LPRecorder sharedRecorder]
-          events]
-                                                                 format:NSPropertyListXMLFormat_v1_0
-                                                       errorDescription:&error];
+  NSData *plistData = [NSPropertyListSerialization
+                       dataFromPropertyList:[[LPRecorder sharedRecorder] events]
+                       format:NSPropertyListXMLFormat_v1_0
+                       errorDescription:&error];
   if (error) {
     NSLog(@"error getting plist data: %@", error);
     return nil;


### PR DESCRIPTION
### Motivation

We use the playback API for rotating the app.

If the LPAsyncPlaybackRoute is not started on the main thread, then the call to the playback API will hang.

Converted to ARC, applied style, applied standards, and made some clarifying code comments.