### PR TITLE
Ensure JavaScript is evaluated on the main thread 

### DIFF
--- a/calabash/Classes/WebViewQuery/LPWKWebViewRuntimeLoader.m
+++ b/calabash/Classes/WebViewQuery/LPWKWebViewRuntimeLoader.m
@@ -87,10 +87,21 @@ static NSString *LPWKWebViewCalabashStringByEvaluatingJavaScriptIMP(id self,
   [invocation setArgument:&javascript atIndex:2];
   [invocation setArgument:&completionHandler atIndex:3];
   [invocation retainArguments];
-  [invocation invoke];
+
+  // Unexpected behavior.
+  //
+  // We are invoking 'evaluateJavaScript:completionHandler' which is an async
+  // method.  We should use 'waitUntilDone:YES', but we should _not_ expect
+  // that the blocking while loop will be skipped.
+  //
+  // Put another way, 'evaluationJavaScript:completionHandler' is
+  // fire-and-forget regardless of whether we pass YES or NO to waitUntilDone.
+  [invocation performSelectorOnMainThread:@selector(invokeWithTarget:)
+                               withObject:self
+                            waitUntilDone:YES];
 
   while(!finish) {
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
   }
 
   NSString *returnValue = nil;

--- a/calabash/Classes/WebViewQuery/UIWebView+LPWebView.m
+++ b/calabash/Classes/WebViewQuery/UIWebView+LPWebView.m
@@ -7,7 +7,15 @@
 @implementation UIWebView (UIWebView_LPWebView)
 
 - (NSString *) calabashStringByEvaluatingJavaScript:(NSString *) javascript {
-  return [self stringByEvaluatingJavaScriptFromString:javascript];
+  if ([[NSThread currentThread] isMainThread]) {
+    return [self stringByEvaluatingJavaScriptFromString:javascript];
+  } else {
+    __block NSString *result = nil;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [self stringByEvaluatingJavaScriptFromString:javascript];
+    });
+    return result;
+  }
 }
 
 @end


### PR DESCRIPTION
### Motivation

If the UIWebView and WKWebView evaluate JavaScript methods are not called on the main thread they will not return the correct values and/or they will cause the application to crash.

Tested with: https://github.com/calabash/ios-webview-test-app