### PR TITLE
Modernize LPOperation's interface and implementation

### DIFF
--- a/XCTest/Tests/Operations/LPOperationTest.m
+++ b/XCTest/Tests/Operations/LPOperationTest.m
@@ -1,0 +1,33 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPOperation.h"
+
+@interface LPOperationTest : XCTestCase
+
+@end
+
+@implementation LPOperationTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void) testDescription {
+  NSDictionary *dictionary =
+  @{@"method_name" : @"appendString:withString:",
+    @"arguments" : @[@"A string", @": appended"]};
+
+  LPOperation *operation = [[LPOperation alloc] initWithOperation:dictionary];
+
+  NSString *actual = [operation description];
+  NSString *expected = @"<LPOperation 'appendString:withString:' with arguments 'A string, : appended'>";
+  expect(actual).to.equal(expected);
+}
+
+@end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -1225,7 +1225,8 @@
 		B184FDC114B6DB2B002A744C /* Operations */ = {
 			isa = PBXGroup;
 			children = (
-				F52149EE18B50A1C005BB4F3 /* Scrolling */,
+				B184FDC214B6DB2B002A744C /* LPOperation.h */,
+				B184FE9214B6DDA1002A744C /* LPOperation.m */,
 				F5CAC06A180D499600E23F03 /* LPSliderOperation.h */,
 				F5CAC06B180D499600E23F03 /* LPSliderOperation.m */,
 				F55A350F17CF8F8F0001E8B4 /* LPDatePickerOperation.h */,
@@ -1236,12 +1237,11 @@
 				B19440431725C70A00EE1B25 /* LPFlashOperation.m */,
 				B15DA5E315C5D80A009E6CFE /* LPQueryAllOperation.h */,
 				B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */,
-				B184FDC214B6DB2B002A744C /* LPOperation.h */,
-				B184FE9214B6DDA1002A744C /* LPOperation.m */,
 				B184FDC414B6DB2B002A744C /* LPQueryOperation.h */,
 				B184FDC514B6DB2B002A744C /* LPQueryOperation.m */,
 				B184FDCA14B6DB2B002A744C /* LPSetTextOperation.h */,
 				B184FDCB14B6DB2B002A744C /* LPSetTextOperation.m */,
+				F52149EE18B50A1C005BB4F3 /* Scrolling */,
 			);
 			path = Operations;
 			sourceTree = "<group>";

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 		F5986B281B5907E100CCB142 /* LPInvocationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F5986B231B5907E100CCB142 /* LPInvocationResult.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5986B291B5907E100CCB142 /* LPInvocationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F5986B231B5907E100CCB142 /* LPInvocationResult.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5986B2A1B5907E100CCB142 /* LPInvocationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F5986B231B5907E100CCB142 /* LPInvocationResult.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5986B301B5A327500CCB142 /* LPOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5986B2F1B5A327500CCB142 /* LPOperationTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F59C5CF818E0BB1A0087B51D /* LPRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = B184FDBE14B6DB2B002A744C /* LPRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F59C5CF918E0BB290087B51D /* LPRouter.h in Headers */ = {isa = PBXBuildFile; fileRef = B184FDBF14B6DB2B002A744C /* LPRouter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F59C5CFA18E0BBAE0087B51D /* LPHTTPResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B116C9B914E6565500663205 /* LPHTTPResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -857,6 +858,7 @@
 		F5986B201B5907A600CCB142 /* LPInvocationResultTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInvocationResultTest.m; sourceTree = "<group>"; };
 		F5986B221B5907E100CCB142 /* LPInvocationResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPInvocationResult.h; sourceTree = "<group>"; };
 		F5986B231B5907E100CCB142 /* LPInvocationResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInvocationResult.m; sourceTree = "<group>"; };
+		F5986B2F1B5A327500CCB142 /* LPOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPOperationTest.m; sourceTree = "<group>"; };
 		F59CA46D1A82EF40007A2F38 /* LPTestTarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LPTestTarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F59CA4701A82EF40007A2F38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F59CA4711A82EF40007A2F38 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -1737,6 +1739,7 @@
 			children = (
 				F5C224EC1AD4766E001DB4FA /* LPSetTextOperationTest.m */,
 				F5C224E51AD47403001DB4FA /* LPScrollOperationTest.m */,
+				F5986B2F1B5A327500CCB142 /* LPOperationTest.m */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -2581,6 +2584,7 @@
 				F50CBFBC1A0405CE004AC9DA /* UIScriptAST.m in Sources */,
 				F50CBFB21A0405B2004AC9DA /* LPExitRoute.m in Sources */,
 				F5A8B4701B39BFEB00F390CA /* LPMultiFormatter.m in Sources */,
+				F5986B301B5A327500CCB142 /* LPOperationTest.m in Sources */,
 				F50CBFA31A0405B2004AC9DA /* LPAppPropertyRoute.m in Sources */,
 				F50CBFB41A0405CE004AC9DA /* LPISO8601DateFormatter.m in Sources */,
 				F50CBF871A040564004AC9DA /* NSNumber+LPCHSExtensions.m in Sources */,

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
@@ -8,7 +8,7 @@
 
 //                 <===               required                ===>
 // _arguments ==> [item_num, section_num, scroll postion, animated]
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
 
   // UICollectionView appears in iOS 6
   Class clz = NSClassFromString(@"UICollectionView");
@@ -18,13 +18,13 @@
     return nil;
   }
 
-  if ([view isKindOfClass:[UICollectionView class]] == NO) {
+  if ([target isKindOfClass:[UICollectionView class]] == NO) {
     NSLog(@"Warning view: %@ should be an instance of UICollectionView but found '%@'",
-            view, view == nil ? nil : [view class]);
+            target, target == nil ? nil : [target class]);
     return nil;
   }
 
-  UICollectionView *collection = (UICollectionView *) view;
+  UICollectionView *collection = (UICollectionView *) target;
 
   NSArray *arguments = self.arguments;
 

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
@@ -6,12 +6,6 @@
 
 @implementation LPCollectionViewScrollToItemOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"CollectionViewScrollToRow: %@",
-                                    _arguments];
-}
-
-
 //                 <===               required                ===>
 // _arguments ==> [item_num, section_num, scroll postion, animated]
 - (id) performWithTarget:(UIView *) aView error:(NSError *__autoreleasing*) aError {
@@ -32,14 +26,16 @@
 
   UICollectionView *collection = (UICollectionView *) aView;
 
-  if ([_arguments count] != 4) {
+  NSArray *arguments = self.arguments;
+
+  if ([arguments count] != 4) {
     NSLog(@"Warning:  required 4 args but found only '%@' - %@",
-            @([_arguments count]), _arguments);
+            @([arguments count]), arguments);
     return nil;
   }
 
-  NSInteger itemIndex = [[_arguments objectAtIndex:0] integerValue];
-  NSInteger section = [[_arguments objectAtIndex:1] integerValue];
+  NSInteger itemIndex = [[arguments objectAtIndex:0] integerValue];
+  NSInteger section = [[arguments objectAtIndex:1] integerValue];
 
   NSInteger numSections = [collection numberOfSections];
   if (section >= numSections) {
@@ -65,7 +61,7 @@
     @"right" : @(UICollectionViewScrollPositionRight)
     };
 
-  NSString *position = [_arguments objectAtIndex:2];
+  NSString *position = [arguments objectAtIndex:2];
 
   NSNumber *posNum = [opts objectForKey:position];
   if (posNum == nil) {
@@ -76,7 +72,7 @@
 
   UICollectionViewScrollPosition scrollPosition = [posNum unsignedIntegerValue];
 
-  NSNumber *animateNum = [_arguments objectAtIndex:3];
+  NSNumber *animateNum = [arguments objectAtIndex:3];
   BOOL animate = [animateNum boolValue];
 
   NSIndexPath *ip = [NSIndexPath indexPathForItem:itemIndex inSection:section];

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
@@ -8,7 +8,7 @@
 
 //                 <===               required                ===>
 // _arguments ==> [item_num, section_num, scroll postion, animated]
-- (id) performWithTarget:(UIView *) aView error:(NSError *__autoreleasing*) aError {
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
 
   // UICollectionView appears in iOS 6
   Class clz = NSClassFromString(@"UICollectionView");
@@ -18,13 +18,13 @@
     return nil;
   }
 
-  if ([aView isKindOfClass:[UICollectionView class]] == NO) {
+  if ([view isKindOfClass:[UICollectionView class]] == NO) {
     NSLog(@"Warning view: %@ should be an instance of UICollectionView but found '%@'",
-            aView, aView == nil ? nil : [aView class]);
+            view, view == nil ? nil : [view class]);
     return nil;
   }
 
-  UICollectionView *collection = (UICollectionView *) aView;
+  UICollectionView *collection = (UICollectionView *) view;
 
   NSArray *arguments = self.arguments;
 

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
@@ -38,7 +38,7 @@
 
 //                 required      optional     optional
 // _arguments ==> [item mark, scroll position, animated]
-- (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
   
   // UICollectionView appears in iOS 6
   Class clz = NSClassFromString(@"UICollectionView");
@@ -48,15 +48,15 @@
     return nil;
   }
 
-  if ([_view isKindOfClass:[UICollectionView class]] == NO) {
+  if ([view isKindOfClass:[UICollectionView class]] == NO) {
     NSLog(@"Warning view: %@ should be a collection view for scrolling to item/cell to make sense",
-          _view);
+          view);
     return nil;
   }
 
   NSArray *arguments = self.arguments;
 
-  UICollectionView *collection = (UICollectionView *) _view;  
+  UICollectionView *collection = (UICollectionView *) view;
   NSString *itemId = [arguments objectAtIndex:0];
   if (itemId == nil || [itemId length] == 0) {
     NSLog(@"Warning: item id: '%@' should be non-nil and non-empty", itemId);
@@ -114,7 +114,7 @@
     });
   }
 
-  return _view;
+  return view;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
@@ -38,7 +38,7 @@
 
 //                 required      optional     optional
 // _arguments ==> [item mark, scroll position, animated]
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
   
   // UICollectionView appears in iOS 6
   Class clz = NSClassFromString(@"UICollectionView");
@@ -48,15 +48,15 @@
     return nil;
   }
 
-  if ([view isKindOfClass:[UICollectionView class]] == NO) {
+  if ([target isKindOfClass:[UICollectionView class]] == NO) {
     NSLog(@"Warning view: %@ should be a collection view for scrolling to item/cell to make sense",
-          view);
+          target);
     return nil;
   }
 
   NSArray *arguments = self.arguments;
 
-  UICollectionView *collection = (UICollectionView *) view;
+  UICollectionView *collection = (UICollectionView *) target;
   NSString *itemId = [arguments objectAtIndex:0];
   if (itemId == nil || [itemId length] == 0) {
     NSLog(@"Warning: item id: '%@' should be non-nil and non-empty", itemId);
@@ -114,7 +114,7 @@
     });
   }
 
-  return view;
+  return target;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
@@ -14,11 +14,6 @@
 
 @implementation LPCollectionViewScrollToItemWithMarkOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"CollectionViewScrollToItem: %@",
-          _arguments];
-}
-
 - (NSIndexPath *) indexPathForItemWithMark:(NSString *) aMark inCollection:(UICollectionView *) aCollection {
   NSUInteger numberOfSections = [aCollection numberOfSections];
   for (NSUInteger section = 0; section < numberOfSections; section++) {
@@ -58,9 +53,11 @@
           _view);
     return nil;
   }
-  
+
+  NSArray *arguments = self.arguments;
+
   UICollectionView *collection = (UICollectionView *) _view;  
-  NSString *itemId = [_arguments objectAtIndex:0];
+  NSString *itemId = [arguments objectAtIndex:0];
   if (itemId == nil || [itemId length] == 0) {
     NSLog(@"Warning: item id: '%@' should be non-nil and non-empty", itemId);
     return nil;
@@ -76,8 +73,8 @@
   BOOL animate = YES;
   
   
-  if ([_arguments count] > 1) {
-    NSString *position = [_arguments objectAtIndex:1];
+  if ([arguments count] > 1) {
+    NSString *position = [arguments objectAtIndex:1];
     
     NSDictionary *opts =
     @{
@@ -100,8 +97,8 @@
     scrollPosition = [posNum unsignedIntegerValue];
   }
   
-  if ([_arguments count] > 2) {
-    NSNumber *ani = [_arguments objectAtIndex:2];
+  if ([arguments count] > 2) {
+    NSNumber *ani = [arguments objectAtIndex:2];
     animate = [ani boolValue];
   }
 

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -15,15 +15,15 @@
 
 //                        required =========> |     optional
 // _arguments ==> [target date str, format str, notify targets, animated]
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
-  if ([view isKindOfClass:[UIDatePicker class]] == NO) {
-    NSLog(@"Warning view: %@ should be a date picker", view);
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
+  if ([target isKindOfClass:[UIDatePicker class]] == NO) {
+    NSLog(@"Warning view: %@ should be a date picker", target);
     return nil;
   }
 
   NSArray *arguments = self.arguments;
 
-  UIDatePicker *picker = (UIDatePicker *) view;
+  UIDatePicker *picker = (UIDatePicker *) target;
 
   NSString *dateStr = arguments[0];
   if (dateStr == nil || [dateStr length] == 0) {
@@ -91,7 +91,7 @@
     }
   }
 
-  return view;
+  return target;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -15,15 +15,15 @@
 
 //                        required =========> |     optional
 // _arguments ==> [target date str, format str, notify targets, animated]
-- (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
-  if ([_view isKindOfClass:[UIDatePicker class]] == NO) {
-    NSLog(@"Warning view: %@ should be a date picker", _view);
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+  if ([view isKindOfClass:[UIDatePicker class]] == NO) {
+    NSLog(@"Warning view: %@ should be a date picker", view);
     return nil;
   }
 
   NSArray *arguments = self.arguments;
 
-  UIDatePicker *picker = (UIDatePicker *) _view;
+  UIDatePicker *picker = (UIDatePicker *) view;
 
   NSString *dateStr = arguments[0];
   if (dateStr == nil || [dateStr length] == 0) {
@@ -91,7 +91,7 @@
     }
   }
 
-  return _view;
+  return view;
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -6,10 +6,6 @@
 
 @implementation LPDatePickerOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"DatePicker: %@", _arguments];
-}
-
 /*
  args << options[:is_timer] || false
  args << options[:notify_targets] || true
@@ -25,19 +21,21 @@
     return nil;
   }
 
+  NSArray *arguments = self.arguments;
+
   UIDatePicker *picker = (UIDatePicker *) _view;
 
-  NSString *dateStr = _arguments[0];
+  NSString *dateStr = arguments[0];
   if (dateStr == nil || [dateStr length] == 0) {
     NSLog(@"Warning: date str: '%@' should be non-nil and non-empty", dateStr);
     return nil;
   }
 
-  NSUInteger argcount = [_arguments count];
+  NSUInteger argcount = [arguments count];
 
   NSString *dateFormat = nil;
   if (argcount > 1) {
-    dateFormat = _arguments[1];
+    dateFormat = arguments[1];
   } else {
     NSLog(@"Warning: date format is required as the second argument");
     return nil;
@@ -46,12 +44,12 @@
 
   BOOL notifyTargets = YES;
   if (argcount > 2) {
-    notifyTargets = [_arguments[2] boolValue];
+    notifyTargets = [arguments[2] boolValue];
   }
 
   BOOL animate = YES;
   if (argcount > 3) {
-    animate = [_arguments[3] boolValue];
+    animate = [arguments[3] boolValue];
   }
 
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];

--- a/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
@@ -15,10 +15,6 @@
 
 @implementation LPFlashOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Flash: %@", _arguments];
-}
-
 - (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
 
   if ([[NSThread currentThread] isMainThread]) {

--- a/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
@@ -15,16 +15,16 @@
 
 @implementation LPFlashOperation
 
-- (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
 
   if ([[NSThread currentThread] isMainThread]) {
-    [LPTouchUtils flashView:_view forDuration:2];
+    [LPTouchUtils flashView:view forDuration:2];
   } else {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      [LPTouchUtils flashView:_view forDuration:2];
+      [LPTouchUtils flashView:view forDuration:2];
     });
   }
-  return [LPJSONUtils jsonifyObject:_view];
+  return [LPJSONUtils jsonifyObject:view];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
@@ -15,16 +15,16 @@
 
 @implementation LPFlashOperation
 
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
 
   if ([[NSThread currentThread] isMainThread]) {
-    [LPTouchUtils flashView:view forDuration:2];
+    [LPTouchUtils flashView:target forDuration:2];
   } else {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      [LPTouchUtils flashView:view forDuration:2];
+      [LPTouchUtils flashView:target forDuration:2];
     });
   }
-  return [LPJSONUtils jsonifyObject:view];
+  return [LPJSONUtils jsonifyObject:target];
 }
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.h
@@ -19,6 +19,6 @@
 
 - (id) initWithOperation:(NSDictionary *) operation;
 
-- (id) performWithTarget:(UIView *) view error:(NSError **) error;
+- (id) performWithTarget:(id) target error:(NSError **) error;
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.h
@@ -12,6 +12,11 @@
   NSArray *_arguments;
   BOOL _done;
 }
+
+@property(nonatomic, assign, readonly) SEL selector;
+@property(nonatomic, copy, readonly) NSArray *arguments;
+@property(nonatomic, assign) BOOL done;
+
 + (id) operationFromDictionary:(NSDictionary *) dictionary;
 
 + (NSArray *) performQuery:(id) query;

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.h
@@ -7,11 +7,7 @@
 #import <Foundation/Foundation.h>
 #import "UIScriptParser.h"
 
-@interface LPOperation : NSObject {
-  SEL _selector;
-  NSArray *_arguments;
-  BOOL _done;
-}
+@interface LPOperation : NSObject
 
 @property(nonatomic, assign, readonly) SEL selector;
 @property(nonatomic, copy, readonly) NSArray *arguments;

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -106,8 +106,8 @@
   return result;
 }
 
-- (id) performWithTarget:(UIView *) target error:(NSError **) error {
-  NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
+- (id) performWithTarget:(UIView *) view error:(NSError **) error {
+  NSMethodSignature *tSig = [view methodSignatureForSelector:_selector];
   NSUInteger argc = tSig.numberOfArguments - 2;
   if (argc != [_arguments count] && *error != NULL) {
     *error = [NSError errorWithDomain:@"CalabashServer" code:1
@@ -129,7 +129,7 @@
     [invocation setArgument:&arg atIndex:index++];
   }
 
-  [invocation invokeWithTarget:target];
+  [invocation invokeWithTarget:view];
 
 
   const char *returnType = tSig.methodReturnType;

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -20,15 +20,15 @@
 
 @interface LPOperation ()
 
-- (NSArray *) arguments;
-
 @end
 
 @implementation LPOperation
 
-- (NSArray *) arguments {
-  return _arguments;
-}
+#pragma mark - Memory Management
+
+@synthesize selector = _selector;
+@synthesize arguments = _arguments;
+@synthesize done = _done;
 
 + (id) operationFromDictionary:(NSDictionary *) dictionary {
   NSString *opName = [dictionary valueForKey:@"method_name"];
@@ -90,6 +90,7 @@
   if (self != nil) {
     _selector = NSSelectorFromString([operation objectForKey:@"method_name"]);
     _arguments = [[operation objectForKey:@"arguments"] retain];
+    _done = NO;
   }
   return self;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -30,6 +30,22 @@
 @synthesize arguments = _arguments;
 @synthesize done = _done;
 
+- (void) dealloc {
+  [_arguments release];
+  _arguments = nil;
+  [super dealloc];
+}
+
+- (id) initWithOperation:(NSDictionary *) operation {
+  self = [super init];
+  if (self != nil) {
+    _selector = NSSelectorFromString([operation objectForKey:@"method_name"]);
+    _arguments = [[operation objectForKey:@"arguments"] retain];
+    _done = NO;
+  }
+  return self;
+}
+
 + (id) operationFromDictionary:(NSDictionary *) dictionary {
   NSString *opName = [dictionary valueForKey:@"method_name"];
   LPOperation *op = nil;
@@ -84,31 +100,11 @@
   return result;
 }
 
-
-- (id) initWithOperation:(NSDictionary *) operation {
-  self = [super init];
-  if (self != nil) {
-    _selector = NSSelectorFromString([operation objectForKey:@"method_name"]);
-    _arguments = [[operation objectForKey:@"arguments"] retain];
-    _done = NO;
-  }
-  return self;
-}
-
-
-- (void) dealloc {
-  [_arguments release];
-  _arguments = nil;
-  [super dealloc];
-}
-
-
 - (NSString *) description {
   return [NSString stringWithFormat:@"Operation<SEL=%@,Args=%@>",
                                     NSStringFromSelector(_selector),
                                     _arguments];
 }
-
 
 - (id) performWithTarget:(UIView *) target error:(NSError **) error {
   NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -106,8 +106,8 @@
   return result;
 }
 
-- (id) performWithTarget:(UIView *) view error:(NSError **) error {
-  NSMethodSignature *tSig = [view methodSignatureForSelector:_selector];
+- (id) performWithTarget:(id) target error:(NSError **) error {
+  NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
   NSUInteger argc = tSig.numberOfArguments - 2;
   if (argc != [_arguments count] && *error != NULL) {
     *error = [NSError errorWithDomain:@"CalabashServer" code:1
@@ -129,7 +129,7 @@
     [invocation setArgument:&arg atIndex:index++];
   }
 
-  [invocation invokeWithTarget:view];
+  [invocation invokeWithTarget:target];
 
 
   const char *returnType = tSig.methodReturnType;

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -80,6 +80,12 @@
   return [op autorelease];
 }
 
+- (NSString *) description {
+  NSString *className = NSStringFromClass([self class]);
+  return [NSString stringWithFormat:@"<%@ '%@' with arguments '%@'>",
+          className, NSStringFromSelector(_selector),
+          [_arguments componentsJoinedByString:@", "]];
+}
 
 + (NSArray *) performQuery:(id) query {
   UIScriptParser *parser = nil;
@@ -98,12 +104,6 @@
   [parser release];
 
   return result;
-}
-
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Operation<SEL=%@,Args=%@>",
-                                    NSStringFromSelector(_selector),
-                                    _arguments];
 }
 
 - (id) performWithTarget:(UIView *) target error:(NSError **) error {

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -106,6 +106,9 @@
   return result;
 }
 
+// map("textField", :delegate) will call this method because the :delegate
+// key does not map to a known operation (see operationFromDictionary:).
+// This method has problems. :(
 - (id) performWithTarget:(id) target error:(NSError **) error {
   NSMethodSignature *tSig = [target methodSignatureForSelector:_selector];
   NSUInteger argc = tSig.numberOfArguments - 2;

--- a/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
@@ -19,11 +19,6 @@ static NSString *const kFaceUp = @"face up";
 
 @implementation LPOrientationOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Orientation: %@", _arguments];
-}
-
-
 + (NSString *) deviceOrientation {
 
   [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
@@ -94,7 +89,9 @@ static NSString *const kFaceUp = @"face up";
 // _arguments ==> {'device' | 'status_bar'}
 - (id) performWithTarget:(UIView *) view error:(NSError **) error {
 
-  NSUInteger argCount = [_arguments count];
+  NSArray *argument = self.arguments;
+
+  NSUInteger argCount = [argument count];
   if (argCount == 0) {
     NSLog(@"Warning: requires exactly one argument: {'%@' | '%@'} found none",
             kDevice, kStatusBar);
@@ -103,11 +100,11 @@ static NSString *const kFaceUp = @"face up";
 
   if (argCount > 1) {
     NSLog(@"Warning: argument should be {'%@' | '%@'} - found '[%@']", kDevice,
-            kStatusBar, [_arguments componentsJoinedByString:@", "]);
+            kStatusBar, [argument componentsJoinedByString:@", "]);
     return nil;
   }
 
-  NSString *firstArg = [_arguments objectAtIndex:0];
+  NSString *firstArg = [argument objectAtIndex:0];
   if ([@[kDevice, kStatusBar] containsObject:firstArg] == NO) {
     NSLog(@"Warning: argument should be {'%@' | '%@'} - found '%@'", kDevice,
             kStatusBar, firstArg);
@@ -119,7 +116,7 @@ static NSString *const kFaceUp = @"face up";
     return [LPOrientationOperation statusBarOrientation];
   } else {
     NSLog(@"Warning: fell through conditions for arguments: '[%@]'",
-            [_arguments componentsJoinedByString:@", "]);
+            [argument componentsJoinedByString:@", "]);
     return nil;
   }
 }

--- a/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOrientationOperation.m
@@ -87,7 +87,7 @@ static NSString *const kFaceUp = @"face up";
 
 
 // _arguments ==> {'device' | 'status_bar'}
-- (id) performWithTarget:(UIView *) view error:(NSError **) error {
+- (id) performWithTarget:(id) target error:(NSError **) error {
 
   NSArray *argument = self.arguments;
 

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -67,13 +67,12 @@
 }
 
 
-- (id) performWithTarget:(UIView *) view error:(NSError **) error {
-  id target = view;
+- (id) performWithTarget:(id) target error:(NSError **) error {
 
   NSArray *arguments = self.arguments;
 
   if ([arguments count] <= 0) {
-    return [LPJSONUtils jsonifyObject:view];
+    return [LPJSONUtils jsonifyObject:target];
   }
   for (NSInteger i = 0; i < [arguments count]; i++) {
     id selObj = [arguments objectAtIndex:i];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -67,13 +67,13 @@
 }
 
 
-- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
-  id target = _view;
+- (id) performWithTarget:(UIView *) view error:(NSError **) error {
+  id target = view;
 
   NSArray *arguments = self.arguments;
 
   if ([arguments count] <= 0) {
-    return [LPJSONUtils jsonifyObject:_view];
+    return [LPJSONUtils jsonifyObject:view];
   }
   for (NSInteger i = 0; i < [arguments count]; i++) {
     id selObj = [arguments objectAtIndex:i];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryAllOperation.m
@@ -9,9 +9,6 @@
 #import "LPCocoaLumberjack.h"
 
 @implementation LPQueryAllOperation
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Query All: %@", _arguments];
-}
 
 - (SEL) parseValuesFromArray:(NSArray *) arr withArgs:(NSMutableArray *) args {
   NSMutableString *selStr = [NSMutableString stringWithCapacity:32];
@@ -73,11 +70,13 @@
 - (id) performWithTarget:(UIView *) _view error:(NSError **) error {
   id target = _view;
 
-  if ([_arguments count] <= 0) {
+  NSArray *arguments = self.arguments;
+
+  if ([arguments count] <= 0) {
     return [LPJSONUtils jsonifyObject:_view];
   }
-  for (NSInteger i = 0; i < [_arguments count]; i++) {
-    id selObj = [_arguments objectAtIndex:i];
+  for (NSInteger i = 0; i < [arguments count]; i++) {
+    id selObj = [arguments objectAtIndex:i];
     id objValue;
     int intValue;
     unsigned int uintValue;
@@ -132,7 +131,7 @@
         if (objValue == nil) {
           return nil;
         } else {
-          if (i == [_arguments count] - 1) {
+          if (i == [arguments count] - 1) {
             return [LPJSONUtils jsonifyObject:objValue];
           } else {
             target = objValue;

--- a/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
@@ -8,10 +8,6 @@
 
 
 @implementation LPQueryOperation
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Query: %@", _arguments];
-}
-
 
 - (id) performWithTarget:(UIView *) _view error:(NSError **) error {
   return [super performWithTarget:_view error:error];

--- a/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
@@ -9,8 +9,8 @@
 
 @implementation LPQueryOperation
 
-- (id) performWithTarget:(UIView *) _view error:(NSError **) error {
-  return [super performWithTarget:_view error:error];
+- (id) performWithTarget:(UIView *) view error:(NSError **) error {
+  return [super performWithTarget:view error:error];
 }
 
 

--- a/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPQueryOperation.m
@@ -9,9 +9,8 @@
 
 @implementation LPQueryOperation
 
-- (id) performWithTarget:(UIView *) view error:(NSError **) error {
-  return [super performWithTarget:view error:error];
+- (id) performWithTarget:(id) target error:(NSError **) error {
+  return [super performWithTarget:target error:error];
 }
-
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -15,13 +15,10 @@
 #import "LPCocoaLumberjack.h"
 
 @implementation LPScrollOperation
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Scroll: %@", _arguments];
-}
-
 
 - (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
-  NSString *dir = [_arguments objectAtIndex:0];
+
+  NSString *dir = [self.arguments objectAtIndex:0];
 
   NSArray *allowedDirections = @[@"up", @"down", @"left", @"right"];
   NSUInteger index = [allowedDirections indexOfObject:dir];

--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -16,7 +16,7 @@
 
 @implementation LPScrollOperation
 
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
 
   NSString *dir = [self.arguments objectAtIndex:0];
 
@@ -33,8 +33,8 @@
     return nil;
   }
 
-  if ([view isKindOfClass:[UIScrollView class]]) {
-    UIScrollView *sv = (UIScrollView *) view;
+  if ([target isKindOfClass:[UIScrollView class]]) {
+    UIScrollView *sv = (UIScrollView *) target;
     CGSize size = sv.bounds.size;
     CGPoint offset = sv.contentOffset;
     CGFloat fraction = 2.0;
@@ -66,9 +66,9 @@
       });
     }
 
-    return view;
-  } else if ([LPIsWebView isWebView:view]) {
-    UIView<LPWebViewProtocol> *webView = (UIView<LPWebViewProtocol> *)view;
+    return target;
+  } else if ([LPIsWebView isWebView:target]) {
+    UIView<LPWebViewProtocol> *webView = (UIView<LPWebViewProtocol> *)target;
     NSString *scrollJS = @"window.scrollBy(%@,%@);";
     if ([@"up" isEqualToString:dir]) {
       scrollJS = [NSString stringWithFormat:scrollJS, @"0", @"-100"];
@@ -81,7 +81,7 @@
     }
     NSString *res = [webView calabashStringByEvaluatingJavaScript:scrollJS];
     NSLog(@"RES:%@", res);
-    return view;
+    return target;
   }
   return nil;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -16,7 +16,7 @@
 
 @implementation LPScrollOperation
 
-- (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
 
   NSString *dir = [self.arguments objectAtIndex:0];
 
@@ -33,8 +33,8 @@
     return nil;
   }
 
-  if ([_view isKindOfClass:[UIScrollView class]]) {
-    UIScrollView *sv = (UIScrollView *) _view;
+  if ([view isKindOfClass:[UIScrollView class]]) {
+    UIScrollView *sv = (UIScrollView *) view;
     CGSize size = sv.bounds.size;
     CGPoint offset = sv.contentOffset;
     CGFloat fraction = 2.0;
@@ -66,9 +66,9 @@
       });
     }
 
-    return _view;
-  } else if ([LPIsWebView isWebView:_view]) {
-    UIView<LPWebViewProtocol> *webView = (UIView<LPWebViewProtocol> *)_view;
+    return view;
+  } else if ([LPIsWebView isWebView:view]) {
+    UIView<LPWebViewProtocol> *webView = (UIView<LPWebViewProtocol> *)view;
     NSString *scrollJS = @"window.scrollBy(%@,%@);";
     if ([@"up" isEqualToString:dir]) {
       scrollJS = [NSString stringWithFormat:scrollJS, @"0", @"-100"];
@@ -81,7 +81,7 @@
     }
     NSString *res = [webView calabashStringByEvaluatingJavaScript:scrollJS];
     NSLog(@"RES:%@", res);
-    return _view;
+    return view;
   }
   return nil;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
@@ -29,11 +29,11 @@
 }
 
 
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
   NSArray *arguments = self.arguments;
 
-  if ([view isKindOfClass:[UITableView class]]) {
-    UITableView *table = (UITableView *) view;
+  if ([target isKindOfClass:[UITableView class]]) {
+    UITableView *table = (UITableView *) target;
     NSNumber *rowNum = [arguments objectAtIndex:0];
     if ([arguments count] >= 2) {
       NSInteger row = [rowNum integerValue];
@@ -70,7 +70,7 @@
                                  animated:animate];
           });
         }
-        return view;
+        return target;
       } else {
         NSLog(@"Warning: table doesn't contain indexPath: %@", path);
         return nil;
@@ -93,12 +93,12 @@
                                animated:YES];
         });
       }
-      return view;
+      return target;
     }
   }
 
   NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",
-          view);
+          target);
   return nil;
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
@@ -14,11 +14,6 @@
 
 @implementation LPScrollToRowOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"ScrollToRow: %@", _arguments];
-}
-
-
 - (NSIndexPath *) indexPathForRow:(NSUInteger) row inTable:(UITableView *) table {
   NSInteger numberOfSections = [table numberOfSections];
   NSInteger i = 0;
@@ -35,19 +30,21 @@
 
 
 - (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
+  NSArray *arguments = self.arguments;
+
   if ([_view isKindOfClass:[UITableView class]]) {
     UITableView *table = (UITableView *) _view;
-    NSNumber *rowNum = [_arguments objectAtIndex:0];
-    if ([_arguments count] >= 2) {
+    NSNumber *rowNum = [arguments objectAtIndex:0];
+    if ([arguments count] >= 2) {
       NSInteger row = [rowNum integerValue];
-      NSInteger sec = [[_arguments objectAtIndex:1] integerValue];
+      NSInteger sec = [[arguments objectAtIndex:1] integerValue];
       NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:sec];
 
       if ((sec >= 0 && sec < [table numberOfSections]) && (row >= 0 && row < [table numberOfRowsInSection:sec])) {
         UITableViewScrollPosition sp = UITableViewScrollPositionTop;
         BOOL animate = YES;
-        if ([_arguments count] >= 3) {
-          NSString *pos = [_arguments objectAtIndex:2];
+        if ([arguments count] >= 3) {
+          NSString *pos = [arguments objectAtIndex:2];
           if ([@"middle" isEqualToString:pos]) {
             sp = UITableViewScrollPositionMiddle;
           } else if ([@"bottom" isEqualToString:pos]) {
@@ -56,8 +53,8 @@
             sp = UITableViewScrollPositionNone;
           }
         }
-        if ([_arguments count] >= 4) {
-          NSNumber *ani = [_arguments objectAtIndex:3];
+        if ([arguments count] >= 4) {
+          NSNumber *ani = [arguments objectAtIndex:3];
           animate = [ani boolValue];
         }
 

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
@@ -29,11 +29,11 @@
 }
 
 
-- (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
   NSArray *arguments = self.arguments;
 
-  if ([_view isKindOfClass:[UITableView class]]) {
-    UITableView *table = (UITableView *) _view;
+  if ([view isKindOfClass:[UITableView class]]) {
+    UITableView *table = (UITableView *) view;
     NSNumber *rowNum = [arguments objectAtIndex:0];
     if ([arguments count] >= 2) {
       NSInteger row = [rowNum integerValue];
@@ -70,7 +70,7 @@
                                  animated:animate];
           });
         }
-        return _view;
+        return view;
       } else {
         NSLog(@"Warning: table doesn't contain indexPath: %@", path);
         return nil;
@@ -93,12 +93,12 @@
                                animated:YES];
         });
       }
-      return _view;
+      return view;
     }
   }
 
   NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",
-          _view);
+          view);
   return nil;
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -39,16 +39,16 @@
 
 //                 required      optional     optional
 // _arguments ==> [row mark, scroll position, animated]
-- (id) performWithTarget:(UIView *) _view error:(NSError *__autoreleasing*) error {
-  if ([_view isKindOfClass:[UITableView class]] == NO) {
+- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
+  if ([view isKindOfClass:[UITableView class]] == NO) {
     NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",
-            _view);
+            view);
     return nil;
   }
 
   NSArray *arguments = self.arguments;
 
-  UITableView *table = (UITableView *) _view;
+  UITableView *table = (UITableView *) view;
   NSString *rowId = [arguments objectAtIndex:0];
   if (rowId == nil || [rowId length] == 0) {
     NSLog(@"Warning: row id: '%@' should be non-nil and non-empty", rowId);
@@ -89,6 +89,6 @@
     });
   }
 
-  return _view;
+  return view;
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -39,16 +39,16 @@
 
 //                 required      optional     optional
 // _arguments ==> [row mark, scroll position, animated]
-- (id) performWithTarget:(UIView *) view error:(NSError *__autoreleasing*) error {
-  if ([view isKindOfClass:[UITableView class]] == NO) {
+- (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
+  if ([target isKindOfClass:[UITableView class]] == NO) {
     NSLog(@"Warning view: %@ should be a table view for scrolling to row/cell to make sense",
-            view);
+            target);
     return nil;
   }
 
   NSArray *arguments = self.arguments;
 
-  UITableView *table = (UITableView *) view;
+  UITableView *table = (UITableView *) target;
   NSString *rowId = [arguments objectAtIndex:0];
   if (rowId == nil || [rowId length] == 0) {
     NSLog(@"Warning: row id: '%@' should be non-nil and non-empty", rowId);
@@ -89,6 +89,6 @@
     });
   }
 
-  return view;
+  return target;
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -6,10 +6,6 @@
 
 @implementation LPScrollToRowWithMarkOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"ScrollToRow: %@", _arguments];
-}
-
 - (BOOL) cell:(UITableViewCell *) aCell contentViewHasSubviewMarked:(NSString *) aMark {
   // check the textLabel first
   if ([self view:aCell.textLabel hasMark:aMark]) {return YES;}
@@ -50,8 +46,10 @@
     return nil;
   }
 
+  NSArray *arguments = self.arguments;
+
   UITableView *table = (UITableView *) _view;
-  NSString *rowId = [_arguments objectAtIndex:0];
+  NSString *rowId = [arguments objectAtIndex:0];
   if (rowId == nil || [rowId length] == 0) {
     NSLog(@"Warning: row id: '%@' should be non-nil and non-empty", rowId);
     return nil;
@@ -67,8 +65,8 @@
   BOOL animate = YES;
 
 
-  if ([_arguments count] > 1) {
-    NSString *scrollPositionArg = [_arguments objectAtIndex:1];
+  if ([arguments count] > 1) {
+    NSString *scrollPositionArg = [arguments objectAtIndex:1];
     if ([@"middle" isEqualToString:scrollPositionArg]) {
       sp = UITableViewScrollPositionMiddle;
     } else if ([@"bottom" isEqualToString:scrollPositionArg]) {
@@ -78,8 +76,8 @@
     }
   }
 
-  if ([_arguments count] > 2) {
-    NSNumber *ani = [_arguments objectAtIndex:2];
+  if ([arguments count] > 2) {
+    NSNumber *ani = [arguments objectAtIndex:2];
     animate = [ani boolValue];
   }
 

--- a/calabash/Classes/FranklyServer/Operations/LPSetTextOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSetTextOperation.m
@@ -16,9 +16,6 @@
 @end
 
 @implementation LPSetTextOperation
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Text: %@", _arguments];
-}
 
 - (NSString *) stringValueForArgument:(id) argument {
   if ([argument isKindOfClass:[NSString class]]) {
@@ -31,7 +28,8 @@
 }
 
 - (id) performWithTarget:(id) target error:(NSError * __autoreleasing *) error {
-  if (!_arguments || [_arguments count] == 0) {
+  NSArray *arguments = self.arguments;
+  if (!arguments || [arguments count] == 0) {
     NSLog(@"Missing the 'text' argument @ index 0 of arguments; nothing to do - returning nil");
     return nil;
   }
@@ -59,14 +57,14 @@
     }
 
     UIView<LPWebViewProtocol> *webView = (UIView<LPWebViewProtocol> *)webViewValue;
-    NSString *text = [self stringValueForArgument:[_arguments objectAtIndex:0]];
+    NSString *text = [self stringValueForArgument:[arguments objectAtIndex:0]];
     NSString *javascript = [NSString stringWithFormat:LP_SET_TEXT_JS,
                             json, text];
     return [webView calabashStringByEvaluatingJavaScript:javascript];
   }
 
   if ([target respondsToSelector:@selector(setText:)]) {
-    NSString *text = [self stringValueForArgument:[_arguments objectAtIndex:0]];
+    NSString *text = [self stringValueForArgument:[arguments objectAtIndex:0]];
     [target performSelector:@selector(setText:) withObject:text];
     return target;
   }

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -7,15 +7,10 @@
 
 @implementation LPSliderOperation
 
-- (NSString *) description {
-  return [NSString stringWithFormat:@"Slider: %@", _arguments];
-}
-
 /*
  args << options[:notify_targets] || true
  args << options[:animate] || true
  */
-
 
 //    required =========> |     optional
 // _arguments ==> [value_st,  notify targets, animate]
@@ -27,7 +22,9 @@
 
   UISlider *slider = (UISlider *) _view;
 
-  NSString *valueStr = _arguments[0];
+  NSArray *arguments = self.arguments;
+
+  NSString *valueStr = arguments[0];
   if (valueStr == nil || [valueStr length] == 0) {
     NSLog(@"Warning: value str: '%@' should be non-nil and non-empty",
             valueStr);
@@ -36,16 +33,16 @@
 
   CGFloat targetValue = [valueStr floatValue];
 
-  NSUInteger argcount = [_arguments count];
+  NSUInteger argcount = [arguments count];
 
   BOOL notifyTargets = YES;
   if (argcount > 1) {
-    notifyTargets = [_arguments[1] boolValue];
+    notifyTargets = [arguments[1] boolValue];
   }
 
   BOOL animate = YES;
   if (argcount > 2) {
-    animate = [_arguments[2] boolValue];
+    animate = [arguments[2] boolValue];
   }
 
   if (targetValue > [slider maximumValue]) {

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -12,15 +12,15 @@
  args << options[:animate] || true
  */
 
-//    required =========> |     optional
-// _arguments ==> [value_st,  notify targets, animate]
-- (id) performWithTarget:(UIView *) view error:(NSError * __autoreleasing *) error {
-  if ([view isKindOfClass:[UISlider class]] == NO) {
-    NSLog(@"Warning view: %@ should be a UISlier", view);
+//    required ===========> |     optional
+//  _arguments => [value_str,  notify targets, animate]
+- (id) performWithTarget:(id) target error:(NSError * __autoreleasing *) error {
+  if ([target isKindOfClass:[UISlider class]] == NO) {
+    NSLog(@"Warning view: %@ should be a UISlier", target);
     return nil;
   }
 
-  UISlider *slider = (UISlider *) view;
+  UISlider *slider = (UISlider *) target;
 
   NSArray *arguments = self.arguments;
 
@@ -69,6 +69,6 @@
   }
 
 
-  return [LPJSONUtils jsonifyObject:view];
+  return [LPJSONUtils jsonifyObject:target];
 }
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -14,13 +14,13 @@
 
 //    required =========> |     optional
 // _arguments ==> [value_st,  notify targets, animate]
-- (id) performWithTarget:(UIView *) _view error:(NSError * __autoreleasing *) error {
-  if ([_view isKindOfClass:[UISlider class]] == NO) {
-    NSLog(@"Warning view: %@ should be a UISlier", _view);
+- (id) performWithTarget:(UIView *) view error:(NSError * __autoreleasing *) error {
+  if ([view isKindOfClass:[UISlider class]] == NO) {
+    NSLog(@"Warning view: %@ should be a UISlier", view);
     return nil;
   }
 
-  UISlider *slider = (UISlider *) _view;
+  UISlider *slider = (UISlider *) view;
 
   NSArray *arguments = self.arguments;
 
@@ -69,6 +69,6 @@
   }
 
 
-  return [LPJSONUtils jsonifyObject:_view];
+  return [LPJSONUtils jsonifyObject:view];
 }
 @end

--- a/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPMapRoute.m
@@ -101,6 +101,13 @@
   } else {
     for (id view in views) {
       NSError *err = nil;
+      // TODO: Do nothing on error?
+      //
+      // It is hard to capture the error with the current method signature
+      // because nil is a valid response. How would you know if there was an
+      // error?
+      //
+      // What should be done if one view generates and another does not?
       id val = [op performWithTarget:view error:&err];
       if (err) {continue;}
       if (val == nil) {


### PR DESCRIPTION
### Motivation

* Replaced _ ivars with properties.
* Fixed bizarre _view method argument
* performWithTarget:(UIView *) => performWithTarget:(id) because this is method is often called with non-view objects.
* Organized the code.
* Clarifying code comments about when [LPOperation performWithTarget:] is actually called.

Discovered several cases where performWithTarget: will crash the app.  Deferring fixes until later.
