### PR TITLE
WIP Expand the LPBackdoorRoute capabilities

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -21,7 +21,9 @@
   return [method isEqualToString:@"POST"];
 }
 
-- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data {
   NSString *originalSelStr = [data objectForKey:@"selector"];
   NSString *selectorName = originalSelStr;
   if (![originalSelStr hasSuffix:@":"]) {

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -11,6 +11,9 @@
 
 #import "LPBackdoorRoute.h"
 #import "LPCocoaLumberjack.h"
+#import "LPInvoker.h"
+#import "LPInvocationResult.h"
+#import "LPInvocationError.h"
 
 @implementation LPBackdoorRoute
 
@@ -44,43 +47,26 @@
   SEL selector = NSSelectorFromString(selectorName);
   id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
   if ([delegate respondsToSelector:selector]) {
-    id result = nil;
-
-    NSMethodSignature *methodSignature;
-    methodSignature = [[delegate class] instanceMethodSignatureForSelector:selector];
-
-    NSInvocation *invocation;
-    invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
-
-    [invocation setSelector:selector];
-    [invocation setArgument:&argument atIndex:2];
-
-    [invocation retainArguments];
-
-    if ([[NSThread currentThread] isMainThread]) {
-      [invocation invokeWithTarget:delegate];
+    LPInvocationResult *invocationResult;
+    invocationResult = [LPInvoker invokeSelector:selector
+                                      withTarget:delegate
+                                       arguments:@[argument]];
+    if ([invocationResult isError]) {
+      NSString *reason = [NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
+                          [invocationResult description]];
+      NSString *details = [NSString stringWithFormat:@"Invoking backdoor selector '%@' with argument '%@' could not be completed because '%@'",
+                           selectorName, argument, [invocationResult description]];
+      return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
     } else {
-      [invocation performSelectorOnMainThread:@selector(invokeWithTarget:)
-                                   withObject:delegate
-                                   waitUntilDone:YES];
+      return
+      @{
+        @"results": invocationResult.value,
+        // Legacy API:  Starting in Calabash 2.0 and Calabash 0.15.0, the 'result'
+        // key will be dropped.
+        @"result" : invocationResult.value,
+        @"outcome" : @"SUCCESS"
+        };
     }
-
-    void *buffer;
-
-    [invocation getReturnValue:&buffer];
-
-    result = (__bridge id)buffer;
-
-    if (!result) {result = [NSNull null];}
-    return
-    @{
-      @"results": result,
-      // Legacy API:  Starting in Calabash 2.0 and Calabash 0.15.0, the 'result'
-      // key will be dropped.
-      @"result" : result,
-      @"outcome" : @"SUCCESS"
-      };
-
   } else {
 
     NSArray *lines =

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -61,7 +61,14 @@
     result = (__bridge id)buffer;
 
     if (!result) {result = [NSNull null];}
-    return  @{ @"result" : result, @"outcome" : @"SUCCESS" };
+    return
+    @{
+      @"results": result,
+      // Legacy API:  Starting in Calabash 2.0 and Calabash 0.15.0, the 'result'
+      // key will be dropped.
+      @"result" : result,
+      @"outcome" : @"SUCCESS"
+      };
 
   } else {
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -15,7 +15,14 @@
 #import "LPInvocationResult.h"
 #import "LPInvocationError.h"
 
+const static NSString *ARG_KEY = @"arg";  /* for backwards compatibility */
+const static NSString *ARGUMENTS_KEY = @"arguments";
+
 @implementation LPBackdoorRoute
+
+- (NSDictionary *)failureWithReason:(NSString *)reason details:(NSString *)details {
+  return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+}
 
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
   return [method isEqualToString:@"POST"];
@@ -24,27 +31,25 @@
 - (NSDictionary *) JSONResponseForMethod:(NSString *) method
                                      URI:(NSString *) path
                                     data:(NSDictionary *) data {
-  NSString *originalSelStr = [data objectForKey:@"selector"];
-  NSString *selectorName = originalSelStr;
-  if (![originalSelStr hasSuffix:@":"]) {
-    LPLogWarn(@"Selector name is missing a ':'");
-    LPLogWarn(@"All backdoor methods must take at least one argument.");
-    LPLogWarn(@"Appending a ':' to the selector name.");
-    LPLogWarn(@"This will be an error in the future.");
-    selectorName = [selectorName stringByAppendingString:@":"];
+  NSString *selectorName = data[@"selector"];
+  if (!selectorName) {
+    LPLogError(@"Expected data dictionary to contain a 'selector' key.\nData = %@", data);
+    return [self failureWithReason:@"Missing selector name."
+                           details:[NSString stringWithFormat:@"Expected selector name to be provided for backdoor, but no 'selector' key in data '%@'", data]];
   }
 
-  id argument = [data objectForKey:@"arg"];
-  if (!argument) {
-    LPLogError(@"Expected data dictionary to contain an 'arg' key");
-    LPLogError(@"data = '%@'", data);
-    NSString *details = [NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument, but found no 'arg' key in data '%@'",
-                         selectorName, data];
-
-    NSString *reason = [NSString stringWithFormat:@"Missing argument for selector: '%@'",
-                        selectorName];
-    return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+  if (data[ARG_KEY] && data[ARGUMENTS_KEY]) {
+    LPLogError(@"Expected data dictionary to contain '%@' XOR '%@'.\nData = %@", ARG_KEY, ARGUMENTS_KEY, data);
+    return [self failureWithReason:@"Missing selector name."
+                           details:[NSString stringWithFormat:@"Expected '%@' OR '%@' key in data, not both. Data: '%@'", ARG_KEY, ARGUMENTS_KEY, data]];
+  } else if (!(data[ARG_KEY] || data[ARGUMENTS_KEY])) {
+    LPLogError(@"Expected data dictionary to contain an '%@' or '%@' key.\nData = %@", ARG_KEY, ARGUMENTS_KEY, data);
+    return [self failureWithReason:[NSString stringWithFormat:@"Missing argument(s) for selector: '%@'",
+                                    selectorName]
+                           details:[NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no '%@' or '%@' key in data '%@'", ARG_KEY, ARGUMENTS_KEY, selectorName, data]];
   }
+  
+  id arguments = data[ARG_KEY] ? @[data[ARG_KEY]] : data[ARGUMENTS_KEY];
 
   SEL selector = NSSelectorFromString(selectorName);
   id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
@@ -52,13 +57,12 @@
     LPInvocationResult *invocationResult;
     invocationResult = [LPInvoker invokeSelector:selector
                                       withTarget:delegate
-                                       arguments:@[argument]];
+                                       arguments:arguments];
     if ([invocationResult isError]) {
-      NSString *reason = [NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
-                          [invocationResult description]];
-      NSString *details = [NSString stringWithFormat:@"Invoking backdoor selector '%@' with argument '%@' could not be completed because '%@'",
-                           selectorName, argument, [invocationResult description]];
-      return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+      return [self failureWithReason:[NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
+                                      [invocationResult description]]
+                             details:[NSString stringWithFormat:@"Invoking backdoor selector '%@' with arguments '%@' could not be completed because '%@'",
+                                      selectorName, arguments, [invocationResult description]]];
     } else {
       return
       @{

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -29,10 +29,21 @@
     selectorName = [selectorName stringByAppendingString:@":"];
   }
 
+  id argument = [data objectForKey:@"arg"];
+  if (!argument) {
+    LPLogError(@"Expected data dictionary to contain an 'arg' key");
+    LPLogError(@"data = '%@'", data);
+    NSString *details = [NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument, but found no 'arg' key in data '%@'",
+                         selectorName, data];
+
+    NSString *reason = [NSString stringWithFormat:@"Missing argument for selector: '%@'",
+                        selectorName];
+    return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+  }
+
   SEL selector = NSSelectorFromString(selectorName);
   id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
   if ([delegate respondsToSelector:selector]) {
-    id argument = [data objectForKey:@"arg"];
     id result = nil;
 
     NSMethodSignature *methodSignature;
@@ -46,8 +57,6 @@
 
     [invocation retainArguments];
 
-    void *buffer;
-
     if ([[NSThread currentThread] isMainThread]) {
       [invocation invokeWithTarget:delegate];
     } else {
@@ -55,6 +64,8 @@
                                    withObject:delegate
                                    waitUntilDone:YES];
     }
+
+    void *buffer;
 
     [invocation getReturnValue:&buffer];
 

--- a/calabash/Classes/Invoker/LPInvoker.m
+++ b/calabash/Classes/Invoker/LPInvoker.m
@@ -650,6 +650,8 @@
       case '@': {
         if ([argument isEqual:@"__self__"]) {
           argument = self.target;
+        } else if ([argument isEqualToString:@"__nil__"]) {
+          argument = nil;
         }
         [invocation setArgument:&argument atIndex:invocationArgIndex];
         break;


### PR DESCRIPTION
**FORCE PUSHED:** Tue Jun 21 12:53 CET

### Motivation

1. Catches the case where the 'arg' key on the `data` dictionary has a nil value.

2. Uses the LPInvoker to allow backdoors to have any signature of this form:

```
- (<ANY>) backdoorSelector(<ANY>) arg;
```

These are a low priority changes and will require some work to update the docs.

If this is rejected, I will merge the nil 'arg' value change.

Ideally, I would like to remove nearly all restrictions on method signatures.  Maybe disallow AppDelegate methods to be called... The docs work could be deferred until this is a reality.

At issue are these Scenarios:

```
 48   @expect_crash
 49   Scenario: Calling backdoor with void return type causes a crash
 50     And I call backdoor on a method whose return type is void
 51     Then the app should crash
 52 
 53   @expect_crash
 54   Scenario: Calling backdoor with primitive return type causes a crash
 55     And I call backdoor on a method that returns a primitive
 56     Then the app should crash
 57 
 58   @invalid_signature
 59   Scenario: Backdoors with primitive argument (NSUInteger) are unpredictable
 60     And I call backdoor on a method that takes an NSUInteger argument
 61     Then I won't get back that integer as a string
 62 
 63   @invalid_signature
 64   Scenario: Backdoors with primitive argument (BOOL) are unpredictable
 65     And I call backdoor on a method that takes a boolean argument
 66     Then I won't get back that boolean as a string
```

- [ ] @krukow needs review
- [x] @sapieneptus needs review

### TODO

- [ ] 1. Fix up the "should crash" Scenarios
- [ ] 2. Fix up the BOOL argument - LPInvoker is _too_ good at coercing encodings - it returns true/false for BOOL and not 0/1.
- [ ] 3. Remove guard against missing `:`
- [ ] 4. Change the reason/details returned when unrecognized selector is sent
- [ ] 5. Add tests for `@"__nil__"`