### PR TITLE
Delete coverage files before compiling XCTest target

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -1885,6 +1885,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F50CBF661A03F222004AC9DA /* Build configuration list for PBXNativeTarget "XCTest" */;
 			buildPhases = (
+				F5986B141B5802F100CCB142 /* ShellScript */,
 				F50CBF5A1A03F222004AC9DA /* Sources */,
 				F50CBF5B1A03F222004AC9DA /* Frameworks */,
 				F50CBF5C1A03F222004AC9DA /* Resources */,
@@ -2090,6 +2091,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh calabash/gitversioning-after.sh \"calabash/LPGitVersionDefines.h\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F5986B141B5802F100CCB142 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "calabash/clean-coverage-files.sh\n";
 			showEnvVarsInLog = 0;
 		};
 		F5BA6EFE1B4BB95700DB898F /* Run Script git versioning 1 of 2 */ = {

--- a/calabash/clean-coverage-files.sh
+++ b/calabash/clean-coverage-files.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Called by XCTest Run Script Build Phase to clear coverage files
+# which, when corrupt, can cause XCTest console spam.
+# https://github.com/specta/specta/issues/167
+INTERMEDIATES_DIR="${BUILD_DIR}/../Intermediates"
+
+if [ -e "${INTERMEDIATES_DIR}" ]; then
+  find ${INTERMEDIATES_DIR} -type f -name "*.gcda" -exec rm -rf {} \;
+fi


### PR DESCRIPTION
### Motivation

**requiring "Generate Test Coverage Files" and/or "Instrument Program Flow" causes Console spam** [/specta/#167](https://github.com/specta/specta/issues/167)