### PR TITLE
LPConditionRoute condition checks need to be done on main thread

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -31,6 +31,7 @@
 @property(atomic, strong, readonly) id query;
 
 - (NSArray *) performQueryOnMainThread;
+- (BOOL) checkNetworkIndicatorOnMainThread;
 
 @end
 
@@ -167,6 +168,18 @@
   }
 }
 
+- (BOOL) checkNetworkIndicatorOnMainThread {
+  if ([[NSThread currentThread] isMainThread]) {
+    return [[UIApplication sharedApplication] isNetworkActivityIndicatorVisible];
+  } else {
+    __block BOOL result = NO;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [[UIApplication sharedApplication] isNetworkActivityIndicatorVisible];
+    });
+    return result;
+  }
+}
+
 #pragma mark - Timer Selector
 
 - (void) checkConditionWithTimer:(NSTimer *) aTimer {
@@ -208,7 +221,7 @@
       return;
     }
   } else if ([condition isEqualToString:kLPConditionRouteNoNetworkIndicator]) {
-    if ([[UIApplication sharedApplication] isNetworkActivityIndicatorVisible]) {
+    if ([self checkNetworkIndicatorOnMainThread]) {
       self.stablePeriodCount = 0;
       return;
     }

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -30,6 +30,7 @@
 @property(atomic, copy, readonly) NSString *condition;
 @property(atomic, strong, readonly) id query;
 
+- (NSNumber *) defaultTimeoutForCondition:(NSString *)condition;
 - (BOOL) atLeastOneAnimatingOnMainThreadWithQuery:(id) query;
 - (BOOL) checkNetworkIndicatorOnMainThread;
 - (void) checkCondition;
@@ -86,6 +87,15 @@
   if (_query) { return _query; }
   _query = [self.data objectForKey:@"query"];
   return _query;
+}
+
+- (NSNumber *) defaultTimeoutForCondition:(NSString *)condition {
+  if ([kLPConditionRouteNoneAnimating isEqualToString:condition]) {
+    return [NSNumber numberWithUnsignedInteger:6];
+  } else if ([kLPConditionRouteNoNetworkIndicator isEqualToString:condition]) {
+    return [NSNumber numberWithUnsignedInteger:30];
+  }
+  return [NSNumber numberWithUnsignedInteger:30];
 }
 
 #pragma mark - Override Superclass Methods
@@ -253,6 +263,8 @@
   }
 }
 
+#pragma mark - Success and Failure
+
 - (void) failWithMessageFormat:(NSString *) messageFmt message:(NSString *) message {
   [self stopAndReleaseRepeatingTimers];
   [super failWithMessageFormat:messageFmt message:message];
@@ -261,15 +273,6 @@
 - (void) succeedWithResult:(NSArray *) result {
   [self stopAndReleaseRepeatingTimers];
   [super succeedWithResult:result];
-}
-
-- (NSNumber *) defaultTimeoutForCondition:(NSString *)condition {
-  if ([kLPConditionRouteNoneAnimating isEqualToString:condition]) {
-    return [NSNumber numberWithUnsignedInteger:6];
-  } else if ([kLPConditionRouteNoNetworkIndicator isEqualToString:condition]) {
-    return [NSNumber numberWithUnsignedInteger:30];
-  }
-  return [NSNumber numberWithUnsignedInteger:30];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -32,6 +32,7 @@
 
 - (NSArray *) performQueryOnMainThread;
 - (BOOL) checkNetworkIndicatorOnMainThread;
+- (void) checkCondition;
 
 @end
 
@@ -62,7 +63,7 @@
   dispatch_source_set_timer(_repeatingTimer, startTime, intervalNano, 0);
 
   dispatch_source_set_event_handler(_repeatingTimer, ^{
-    [self checkConditionWithTimer:nil];
+    [self checkCondition];
   });
 
   dispatch_resume(_repeatingTimer);
@@ -180,9 +181,10 @@
   }
 }
 
-#pragma mark - Timer Selector
+#pragma mark - Called by timer
 
-- (void) checkConditionWithTimer:(NSTimer *) aTimer {
+- (void) checkCondition {
+
   if (!_repeatingTimer) {
     LPLogWarn(@"Check condition received a nil timer - returning");
     return;


### PR DESCRIPTION
### Motivation

Chris discovered a case where the LPConditionRoute was causing a crash.

I have not been able to reproduce with any of my tests.

```
UIKit_UIApplication_EnsureUIThread + 132
UIKit_UIView_get_BackgroundColor + 20
Xamarin_Forms_Platform_iOS_VisualElementRenderer_1_get_BackgroundColor + 88

< snip >

-[Xamarin_Forms_Platform_iOS_VisualElementRenderer_1 backgroundColor] + 64
+[LPTouchUtils isViewTransparent:] + 44
+[LPTouchUtils isViewVisible:] + 1440
-[UIScriptASTClassName addView:toArray:ifMatchesVisibility:] + 80
-[UIScriptASTClassName evalDescWith:result:visibility:] + 152
-[UIScriptASTClassName evalDescWith:result:visibility:] + 452
-[UIScriptASTClassName evalWith:direction:visibility:] + 400
-[UIScriptParser evalWith:] + 492
+[LPOperation performQuery:] + 424
-[LPConditionRoute checkConditionWithTimer:] + 664
-[LPConditionRoute startAndRetainRepeatingTimers]_block_invoke + 56
```

The LPConditionRoute timer _must_ not be run the main thread because it will block the UI.  This PR ensures the condition checks (none animating and network indicator) are performed the main thread.

@sapieneptus Can you take a look?  In particular the `atLeastOneAnimatingOnMainThreadWithQuery:` could use a review.

### Testing

Tested with CalSmokeApp.  I think it should be tested against a forms app.