### PR TITLE
Clean up LPOperation performWithTarget:error:

### DIFF
--- a/XCTest/Tests/Operations/LPOperationTest.m
+++ b/XCTest/Tests/Operations/LPOperationTest.m
@@ -30,4 +30,32 @@
   expect(actual).to.equal(expected);
 }
 
+- (void) testPerformSelectorNoArguments {
+  NSDictionary *dictionary = @{@"method_name" : @"length",
+                               @"arguments" : @[]};
+
+  LPOperation *operation = [[LPOperation alloc] initWithOperation:dictionary];
+  NSError *error = nil;
+  id actual = [operation performWithTarget:@"string" error:&error];
+
+  expect(actual).to.equal(@(@"string".length));
+  expect(error).to.equal(nil);
+}
+
+- (void) testPerformSelectorOneArgument {
+  NSDictionary *dictionary = @{@"method_name" : @"addObject:",
+                               @"arguments" : @[@"arg!"]};
+
+  LPOperation *operation = [[LPOperation alloc] initWithOperation:dictionary];
+  NSError *error = nil;
+
+  NSMutableArray *array = [@[] mutableCopy];
+  id actual = [operation performWithTarget:array error:&error];
+
+  //expect(actual).to.equal(@(@"string".length));
+  expect(error).to.equal(nil);
+  expect(actual).to.equal(@"<VOID>");
+  expect(array[0]).to.equal(@"arg!");
+}
+
 @end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		B15BF9B119ABB1DD00B38577 /* LPOrientationOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F591380317C39128007B2BE4 /* LPOrientationOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9B219ABB1DD00B38577 /* LPFlashOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B19440431725C70A00EE1B25 /* LPFlashOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9B319ABB1DD00B38577 /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
-		B15BF9B419ABB1DD00B38577 /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; };
+		B15BF9B419ABB1DD00B38577 /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9B519ABB1DD00B38577 /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
 		B15BF9B619ABB1DD00B38577 /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9B719ABB1DD00B38577 /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -124,7 +124,7 @@
 		B1D5BD8819A23BCE0070E8CE /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8919A23BCE0070E8CE /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; };
 		B1D5BD8A19A23BCE0070E8CE /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
-		B1D5BD8B19A23BCE0070E8CE /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; };
+		B1D5BD8B19A23BCE0070E8CE /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8C19A23BCE0070E8CE /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
 		B1D5BD8D19A23BCE0070E8CE /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8E19A23BCE0070E8CE /* LPUIATapRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B164575518FDCE4900CAA25A /* LPUIATapRoute.m */; };
@@ -227,7 +227,7 @@
 		F5091BEB18C4E1D700C85307 /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BEC18C4E1D700C85307 /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; };
 		F5091BED18C4E1D700C85307 /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
-		F5091BEE18C4E1D700C85307 /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; };
+		F5091BEE18C4E1D700C85307 /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BEF18C4E1D700C85307 /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
 		F5091BF018C4E1D700C85307 /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BF118C4E1D700C85307 /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -311,7 +311,7 @@
 		F50CBF941A04058C004AC9DA /* LPOrientationOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F591380317C39128007B2BE4 /* LPOrientationOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF951A04058C004AC9DA /* LPFlashOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B19440431725C70A00EE1B25 /* LPFlashOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF961A04058C004AC9DA /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
-		F50CBF971A04058C004AC9DA /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; };
+		F50CBF971A04058C004AC9DA /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF981A04058C004AC9DA /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
 		F50CBF991A04058C004AC9DA /* LPScrollOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC714B6DB2B002A744C /* LPScrollOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF9A1A04058C004AC9DA /* LPScrollToRowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC914B6DB2B002A744C /* LPScrollToRowOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -1,3 +1,7 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 //
 //  Operation.m
 //  Created by Karl Krukow on 14/08/11.
@@ -30,17 +34,11 @@
 @synthesize arguments = _arguments;
 @synthesize done = _done;
 
-- (void) dealloc {
-  [_arguments release];
-  _arguments = nil;
-  [super dealloc];
-}
-
 - (id) initWithOperation:(NSDictionary *) operation {
   self = [super init];
   if (self != nil) {
     _selector = NSSelectorFromString([operation objectForKey:@"method_name"]);
-    _arguments = [[operation objectForKey:@"arguments"] retain];
+    _arguments = [operation objectForKey:@"arguments"];
     _done = NO;
   }
   return self;
@@ -48,36 +46,36 @@
 
 + (id) operationFromDictionary:(NSDictionary *) dictionary {
   NSString *opName = [dictionary valueForKey:@"method_name"];
-  LPOperation *op = nil;
+  LPOperation *operation = nil;
   if ([opName isEqualToString:@"scrollToRow"]) {
-    op = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
+    operation = [[LPScrollToRowOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"collectionViewScrollToItemWithMark"]) {
-    op = [[LPCollectionViewScrollToItemWithMarkOperation alloc] initWithOperation:dictionary];
+    operation = [[LPCollectionViewScrollToItemWithMarkOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"scrollToRowWithMark"]) {
-    op = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
+    operation = [[LPScrollToRowWithMarkOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"scroll"]) {
-    op = [[LPScrollOperation alloc] initWithOperation:dictionary];
+    operation = [[LPScrollOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"query"]) {
-    op = [[LPQueryOperation alloc] initWithOperation:dictionary];
+    operation = [[LPQueryOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"query_all"]) {
-    op = [[LPQueryAllOperation alloc] initWithOperation:dictionary];
+    operation = [[LPQueryAllOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"setText"]) {
-    op = [[LPSetTextOperation alloc] initWithOperation:dictionary];
+    operation = [[LPSetTextOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"flash"]) {
-    op = [[LPFlashOperation alloc] initWithOperation:dictionary];
+    operation = [[LPFlashOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"orientation"]) {
-    op = [[LPOrientationOperation alloc] initWithOperation:dictionary];
+    operation = [[LPOrientationOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"changeDatePickerDate"]) {
-    op = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
+    operation = [[LPDatePickerOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"changeSlider"]) {
-    op = [[LPSliderOperation alloc] initWithOperation:dictionary];
+    operation = [[LPSliderOperation alloc] initWithOperation:dictionary];
   } else if ([opName isEqualToString:@"collectionViewScroll"]) {
-    op = [[LPCollectionViewScrollToItemOperation alloc]
+    operation = [[LPCollectionViewScrollToItemOperation alloc]
             initWithOperation:dictionary];
   } else {
-    op = [[LPOperation alloc] initWithOperation:dictionary];
+    operation = [[LPOperation alloc] initWithOperation:dictionary];
   }
-  return [op autorelease];
+  return operation;
 }
 
 - (NSString *) description {
@@ -101,7 +99,6 @@
   NSArray *allWindows = [LPTouchUtils applicationWindows];
   
   NSArray *result = [parser evalWith:allWindows];
-  [parser release];
 
   return result;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -113,14 +113,20 @@
 
  # Calls this method, because :text is not a defined operation.
  > map("textField", :text)
+ => [ "old text" ]
 
- # Does not call this method because :setText is a defined operation -
+ # Does not call this method, because :setText is a defined operation -
  # see operationFromDictionary:
  > map("textField", :setText, 'new text')
+ => [ <UITextField ... > ]
 
- The map function is the only caller I have found.
+ # Calls this method, because 'setText:' is not a defined operation.
+ > map("textField", 'setText:', 'newer text')
+ => [ "<VOID>" ]
 
- This method has problems. :(
+ The map function is the only caller I have found.  My guess is that this is
+ legacy code that is not expected to be hit by casual users.  Most arbritary
+ invocations pass through `query` and not map.
  */
 - (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
   LPInvocationResult *invocationResult;


### PR DESCRIPTION
### Motivation

This method is called by `map` when there there is no matching LPOperation.

I was able to produce a bunch of examples that caused crashes.   

* Added a guard to prevent crashes
* Documented the behavior of the method
* Converted file to ARC
* Wrote some examples.