### PR TITLE
LPQueryAllOperation needs some TLC

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -236,7 +236,20 @@
         break;
       }
       case 'c': {
-        char chVal = [arg charValue];
+        NSLog(@"arg class: %@", [arg class]);
+        NSLog(@"arg value: %@", arg);
+        char chVal;
+        if ([arg respondsToSelector:@selector(charValue)]) {
+          chVal = [arg charValue];
+        } else if ([arg respondsToSelector:@selector(characterAtIndex:)]) {
+          chVal = (char)[arg characterAtIndex:0];
+        } else {
+          NSLog(@"Cannot coerce '%@' of class '%@' into a char",
+                arg, [arg class]);
+          NSLog(@"To avoid crashing, setting char value to CHAR_MAX: %@",
+                @(CHAR_MAX));
+          chVal = CHAR_MAX;
+        }
         [invocation setArgument:&chVal atIndex:i + 2];
         break;
       }

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -194,8 +194,12 @@
           double d1 = *doubles;
           doubles++;
           double d2 = *doubles;
-          return [NSArray arrayWithObjects:[NSNumber numberWithDouble:d1],
-                                           [NSNumber numberWithDouble:d2], nil];
+
+          NSArray *array = @[@(d1), @(d2)];
+
+          [value release];
+          free(buffer);
+          return array;
         } else {
           NSString *description = [value description];
           [value release];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -308,21 +308,33 @@
         break;
       }
       case '{': {
-        //not supported yet
-        if (strcmp(cType, "{CGPoint=ff}") == 0) {
+        NSLog(@"In the struct case! '%@'",
+              [NSString stringWithCString:cType encoding:NSUTF8StringEncoding]);
+
+        NSString *structString = [NSString stringWithCString:cType
+                                                    encoding:NSUTF8StringEncoding];
+        if ([structString rangeOfString:@"{CGPoint"].location == 0) {
+          NSLog(@"In the point case");
           CGPoint point;
           CGPointMakeWithDictionaryRepresentation((CFDictionaryRef) arg,
-                  &point);
+                                                  &point);
           [invocation setArgument:&point atIndex:i + 2];
           break;
-        } else if (strcmp(cType, "{CGRect={CGPoint=ff}{CGSize=ff}}") == 0) {
+        } else if ([structString rangeOfString:@"{CGRect"].location == 0) {
+          NSLog(@"In the rect case");
           CGRect rect;
           CGRectMakeWithDictionaryRepresentation((CFDictionaryRef) arg, &rect);
           [invocation setArgument:&rect atIndex:i + 2];
           break;
+        } else {
+          NSString *name = @"Unsupported argument encoding";
+          NSString *reason;
+          reason = [NSString stringWithFormat:@"Encoding for struct '%@' is not supported.", structString];
+
+          @throw [NSException exceptionWithName:name
+                                         reason:reason
+                                       userInfo:nil];
         }
-        @throw [NSString stringWithFormat:@"not yet support struct args: %@",
-                                          sig];
       }
     }
   }

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -269,11 +269,24 @@
         [invocation setArgument:&chVal atIndex:i + 2];
         break;
       }
+
       case 'S': {
-        unsigned short SValue = [arg unsignedShortValue];
+        unsigned short SValue;
+        if ([arg respondsToSelector:@selector(unsignedShortValue)]) {
+          SValue = [arg unsignedShortValue];
+        } else if ([arg respondsToSelector:@selector(characterAtIndex:)]) {
+          SValue = (unsigned short)[arg characterAtIndex:0];
+        } else {
+          NSLog(@"Cannot coerce '%@' of class '%@' into an unsigned short",
+                arg, [arg class]);
+          NSLog(@"To avoid crashing, setting short value to USHRT_MAX: %@",
+                @(USHRT_MAX));
+          SValue = USHRT_MAX;
+        }
         [invocation setArgument:&SValue atIndex:i + 2];
         break;
       }
+
       case 'B': {
         _Bool Bvalue = [arg boolValue];
         [invocation setArgument:&Bvalue atIndex:i + 2];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -314,19 +314,18 @@
         NSString *structString = [NSString stringWithCString:cType
                                                     encoding:NSUTF8StringEncoding];
         if ([structString rangeOfString:@"{CGPoint"].location == 0) {
-          NSLog(@"In the point case");
           CGPoint point;
           CGPointMakeWithDictionaryRepresentation((CFDictionaryRef) arg,
                                                   &point);
           [invocation setArgument:&point atIndex:i + 2];
           break;
         } else if ([structString rangeOfString:@"{CGRect"].location == 0) {
-          NSLog(@"In the rect case");
           CGRect rect;
           CGRectMakeWithDictionaryRepresentation((CFDictionaryRef) arg, &rect);
           [invocation setArgument:&rect atIndex:i + 2];
           break;
         } else {
+          // TODO: Can we support the '{?=dd}' encoding?
           NSString *name = @"Unsupported argument encoding";
           NSString *reason;
           reason = [NSString stringWithFormat:@"Encoding for struct '%@' is not supported.", structString];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -235,9 +235,25 @@
         [invocation setArgument:&cstringValue atIndex:i + 2];
         break;
       }
+
+      case 'C' : {
+        unichar chVal;
+        if ([arg respondsToSelector:@selector(unsignedCharValue)]) {
+          chVal = [arg unsignedCharValue];
+        } else if ([arg respondsToSelector:@selector(characterAtIndex:)]) {
+          chVal = [arg characterAtIndex:0];
+        } else {
+          NSLog(@"Cannot coerce '%@' of class '%@' into a unichar",
+                arg, [arg class]);
+          NSLog(@"To avoid crashing, setting char value to UCHAR_MAX: %@",
+                @(UCHAR_MAX));
+          chVal = UCHAR_MAX;
+        }
+        [invocation setArgument:&chVal atIndex:i + 2];
+        break;
+      }
+
       case 'c': {
-        NSLog(@"arg class: %@", [arg class]);
-        NSLog(@"arg value: %@", arg);
         char chVal;
         if ([arg respondsToSelector:@selector(charValue)]) {
           chVal = [arg charValue];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -76,6 +76,7 @@
     short shortValue;
     float floatValue;
     double doubleValue;
+    long double longDoubleValue;
     unsigned short SValue;
     BOOL Bvalue;
     unsigned long long Qvalue;
@@ -130,6 +131,10 @@
         return [NSNumber numberWithShort:shortValue];
       case 'd':[invocation getReturnValue:(void **) &doubleValue];
         return [NSNumber numberWithDouble:doubleValue];
+      case 'D':[invocation getReturnValue:(void **) &longDoubleValue];
+        // http://stackoverflow.com/questions/6488956/store-nsnumber-in-a-long-double-type
+        // There is no Objective-C support for encoding a long double as a object
+        return [NSNumber numberWithDouble:longDoubleValue];
       case 'f':[invocation getReturnValue:(void **) &floatValue];
         return [NSNumber numberWithFloat:floatValue];
       case 'l':[invocation getReturnValue:(void **) &longValue];
@@ -220,6 +225,15 @@
         [invocation setArgument:&dbVal atIndex:i + 2];
         break;
       }
+
+      case 'D': {
+        // http://stackoverflow.com/questions/6488956/store-nsnumber-in-a-long-double-type
+        // There is no Objective-C support for encoding a long double as a object
+        long double longDouble = (long double)[arg doubleValue];
+        [invocation setArgument:&longDouble atIndex:i + 2];
+        break;
+      }
+
       case 'f': {
         float fltVal = [arg floatValue];
         [invocation setArgument:&fltVal atIndex:i + 2];


### PR DESCRIPTION
### Motivation

1. Fixes a long standing memory leak.
2. Found three argument encodings that resulted in crashes.
3. Add support for `long double` encoding for return values and arguments
4. Add support for arguments that are CGPoint and CGRect
5. Add logging for exceptional cases
6. Ensure that invocations and performSelector* calls are done on the main thread

Hurray!


@krukow @sapieneptus