### PR TITLE
Version tool can return git revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ calabash-ios
 .irbrc
 Gemfile.lock
 
-# version binary
-version
+# Command line tools
+bin

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ calabash-ios
 .irbrc
 Gemfile.lock
 
+# version binary
+version

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,7 @@ test_app:
 xct:
 	scripts/test/xctest.rb
 
+version-tool:
+	rm -rf version
+	scripts/make-version.sh
+	version --revision ALL

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all:
 	$(MAKE) dylibs
 
 clean:
+	rm -rf bin
 	rm -rf build
 	rm -rf calabash.framework
 	rm -rf libFrankCalabash.a
@@ -52,7 +53,6 @@ test_app:
 xct:
 	scripts/test/xctest.rb
 
-version-tool:
-	rm -rf version
+version:
 	scripts/make-version.sh
-	version --revision ALL
+	bin/version --revision ALL

--- a/VersionTool/main.m
+++ b/VersionTool/main.m
@@ -1,5 +1,24 @@
 #import <Foundation/Foundation.h>
 #import "LPVersionRoute.h"
+#import "LPGitVersionDefines.h"
+
+#ifdef LP_GIT_SHORT_REVISION
+static NSString *const kLPGitShortRevision = LP_GIT_SHORT_REVISION;
+#else
+static NSString *const kLPGitShortRevision = @"Unknown";
+#endif
+
+#ifdef LP_GIT_BRANCH
+static NSString *const kLPGitBranch = LP_GIT_BRANCH;
+#else
+static NSString *const kLPGitBranch = @"Unknown";
+#endif
+
+#ifdef LP_GIT_REMOTE_ORIGIN
+static NSString *const kLPGitRemoteOrigin = LP_GIT_REMOTE_ORIGIN;
+#else
+static NSString *const kLPGitRemoteOrigin = @"Unknown";
+#endif
 
 int main(int argc, const char * argv[]) {
 

--- a/VersionTool/main.m
+++ b/VersionTool/main.m
@@ -1,11 +1,3 @@
-//
-//  main.m
-//  version
-//
-//  Created by Joshua Moody on 27.3.14.
-//  Copyright (c) 2014 Xamarin. All rights reserved.
-//
-
 #import <Foundation/Foundation.h>
 #import "LPVersionRoute.h"
 

--- a/VersionTool/main.m
+++ b/VersionTool/main.m
@@ -23,8 +23,20 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
 int main(int argc, const char * argv[]) {
 
   @autoreleasepool {
-    NSString *calabashVersion = [kLPCALABASHVERSION componentsSeparatedByString:@" "].lastObject;
-    printf("%s\n", [calabashVersion cStringUsingEncoding:NSASCIIStringEncoding]);
+    NSUserDefaults *standardDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *revision = [standardDefaults stringForKey:@"-revision"];
+
+    if ([revision isEqualToString:@"ALL"]) {
+      printf("%s %s %s\n",
+             [kLPGitRemoteOrigin cStringUsingEncoding:NSASCIIStringEncoding],
+             [kLPGitBranch cStringUsingEncoding:NSASCIIStringEncoding],
+             [kLPGitShortRevision cStringUsingEncoding:NSASCIIStringEncoding]);
+
+    } else {
+      NSString *calabashVersion = [kLPCALABASHVERSION componentsSeparatedByString:@" "].lastObject;
+      printf("%s\n", [calabashVersion cStringUsingEncoding:NSASCIIStringEncoding]);
+
+    }
   }
   return 0;
 }

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -1861,7 +1861,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F537399718E5253B004133FA /* Build configuration list for PBXNativeTarget "version" */;
 			buildPhases = (
+				F52B40BC1B4BA2790022AEC8 /* Run Script git versioning 1 of 2 */,
 				F537398818E5253B004133FA /* Sources */,
+				F52B40BD1B4BA2970022AEC8 /* Run Script git versioning 2 of 2 */,
 				F537398918E5253B004133FA /* Frameworks */,
 			);
 			buildRules = (
@@ -2011,6 +2013,36 @@
 			inputPaths = (
 			);
 			name = "Run Script - git versioning 2 of 2";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh calabash/gitversioning-after.sh \"calabash/LPGitVersionDefines.h\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F52B40BC1B4BA2790022AEC8 /* Run Script git versioning 1 of 2 */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script git versioning 1 of 2";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh calabash/gitversioning-before.sh \"calabash/LPGitVersionDefines.h\"";
+			showEnvVarsInLog = 0;
+		};
+		F52B40BD1B4BA2970022AEC8 /* Run Script git versioning 2 of 2 */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script git versioning 2 of 2";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/scripts/make-version.sh
+++ b/scripts/make-version.sh
@@ -10,13 +10,23 @@ TARGET_NAME="version"
 XC_PROJECT="calabash.xcodeproj"
 XC_SCHEME="${TARGET_NAME}"
 CAL_BUILD_DIR="${PWD}/build"
+DESTINATION="bin/${TARGET_NAME}"
+
 rm -rf "${CAL_BUILD_DIR}"
 mkdir -p "${CAL_BUILD_DIR}"
 
-if [ -e "${TARGET_NAME}" ]; then
-  echo "INFO: removing ./$TARGET_NAME"
-  rm "${TARGET_NAME}"
+if [ ! -d ./bin ]; then
+  echo "INFO: making a ./bin directory"
+  mkdir ./bin
 fi
+
+if [ -e "${DESTINATION}" ]; then
+  echo "INFO: removing ./$DESTINATION"
+  rm "${DESTINATION}"
+fi
+
+set +o errexit
+
 xcrun xcodebuild \
   -SYMROOT="${CAL_BUILD_DIR}" \
   -derivedDataPath "${CAL_BUILD_DIR}" \
@@ -25,9 +35,20 @@ xcrun xcodebuild \
   -scheme "${TARGET_NAME}" \
   -sdk macosx \
   -configuration "${CAL_BUILD_CONFIG}" \
-  clean build
+  clean build | xcpretty -c
+
+RETVAL=${PIPESTATUS[0]}
+
+set -o errexit
+
+if [ $RETVAL != 0 ]; then
+  echo "FAIL:  could not build"
+  exit $RETVAL
+else
+  echo "INFO: successfully built"
+fi
 
 BINARY="${CAL_BUILD_DIR}/Build/Products/Debug/${TARGET_NAME}"
 
-echo "INFO: moving $TARGET_NAME to ./"
-cp "${BINARY}" ./
+echo "INFO: moving $TARGET_NAME to ${DESTINATION}"
+cp "${BINARY}" ${DESTINATION}

--- a/scripts/make-version.sh
+++ b/scripts/make-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This script is for developer use only.
+#
+# It is for debugging the version command-line tool.
+#
+# It is not part of the library generation process.
+
+TARGET_NAME="version"
+XC_PROJECT="calabash.xcodeproj"
+XC_SCHEME="${TARGET_NAME}"
+CAL_BUILD_DIR="${PWD}/build"
+rm -rf "${CAL_BUILD_DIR}"
+mkdir -p "${CAL_BUILD_DIR}"
+
+if [ -e "${TARGET_NAME}" ]; then
+  echo "INFO: removing ./$TARGET_NAME"
+  rm "${TARGET_NAME}"
+fi
+xcrun xcodebuild \
+  -SYMROOT="${CAL_BUILD_DIR}" \
+  -derivedDataPath "${CAL_BUILD_DIR}" \
+  ONLY_ACTIVE_ARCH=NO \
+  -project "${XC_PROJECT}" \
+  -scheme "${TARGET_NAME}" \
+  -sdk macosx \
+  -configuration "${CAL_BUILD_CONFIG}" \
+  clean build
+
+BINARY="${CAL_BUILD_DIR}/Build/Products/Debug/${TARGET_NAME}"
+
+echo "INFO: moving $TARGET_NAME to ./"
+cp "${BINARY}" ./


### PR DESCRIPTION
### Motivation

It is becoming difficult for me to keep track of the provenance of the framework and dylibs that are committed in various repos:

* Briar iOS Example
* Calabash iOS Smoke Test
* Calabash WebView Test

This PR allows the calabash.framework/Resources/version tool to report the git revision details.

```
$ calabash.framework/Resources/version --revision ALL
git@github.com:calabash/calabash-ios-server.git feature/version-tool-can-return-git-revision 0c56b54
```

There are no other options:  ALL is the only one.

@sapieneptus @krukow @TobiasRoikjer

This might be of interest to you.   It is the same information that is output by `server_version`:

```
                        "git" => {
             "revision" => "b9af34a",
        "remote_origin" => "git@github.com:calabash/calabash-ios-server.git",
               "branch" => "feature/dylib-targets-must-call-git-revision-scripts"
    },
```

This information is important:  we don't want to be debugging someone's custom build of the server.

