### PR TITLE
LPInvoker can be forced to execute it's invocations on main thread

### DIFF
--- a/XCTest/Tests/Invoker/LPInvokerThreadingTest.m
+++ b/XCTest/Tests/Invoker/LPInvokerThreadingTest.m
@@ -1,0 +1,79 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPInvoker.h"
+#import "InvokerFactory.h"
+
+@interface LPInvokerThreadingTest : XCTestCase
+
+@end
+
+@implementation LPInvokerThreadingTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void) testZeroArgOnMainThread {
+  expect([[NSThread currentThread] isMainThread]).to.equal(YES);
+
+  Target *target = [Target new];
+  SEL selector = @selector(selectorThatReturnsDouble);
+
+  id result = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
+                                                     withTarget:target];
+  expect(result).to.equal(@(DBL_MAX));
+}
+
+- (void) testZeroArgPrimativeOffMainThread {
+  expect([[NSThread currentThread] isMainThread]).to.equal(YES);
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Async"];
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    expect([[NSThread currentThread] isMainThread]).to.equal(NO);
+
+    Target *target = [Target new];
+    SEL selector = @selector(selectorThatReturnsDouble);
+
+    id result = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
+                                                       withTarget:target];
+
+    expect(result).to.equal(@(DBL_MAX));
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:0.1 handler:^(NSError *error) {
+    if (error) { XCTFail(@"Expectation Failed with error: %@", error); }
+  }];
+}
+
+- (void) testZeroArgTargetDefinedOnMainThread {
+  expect([[NSThread currentThread] isMainThread]).to.equal(YES);
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Async"];
+
+  NSArray *target = @[@"first", @"second", @"last"];
+  SEL selector = @selector(lastObject);
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    expect([[NSThread currentThread] isMainThread]).to.equal(NO);
+
+    id result = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
+                                                       withTarget:target];
+
+    expect(result).to.equal(@"last");
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:0.1 handler:^(NSError *error) {
+    if (error) { XCTFail(@"Expectation Failed with error: %@", error); }
+  }];
+}
+
+@end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		F56630961A39B09C00DEA0C0 /* LPInfoPlist.m in Sources */ = {isa = PBXBuildFile; fileRef = F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F56630981A39B09C00DEA0C0 /* LPInfoPlist.m in Sources */ = {isa = PBXBuildFile; fileRef = F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F56B4EF41B56FC3600E7EA23 /* LPInvokerSelectorWithArgumentsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F56B4EF31B56FC3600E7EA23 /* LPInvokerSelectorWithArgumentsTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F56B4EF61B57E04E00E7EA23 /* LPInvokerThreadingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F56B4EF51B57E04E00E7EA23 /* LPInvokerThreadingTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F570992C1B5518EF00DB35EC /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F570992B1B5518EF00DB35EC /* CoreLocation.framework */; };
 		F570992E1B555C3C00DB35EC /* LPInvokerArgumentEncodingIsHandledTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F570992D1B555C3C00DB35EC /* LPInvokerArgumentEncodingIsHandledTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F57099301B55751200DB35EC /* LPInvokerHasArgumentWithUnhandleEncodingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F570992F1B55751200DB35EC /* LPInvokerHasArgumentWithUnhandleEncodingTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -786,6 +787,7 @@
 		F566308A1A39B09C00DEA0C0 /* LPInfoPlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPInfoPlist.h; sourceTree = "<group>"; };
 		F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInfoPlist.m; sourceTree = "<group>"; };
 		F56B4EF31B56FC3600E7EA23 /* LPInvokerSelectorWithArgumentsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInvokerSelectorWithArgumentsTest.m; sourceTree = "<group>"; };
+		F56B4EF51B57E04E00E7EA23 /* LPInvokerThreadingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInvokerThreadingTest.m; sourceTree = "<group>"; };
 		F56CBBB01B451B74002D1DC1 /* VERSION.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = VERSION.md; sourceTree = "<group>"; };
 		F570992B1B5518EF00DB35EC /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		F570992D1B555C3C00DB35EC /* LPInvokerArgumentEncodingIsHandledTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInvokerArgumentEncodingIsHandledTest.m; sourceTree = "<group>"; };
@@ -1698,6 +1700,7 @@
 				F570992D1B555C3C00DB35EC /* LPInvokerArgumentEncodingIsHandledTest.m */,
 				F570992F1B55751200DB35EC /* LPInvokerHasArgumentWithUnhandleEncodingTest.m */,
 				F56B4EF31B56FC3600E7EA23 /* LPInvokerSelectorWithArgumentsTest.m */,
+				F56B4EF51B57E04E00E7EA23 /* LPInvokerThreadingTest.m */,
 			);
 			path = Invoker;
 			sourceTree = "<group>";
@@ -2557,6 +2560,7 @@
 				F50CBF831A040564004AC9DA /* LPHTTPConnection.m in Sources */,
 				F5C224E21AD473F0001DB4FA /* LPJSONUtilsTest.m in Sources */,
 				89F2EFF01B224F6D00958052 /* LPJSONUtils+Introspection.m in Sources */,
+				F56B4EF61B57E04E00E7EA23 /* LPInvokerThreadingTest.m in Sources */,
 				F50CBFB11A0405B2004AC9DA /* LPBackdoorRoute.m in Sources */,
 				F5BA6F221B4EC8CC00DB898F /* LPInvokerObjectByCoercingReturnValueTest.m in Sources */,
 				F5C224ED1AD4766E001DB4FA /* LPSetTextOperationTest.m in Sources */,

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -42,8 +42,8 @@
   SEL selector = NSSelectorFromString(@"postDataAsString");
 
   if ([connection respondsToSelector:selector]) {
-    id connectionData = [LPInvoker invokeZeroArgumentSelector:selector
-                                                   withTarget:connection];
+    id connectionData = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
+                                                               withTarget:connection];
     NSDictionary *data = [LPJSONUtils deserializeDictionary:connectionData];
 
     response = [self JSONResponseForMethod:@"POST"

--- a/calabash/Classes/Invoker/LPInvoker.h
+++ b/calabash/Classes/Invoker/LPInvoker.h
@@ -54,6 +54,10 @@
 + (id) invokeOnMainThreadZeroArgumentSelector:(SEL) selector
                                    withTarget:(id) target;
 
++ (id) invokeOnMainThreadSelector:(SEL) selector
+                       withTarget:(id) target
+                         argments:(NSArray *) arguments;
+
 - (BOOL) targetRespondsToSelector;
 - (NSString *) encodingForSelectorReturnType;
 - (BOOL) selectorReturnTypeEncodingIsUnhandled;

--- a/calabash/Classes/Invoker/LPInvoker.h
+++ b/calabash/Classes/Invoker/LPInvoker.h
@@ -51,6 +51,9 @@
            withTarget:(id) receiver
             arguments:(NSArray *) arguments;
 
++ (id) invokeOnMainThreadZeroArgumentSelector:(SEL) selector
+                                   withTarget:(id) target;
+
 - (BOOL) targetRespondsToSelector;
 - (NSString *) encodingForSelectorReturnType;
 - (BOOL) selectorReturnTypeEncodingIsUnhandled;

--- a/calabash/Classes/Invoker/LPInvoker.m
+++ b/calabash/Classes/Invoker/LPInvoker.m
@@ -77,6 +77,24 @@
   }
 }
 
++ (id) invokeOnMainThreadSelector:(SEL) selector
+                       withTarget:(id) target
+                         argments:(NSArray *) arguments {
+  if ([[NSThread currentThread] isMainThread]) {
+    return [LPInvoker invokeSelector:selector
+                          withTarget:target
+                           arguments:arguments];
+  } else {
+    __block id result = [NSNull null];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [LPInvoker invokeSelector:selector
+                              withTarget:target
+                               arguments:arguments];
+    });
+    return result;
+  }
+}
+
 + (id) invokeZeroArgumentSelector:(SEL) selector withTarget:(id) target {
   LPInvoker *invoker = [[LPInvoker alloc] initWithSelector:selector
                                                     target:target];

--- a/calabash/Classes/Invoker/LPInvoker.m
+++ b/calabash/Classes/Invoker/LPInvoker.m
@@ -64,6 +64,19 @@
   return [self description];
 }
 
++ (id) invokeOnMainThreadZeroArgumentSelector:(SEL) selector
+                                   withTarget:(id) target {
+  if ([[NSThread currentThread] isMainThread]) {
+    return [LPInvoker invokeZeroArgumentSelector:selector withTarget:target];
+  } else {
+    __block id result = [NSNull null];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [LPInvoker invokeZeroArgumentSelector:selector withTarget:target];
+    });
+    return result;
+  }
+}
+
 + (id) invokeZeroArgumentSelector:(SEL) selector withTarget:(id) target {
   LPInvoker *invoker = [[LPInvoker alloc] initWithSelector:selector
                                                     target:target];

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -49,7 +49,8 @@
          whenTarget:(id) target
          respondsTo:(SEL) selector {
   if ([target respondsToSelector:selector]) {
-    id value = [LPInvoker invokeZeroArgumentSelector:selector withTarget:target];
+    id value = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
+                                                      withTarget:target];
     [dictionary setObject:value forKey:key];
   }
 }
@@ -59,7 +60,8 @@
          withTarget:(id) target
            selector:(SEL) selector {
   if ([target respondsToSelector:selector]) {
-    id value = [LPInvoker invokeZeroArgumentSelector:selector withTarget:target];
+    id value = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
+                                                      withTarget:target];
     [dictionary setObject:value forKey:key];
   } else {
     [dictionary setObject:[NSNull null] forKey:key];


### PR DESCRIPTION
### Motivation

We need to ensure we are setting the arguments of the invocation and invoking on the main thread.

@sapieneptus Can you have a look at the tests in the XCTests/Invoker/LPInvokerThreadingTest.m?  

I want more tests!

I believe that I will eventually implement your suggest class-that-knows-about-thread, but I am still exploring the problem space.