### PR TITLE
LPRouter forces response handling to main thread

### DIFF
--- a/XCTest/Tests/Routes/LPRouterTest.m
+++ b/XCTest/Tests/Routes/LPRouterTest.m
@@ -2,6 +2,23 @@
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
+#import "LPRouter.h"
+#import "LPRoute.h"
+
+@interface TestRoute : NSObject <LPRoute>
+
+@end
+
+@implementation TestRoute
+
+@end
+
+@interface LPRouter (LPXCTEST)
+
++ (id<LPRoute>) routeForKey:(NSString *) key;
+
+@end
+
 @interface LPRouterTest : XCTestCase
 
 @end
@@ -14,6 +31,18 @@
 
 - (void)tearDown {
   [super tearDown];
+}
+
+#pragma mark - Adding and Fetching Routes
+
+- (void) testManagingRoutes {
+  id <LPRoute> route = [TestRoute new];
+  NSString *key = @"test route";
+
+  [LPRouter addRoute:route forPath:key];
+
+  id <LPRoute> fetched = [LPRouter routeForKey:key];
+  expect(fetched).to.equal(route);
 }
 
 @end

--- a/XCTest/Tests/Routes/LPRouterTest.m
+++ b/XCTest/Tests/Routes/LPRouterTest.m
@@ -1,0 +1,19 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+@interface LPRouterTest : XCTestCase
+
+@end
+
+@implementation LPRouterTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+@end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		B15BF9A719ABB1DD00B38577 /* LPHTTPFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A514E6564200663205 /* LPHTTPFileResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A819ABB1DD00B38577 /* LPHTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A714E6564200663205 /* LPHTTPRedirectResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A919ABB1DD00B38577 /* LPCORSResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B1059F0418C546EB005A0262 /* LPCORSResponse.m */; };
-		B15BF9AA19ABB1DD00B38577 /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; };
+		B15BF9AA19ABB1DD00B38577 /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9AB19ABB1DD00B38577 /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9AC19ABB1DD00B38577 /* LPScrollToRowWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE0BC5174F58A5006E4050 /* LPScrollToRowWithMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9AD19ABB1DD00B38577 /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A318B391810094E71E /* LPCollectionViewScrollToItemWithMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -122,7 +122,7 @@
 		B1D5BD8619A23BCE0070E8CE /* LPHTTPFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A514E6564200663205 /* LPHTTPFileResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8719A23BCE0070E8CE /* LPHTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A714E6564200663205 /* LPHTTPRedirectResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8819A23BCE0070E8CE /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B1D5BD8919A23BCE0070E8CE /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; };
+		B1D5BD8919A23BCE0070E8CE /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8A19A23BCE0070E8CE /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
 		B1D5BD8B19A23BCE0070E8CE /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8C19A23BCE0070E8CE /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
@@ -225,7 +225,7 @@
 		F5091BE918C4E1D700C85307 /* LPHTTPFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A514E6564200663205 /* LPHTTPFileResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BEA18C4E1D700C85307 /* LPHTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A714E6564200663205 /* LPHTTPRedirectResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BEB18C4E1D700C85307 /* LPScrollToMarkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF97A718B392370094E71E /* LPScrollToMarkOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		F5091BEC18C4E1D700C85307 /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; };
+		F5091BEC18C4E1D700C85307 /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BED18C4E1D700C85307 /* LPQueryAllOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B15DA5E415C5D80A009E6CFE /* LPQueryAllOperation.m */; };
 		F5091BEE18C4E1D700C85307 /* LPOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FE9214B6DDA1002A744C /* LPOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BEF18C4E1D700C85307 /* LPQueryOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC514B6DB2B002A744C /* LPQueryOperation.m */; };
@@ -304,7 +304,7 @@
 		F50CBF8D1A04056F004AC9DA /* LPHTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9A714E6564200663205 /* LPHTTPRedirectResponse.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF8E1A04058C004AC9DA /* LPCORSResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = B1059F0418C546EB005A0262 /* LPCORSResponse.m */; };
 		F50CBF8F1A04058C004AC9DA /* LPI.mm in Sources */ = {isa = PBXBuildFile; fileRef = B184FDBD14B6DB2B002A744C /* LPI.mm */; };
-		F50CBF901A04058C004AC9DA /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; };
+		F50CBF901A04058C004AC9DA /* LPRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FDC014B6DB2B002A744C /* LPRouter.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF911A04058C004AC9DA /* LPCollectionViewScrollToItemOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C3A62E18A2EA0800DB7E42 /* LPCollectionViewScrollToItemOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF921A04058C004AC9DA /* LPSliderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CAC06B180D499600E23F03 /* LPSliderOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF931A04058C004AC9DA /* LPDatePickerOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F55A351017CF8F8F0001E8B4 /* LPDatePickerOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -379,6 +379,7 @@
 		F537399B18E6E0BE004133FA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F537399918E6E0BE004133FA /* main.m */; };
 		F5396A721AA6056D00D75E78 /* lp-simple-example.html in Resources */ = {isa = PBXBuildFile; fileRef = F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */; };
 		F5419F0D1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5419F0C1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F54EFE8D1B5B88D500F8D665 /* LPRouterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F54EFE8C1B5B88D500F8D665 /* LPRouterTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F55185571AC3866300CE06DC /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5A33A721AC01E8E00224639 /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F55185581AC3875200CE06DC /* LPWebViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F5A33A601AC01A9F00224639 /* LPWebViewProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F55185591AC3875900CE06DC /* UIWebView+LPWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5A33A4F1AC00D1300224639 /* UIWebView+LPWebView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -783,6 +784,7 @@
 		F537399918E6E0BE004133FA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F5396A6F1AA6056D00D75E78 /* lp-simple-example.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "lp-simple-example.html"; sourceTree = "<group>"; };
 		F5419F0C1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPJSONUtils_AccessibilityElementTest.m; sourceTree = "<group>"; };
+		F54EFE8C1B5B88D500F8D665 /* LPRouterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPRouterTest.m; sourceTree = "<group>"; };
 		F5543F211ABF7D7000E1A0BF /* LPPluginLoaderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPPluginLoaderTest.m; sourceTree = "<group>"; };
 		F5543F231ABF7DE900E1A0BF /* LPPluginLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPPluginLoader.h; sourceTree = "<group>"; };
 		F5543F241ABF7DE900E1A0BF /* LPPluginLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPPluginLoader.m; sourceTree = "<group>"; };
@@ -1755,6 +1757,7 @@
 				89F2EFE71B22462700958052 /* LPIntrospectionRouteTest.m */,
 				89128F931B25DD92008874B0 /* LPIntrospectionTestView.h */,
 				89128F941B25DD92008874B0 /* LPIntrospectionTestView.m */,
+				F54EFE8C1B5B88D500F8D665 /* LPRouterTest.m */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -2631,6 +2634,7 @@
 				F50CBF961A04058C004AC9DA /* LPQueryAllOperation.m in Sources */,
 				B15369FD1A327A400093923F /* LPUIATapRouteOverSharedElement.m in Sources */,
 				F5C224E01AD473F0001DB4FA /* LPDeviceTest.m in Sources */,
+				F54EFE8D1B5B88D500F8D665 /* LPRouterTest.m in Sources */,
 				F50CBF7D1A040564004AC9DA /* LPSSKeychainQuery.m in Sources */,
 				F50CBF9C1A04058C004AC9DA /* LPRecorder.m in Sources */,
 				F50CBF7C1A040564004AC9DA /* LPSSKeychain.m in Sources */,

--- a/calabash/Classes/FranklyServer/LPRoute.h
+++ b/calabash/Classes/FranklyServer/LPRoute.h
@@ -18,6 +18,8 @@
 
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path;
 
-- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data;
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data;
 
 @end

--- a/calabash/Classes/FranklyServer/LPRouter.h
+++ b/calabash/Classes/FranklyServer/LPRouter.h
@@ -6,10 +6,9 @@
 #import "LPHTTPConnection.h"
 #import "LPRoute.h"
 
-@interface LPRouter : LPHTTPConnection {
-  NSMutableData *_postData;
-}
-@property(nonatomic, retain, readonly) NSData *postData;
+@interface LPRouter : LPHTTPConnection
+
+- (NSData *) postData;
 
 + (void) addRoute:(id <LPRoute>) route forPath:(NSString *) path;
 

--- a/calabash/Classes/FranklyServer/LPRouter.m
+++ b/calabash/Classes/FranklyServer/LPRouter.m
@@ -92,23 +92,12 @@
 }
 
 - (NSMutableData *) mutablePostData {
-  if (_mutablePostData) {
-    LPLogDebug(@"mutable post data already set: %@",
-               [[NSString alloc] initWithData:_mutablePostData
-                                     encoding:NSUTF8StringEncoding]);
-    return _mutablePostData;
-  }
-
-  LPLogDebug(@"mutable post data nil, creating an new data object");
+  if (_mutablePostData) { return _mutablePostData;  }
   _mutablePostData = [[NSMutableData alloc] initWithData:[NSData data]];
   return _mutablePostData;
 }
 
 - (void) processBodyData:(NSData *) postDataChunk {
-  LPLogDebug(@"Calling process body data!");
-  LPLogDebug(@"data = %@",
-             [[NSString alloc] initWithData:postDataChunk
-                                   encoding:NSUTF8StringEncoding]);
   [self.mutablePostData appendData:postDataChunk];
 }
 
@@ -185,12 +174,6 @@
 
     SEL raw = @selector(httpResponseForMethod:URI:);
     if ([route respondsToSelector:raw]) {
-      LPLogDebug(@"Making a raw call to route with:");
-      LPLogDebug(@"selector:  %@", NSStringFromSelector(raw));
-      LPLogDebug(@"  target:  %@", NSStringFromClass([route class]));
-      LPLogDebug(@"  method:  %@", method);
-      LPLogDebug(@"    path:  %@", path);
-
       NSArray *arguments = @[method, path];
       LPInvocationResult *invocationResult;
       invocationResult = [LPInvoker invokeSelector:raw
@@ -221,10 +204,8 @@
                                                   URI:(NSString *) path {
 
   if ([[NSThread currentThread] isMainThread]) {
-    LPLogDebug(@"Handling response for: '%@' on current thread which is the main thread", method);
     return [self httpResponseOnMainThreadForMethod:method URI:path];
   } else {
-    LPLogDebug(@"Forcing handling response for: '%@' on the main thread", method);
     __weak typeof(self) wself = self;
     __block NSObject<LPHTTPResponse> *result = nil;
     dispatch_sync(dispatch_get_main_queue(), ^{

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
@@ -77,18 +77,9 @@
 
   NSIndexPath *ip = [NSIndexPath indexPathForItem:itemIndex inSection:section];
 
-  if ([[NSThread currentThread] isMainThread]) {
-    [collection scrollToItemAtIndexPath:ip
-                       atScrollPosition:scrollPosition
-                               animated:animate];
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [collection scrollToItemAtIndexPath:ip
-                         atScrollPosition:scrollPosition
-                                 animated:animate];
-    });
-  }
-
+  [collection scrollToItemAtIndexPath:ip
+                     atScrollPosition:scrollPosition
+                             animated:animate];
   return collection;
 }
 

--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemWithMarkOperation.m
@@ -102,18 +102,9 @@
     animate = [ani boolValue];
   }
 
-  if ([[NSThread currentThread] isMainThread]) {
-    [collection scrollToItemAtIndexPath:path
-                       atScrollPosition:scrollPosition
-                               animated:animate];
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [collection scrollToItemAtIndexPath:path
-                         atScrollPosition:scrollPosition
-                                 animated:animate];
-    });
-  }
-
+  [collection scrollToItemAtIndexPath:path
+                     atScrollPosition:scrollPosition
+                             animated:animate];
   return target;
 }
 

--- a/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPDatePickerOperation.m
@@ -78,17 +78,8 @@
   }
 
   if (notifyTargets) {
-    if ([[NSThread currentThread] isMainThread]) {
-      [picker setDate:date animated:animate];
-      UIControlEvents events = [picker allControlEvents];
-      [picker sendActionsForControlEvents:events];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        [picker setDate:date animated:animate];
-        UIControlEvents events = [picker allControlEvents];
-        [picker sendActionsForControlEvents:events];
-      });
-    }
+    UIControlEvents events = [picker allControlEvents];
+    [picker sendActionsForControlEvents:events];
   }
 
   return target;

--- a/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPFlashOperation.m
@@ -16,14 +16,7 @@
 @implementation LPFlashOperation
 
 - (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
-
-  if ([[NSThread currentThread] isMainThread]) {
-    [LPTouchUtils flashView:target forDuration:2];
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [LPTouchUtils flashView:target forDuration:2];
-    });
-  }
+  [LPTouchUtils flashView:target forDuration:2];
   return [LPJSONUtils jsonifyObject:target];
 }
 

--- a/calabash/Classes/FranklyServer/Operations/LPOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPOperation.m
@@ -130,9 +130,9 @@
  */
 - (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
   LPInvocationResult *invocationResult;
-  invocationResult = [LPInvoker invokeOnMainThreadSelector:self.selector
-                                                withTarget:target
-                                                 arguments:self.arguments];
+  invocationResult = [LPInvoker invokeSelector:self.selector
+                                    withTarget:target
+                                     arguments:self.arguments];
   id returnValue = nil;
 
   if ([invocationResult isError]) {

--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -58,13 +58,7 @@
       point = CGPointMake(offset.x + scrollAmount, offset.y);
     }
 
-    if ([[NSThread currentThread] isMainThread]) {
-      [sv setContentOffset:point animated:YES];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        [sv setContentOffset:point animated:YES];
-      });
-    }
+    [sv setContentOffset:point animated:YES];
 
     return target;
   } else if ([LPIsWebView isWebView:target]) {

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
@@ -58,18 +58,10 @@
           animate = [ani boolValue];
         }
 
-        if ([[NSThread currentThread] isMainThread]) {
-          [table scrollToRowAtIndexPath:path
-                       atScrollPosition:sp
-                               animated:animate];
+        [table scrollToRowAtIndexPath:path
+                     atScrollPosition:sp
+                             animated:animate];
 
-        } else {
-          dispatch_sync(dispatch_get_main_queue(), ^{
-            [table scrollToRowAtIndexPath:path
-                         atScrollPosition:sp
-                                 animated:animate];
-          });
-        }
         return target;
       } else {
         NSLog(@"Warning: table doesn't contain indexPath: %@", path);
@@ -78,21 +70,11 @@
     } else {
       NSIndexPath *indexPathForRow = [self indexPathForRow:[rowNum unsignedIntegerValue]
                                                    inTable:table];
-      if (!indexPathForRow) {
-        return nil;
-      }
+      if (!indexPathForRow) { return nil;  }
 
-      if ([[NSThread currentThread] isMainThread]) {
-        [table scrollToRowAtIndexPath:indexPathForRow
-                     atScrollPosition:UITableViewScrollPositionTop
-                             animated:YES];
-      } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
-          [table scrollToRowAtIndexPath:indexPathForRow
-                       atScrollPosition:UITableViewScrollPositionTop
-                               animated:YES];
-        });
-      }
+      [table scrollToRowAtIndexPath:indexPathForRow
+                   atScrollPosition:UITableViewScrollPositionTop
+                           animated:YES];
       return target;
     }
   }

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -81,13 +81,7 @@
     animate = [ani boolValue];
   }
 
-  if ([[NSThread currentThread] isMainThread]) {
-    [table scrollToRowAtIndexPath:path atScrollPosition:sp animated:animate];
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [table scrollToRowAtIndexPath:path atScrollPosition:sp animated:animate];
-    });
-  }
+  [table scrollToRowAtIndexPath:path atScrollPosition:sp animated:animate];
 
   return target;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPSliderOperation.m
@@ -57,17 +57,9 @@
 
   if (notifyTargets) {
     UIControlEvents events = [slider allControlEvents];
-    if ([[NSThread currentThread] isMainThread]) {
-      [slider setValue:targetValue animated:animate];
-      [slider sendActionsForControlEvents:events];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        [slider setValue:targetValue animated:animate];
-        [slider sendActionsForControlEvents:events];
-      });
-    }
+    [slider setValue:targetValue animated:animate];
+    [slider sendActionsForControlEvents:events];
   }
-
 
   return [LPJSONUtils jsonifyObject:target];
 }

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -52,8 +52,8 @@
          respondsTo:(SEL) selector {
   if ([target respondsToSelector:selector]) {
     LPInvocationResult *result;
-    result = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
-                                                    withTarget:target];
+    result = [LPInvoker invokeZeroArgumentSelector:selector
+                                        withTarget:target];
 
     [dictionary setObject:result.value forKey:key];
   }
@@ -65,8 +65,8 @@
            selector:(SEL) selector {
   if ([target respondsToSelector:selector]) {
     LPInvocationResult *result;
-    result = [LPInvoker invokeOnMainThreadZeroArgumentSelector:selector
-                                                    withTarget:target];
+    result = [LPInvoker invokeZeroArgumentSelector:selector
+                                        withTarget:target];
     [dictionary setObject:result.value forKey:key];
   } else {
     [dictionary setObject:[NSNull null] forKey:key];

--- a/calabash/Classes/WebViewQuery/UIWebView+LPWebView.m
+++ b/calabash/Classes/WebViewQuery/UIWebView+LPWebView.m
@@ -7,15 +7,7 @@
 @implementation UIWebView (UIWebView_LPWebView)
 
 - (NSString *) calabashStringByEvaluatingJavaScript:(NSString *) javascript {
-  if ([[NSThread currentThread] isMainThread]) {
-    return [self stringByEvaluatingJavaScriptFromString:javascript];
-  } else {
-    __block NSString *result = nil;
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      result = [self stringByEvaluatingJavaScriptFromString:javascript];
-    });
-    return result;
-  }
+  return [self stringByEvaluatingJavaScriptFromString:javascript];
 }
 
 @end


### PR DESCRIPTION
### Motivation

The overarching task is to update the CocoaHTTPServer and CocoaAsyncSocket sources.

This forces HTTP responses to be handled on the main thread.

It allows us to remove _some_ of the unnecessary thread checks that I previously added.

The remaining thread checks are in:

1. LPBackdoorRoute - Will be handled in another PR.
2. LPRecorder -  Execution is forced to the main thread here to allow _rotations_ to occur.  This is not a _route_ or and an _operation_.
3. LPInvoker - provides an API for invoking off and on the main thread.
4. LPWKWebViewRuntimeLoader - WKWebView `evaluateJavaScript:` is async and _must_ be performed on the main thread.  We perform an NSInvocation on the main thread.
5. LPConditionRoute - The timer _must not be started on the main thread._  The checks that timer performs _must be performed on the main thread._
6. In LPMapRoute there is some code to force an invocation on the main thread to support the Frank plug-in.  I have no tests for the Frank plug-in.  I doubt there are any users.

@sapieneptus I decided not to implement an API for executing code off/on the main thread.  I still think this idea has merit and should be revisited once we've merged the new CocoaHTTPServer sources.

It may seem that I went about this all backward - it could be argued that I should have started with the LPRouter first.  However, I really wanted to understand what the server was doing and where the problem spots were.

### Tests

The XTC results below are the result of merging this PR with my local branch that includes _all new CocoaHTTPServer and CocoaAsyncSocket sources_.

* [UIWebView and WKWebView Tests](https://testcloud.xamarin.com/test/calwebview-cal_0dc2dbdc-216e-4503-b05c-55df82cb034d/) - Has a known failing test - unrelated to these changes.
* [Calabash iOS Smoke Test](https://testcloud.xamarin.com/test/calsmoke-cal_5d8a40b4-50ff-471b-a0f3-4b96bff3818f/) - Has a couple of known failing tests (enable/disable autocorrect) and one failing test (rotation).  I subsequently fixed this, but haven't gotten around to pushing another XTC run.


Locally, I tested against Briar. The pending Scenarios are known issues with rotation + touching the 'Cancel' button on MFMessageComposeViewController views.

```
120 scenarios (5 pending, 115 passed)
566 steps (5 pending, 561 passed)
35m27.240s
```
cc @krukow @rasmuskl @john7doe 