### PR TITLE
Update CocoaHTTPServer 2.3

### DIFF
--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		B15BF99C19ABB1DD00B38577 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99D19ABB1DD00B38577 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99E19ABB1DD00B38577 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		B15BF99F19ABB1DD00B38577 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		B15BF9A019ABB1DD00B38577 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		B15BF99F19ABB1DD00B38577 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A119ABB1DD00B38577 /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A219ABB1DD00B38577 /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A319ABB1DD00B38577 /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };
@@ -109,8 +109,8 @@
 		B1D5BD7919A23BCE0070E8CE /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7A19A23BCE0070E8CE /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7B19A23BCE0070E8CE /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		B1D5BD7C19A23BCE0070E8CE /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		B1D5BD7D19A23BCE0070E8CE /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		B1D5BD7C19A23BCE0070E8CE /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7E19A23BCE0070E8CE /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7F19A23BCE0070E8CE /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8019A23BCE0070E8CE /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };
@@ -213,8 +213,8 @@
 		F5091BDD18C4E1D700C85307 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDE18C4E1D700C85307 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDF18C4E1D700C85307 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		F5091BE018C4E1D700C85307 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		F5091BE118C4E1D700C85307 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		F5091BE018C4E1D700C85307 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE218C4E1D700C85307 /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE318C4E1D700C85307 /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE418C4E1D700C85307 /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };
@@ -292,8 +292,8 @@
 		F50CBF811A040564004AC9DA /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF821A040564004AC9DA /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF831A040564004AC9DA /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		F50CBF841A040564004AC9DA /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		F50CBF851A040564004AC9DA /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		F50CBF841A040564004AC9DA /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF861A040564004AC9DA /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF871A040564004AC9DA /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF881A040564004AC9DA /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -406,6 +406,10 @@
 		F5543F311ABF7DF500E1A0BF /* LPPluginLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = F5543F241ABF7DE900E1A0BF /* LPPluginLoader.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F55A248C1B5A7F8300251DD4 /* LPQueryAllOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F55A248B1B5A7F8300251DD4 /* LPQueryAllOperationTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F55D412418C9130100813F78 /* LPKeychainRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F55D412118C9130100813F78 /* LPKeychainRoute.m */; };
+		F56592661B47E76C00C044C8 /* LPWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = F56592621B47E76C00C044C8 /* LPWebSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F56592671B47E76C00C044C8 /* LPWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = F56592621B47E76C00C044C8 /* LPWebSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F56592681B47E76C00C044C8 /* LPWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = F56592621B47E76C00C044C8 /* LPWebSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F56592691B47E76C00C044C8 /* LPWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = F56592621B47E76C00C044C8 /* LPWebSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F56630921A39B09C00DEA0C0 /* LPInfoPlist.m in Sources */ = {isa = PBXBuildFile; fileRef = F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F56630951A39B09C00DEA0C0 /* LPInfoPlist.m in Sources */ = {isa = PBXBuildFile; fileRef = F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F56630961A39B09C00DEA0C0 /* LPInfoPlist.m in Sources */ = {isa = PBXBuildFile; fileRef = F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -794,6 +798,8 @@
 		F55D412018C9130100813F78 /* LPKeychainRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPKeychainRoute.h; sourceTree = "<group>"; };
 		F55D412118C9130100813F78 /* LPKeychainRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPKeychainRoute.m; sourceTree = "<group>"; };
 		F56592601B4713FE00C044C8 /* LPRepeatingTimerProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPRepeatingTimerProtocol.h; sourceTree = "<group>"; };
+		F56592611B47E76C00C044C8 /* LPWebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPWebSocket.h; sourceTree = "<group>"; };
+		F56592621B47E76C00C044C8 /* LPWebSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPWebSocket.m; sourceTree = "<group>"; };
 		F566308A1A39B09C00DEA0C0 /* LPInfoPlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPInfoPlist.h; sourceTree = "<group>"; };
 		F566308B1A39B09C00DEA0C0 /* LPInfoPlist.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInfoPlist.m; sourceTree = "<group>"; };
 		F56B4EF31B56FC3600E7EA23 /* LPInvokerSelectorWithArgumentsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPInvokerSelectorWithArgumentsTest.m; sourceTree = "<group>"; };
@@ -1186,6 +1192,8 @@
 				B116C9B914E6565500663205 /* LPHTTPResponse.h */,
 				B116C9BA14E6565500663205 /* LPHTTPServer.h */,
 				B116C9BB14E6565500663205 /* LPHTTPServer.m */,
+				F56592611B47E76C00C044C8 /* LPWebSocket.h */,
+				F56592621B47E76C00C044C8 /* LPWebSocket.m */,
 				B116C98214E5214600663205 /* Categories */,
 				B184FDA414B6DB2B002A744C /* Responses */,
 			);
@@ -2213,6 +2221,7 @@
 				B15BF9BD19ABB1DE00B38577 /* LPAppPropertyRoute.m in Sources */,
 				B15BF9BE19ABB1DE00B38577 /* LPQueryLogRoute.m in Sources */,
 				F5C04E331B33110B00F23526 /* LPDecimalRounder.m in Sources */,
+				F56592691B47E76C00C044C8 /* LPWebSocket.m in Sources */,
 				F5F2D5ED1ACACF2F0027937B /* LPIsWebView.m in Sources */,
 				B15BF9BF19ABB1DE00B38577 /* LPUIATapRoute.m in Sources */,
 				B15BF9C019ABB1DE00B38577 /* LPLocationRoute.m in Sources */,
@@ -2327,6 +2336,7 @@
 				B1D5BD9C19A23BCE0070E8CE /* LPNoContentResponse.m in Sources */,
 				B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */,
 				F5C04E321B33110B00F23526 /* LPDecimalRounder.m in Sources */,
+				F56592681B47E76C00C044C8 /* LPWebSocket.m in Sources */,
 				F5F2D5EC1ACACF2F0027937B /* LPIsWebView.m in Sources */,
 				F5BA6F0C1B4E4B8200DB898F /* LPInvoker.m in Sources */,
 				B1D5BD9E19A23BCE0070E8CE /* LPAsyncPlaybackRoute.m in Sources */,
@@ -2440,6 +2450,7 @@
 				F5091BFE18C4E1D700C85307 /* LPScreenshotRoute.m in Sources */,
 				F5091BFF18C4E1D700C85307 /* LPAsyncPlaybackRoute.m in Sources */,
 				F5C04E2F1B33110B00F23526 /* LPDecimalRounder.m in Sources */,
+				F56592671B47E76C00C044C8 /* LPWebSocket.m in Sources */,
 				F5F2D5E91ACACF2F0027937B /* LPIsWebView.m in Sources */,
 				F5091C0018C4E1D700C85307 /* LPBackdoorRoute.m in Sources */,
 				F5091C0118C4E1D700C85307 /* LPVersionRoute.m in Sources */,
@@ -2615,6 +2626,7 @@
 				F50CBF971A04058C004AC9DA /* LPOperation.m in Sources */,
 				F5BA6F121B4E4D2B00DB898F /* InvokerFactory.m in Sources */,
 				F5C224C71ACDF299001DB4FA /* LPWKWebViewRuntimeLoader.m in Sources */,
+				F56592661B47E76C00C044C8 /* LPWebSocket.m in Sources */,
 				F50CBFA11A0405B2004AC9DA /* LPKeychainRoute.m in Sources */,
 				F50CBF941A04058C004AC9DA /* LPOrientationOperation.m in Sources */,
 				F50CBFC71A0405E9004AC9DA /* LPJSONUtils.m in Sources */,

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		B15BF99A19ABB1DD00B38577 /* LPSSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E2D1DA18C9120E00A0D9B6 /* LPSSKeychain.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99B19ABB1DD00B38577 /* LPSSKeychainQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E2D1DC18C9120E00A0D9B6 /* LPSSKeychainQuery.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99C19ABB1DD00B38577 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B15BF99D19ABB1DD00B38577 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; };
+		B15BF99D19ABB1DD00B38577 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99E19ABB1DD00B38577 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
 		B15BF99F19ABB1DD00B38577 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		B15BF9A019ABB1DD00B38577 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
@@ -107,7 +107,7 @@
 		B1670E2E1A32411100000A62 /* LPDumpRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = B13B7FBE1A31FE560054FFB1 /* LPDumpRoute.m */; };
 		B1670E341A3248CC00000A62 /* LPSharedUIATextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F772191A22A398009A2336 /* LPSharedUIATextField.m */; };
 		B1D5BD7919A23BCE0070E8CE /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B1D5BD7A19A23BCE0070E8CE /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; };
+		B1D5BD7A19A23BCE0070E8CE /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7B19A23BCE0070E8CE /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
 		B1D5BD7C19A23BCE0070E8CE /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		B1D5BD7D19A23BCE0070E8CE /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
@@ -211,7 +211,7 @@
 		B1FBBC5F19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50292971ACAD4FE00D07D31 /* LPIsWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5F2D5E11ACACF2F0027937B /* LPIsWebView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F5091BDD18C4E1D700C85307 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		F5091BDE18C4E1D700C85307 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; };
+		F5091BDE18C4E1D700C85307 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDF18C4E1D700C85307 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
 		F5091BE018C4E1D700C85307 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		F5091BE118C4E1D700C85307 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
@@ -290,7 +290,7 @@
 		F50CBF7C1A040564004AC9DA /* LPSSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E2D1DA18C9120E00A0D9B6 /* LPSSKeychain.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF7D1A040564004AC9DA /* LPSSKeychainQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E2D1DC18C9120E00A0D9B6 /* LPSSKeychainQuery.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF811A040564004AC9DA /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		F50CBF821A040564004AC9DA /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; };
+		F50CBF821A040564004AC9DA /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF831A040564004AC9DA /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
 		F50CBF841A040564004AC9DA /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; };
 		F50CBF851A040564004AC9DA /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -1788,20 +1788,20 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F55185791AC38A5200CE06DC /* LPHTTPResponse.h in Headers */,
+				F551857D1AC38A5200CE06DC /* CalabashServer.h in Headers */,
+				F55185701AC389C700CE06DC /* LPCORSResponse.h in Headers */,
 				F55185751AC389F600CE06DC /* LPHTTPAsyncFileResponse.h in Headers */,
 				F55185761AC389F600CE06DC /* LPHTTPDataResponse.h in Headers */,
 				F55185771AC389F600CE06DC /* LPHTTPDynamicFileResponse.h in Headers */,
 				F55185781AC389F600CE06DC /* LPHTTPFileResponse.h in Headers */,
-				F55185701AC389C700CE06DC /* LPCORSResponse.h in Headers */,
+				F55185791AC38A5200CE06DC /* LPHTTPResponse.h in Headers */,
+				F50292971ACAD4FE00D07D31 /* LPIsWebView.h in Headers */,
 				F551857A1AC38A5200CE06DC /* LPRoute.h in Headers */,
 				F551857B1AC38A5200CE06DC /* LPRouter.h in Headers */,
 				F551857C1AC38A5200CE06DC /* LPVersionRoute.h in Headers */,
-				F55185641AC3879D00CE06DC /* LPWebViewProtocol.h in Headers */,
 				F5C094511A979CC200AE5991 /* LPWebQuery.h in Headers */,
+				F55185641AC3879D00CE06DC /* LPWebViewProtocol.h in Headers */,
 				F55185651AC3879D00CE06DC /* UIWebView+LPWebView.h in Headers */,
-				F551857D1AC38A5200CE06DC /* CalabashServer.h in Headers */,
-				F50292971ACAD4FE00D07D31 /* LPIsWebView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1810,19 +1810,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				B1D5BDC919A23BCE0070E8CE /* CalabashServer.h in Headers */,
-				B1D5BDCA19A23BCE0070E8CE /* LPRoute.h in Headers */,
-				B1D5BDCB19A23BCE0070E8CE /* LPRouter.h in Headers */,
-				F5C094501A979CC200AE5991 /* LPWebQuery.h in Headers */,
-				F55185611AC3878D00CE06DC /* LPWebViewProtocol.h in Headers */,
-				F55185621AC3878D00CE06DC /* UIWebView+LPWebView.h in Headers */,
 				F55185741AC389E800CE06DC /* LPCORSResponse.h in Headers */,
-				F5F2D5E61ACACF2F0027937B /* LPIsWebView.h in Headers */,
-				B1D5BDCC19A23BCE0070E8CE /* LPHTTPResponse.h in Headers */,
 				B1D5BDCD19A23BCE0070E8CE /* LPHTTPAsyncFileResponse.h in Headers */,
 				B1D5BDCE19A23BCE0070E8CE /* LPHTTPDataResponse.h in Headers */,
 				B1D5BDCF19A23BCE0070E8CE /* LPHTTPDynamicFileResponse.h in Headers */,
 				B1D5BDD019A23BCE0070E8CE /* LPHTTPFileResponse.h in Headers */,
+				B1D5BDCC19A23BCE0070E8CE /* LPHTTPResponse.h in Headers */,
+				F5F2D5E61ACACF2F0027937B /* LPIsWebView.h in Headers */,
+				B1D5BDCA19A23BCE0070E8CE /* LPRoute.h in Headers */,
+				B1D5BDCB19A23BCE0070E8CE /* LPRouter.h in Headers */,
 				B1D5BDD119A23BCE0070E8CE /* LPVersionRoute.h in Headers */,
+				F5C094501A979CC200AE5991 /* LPWebQuery.h in Headers */,
+				F55185611AC3878D00CE06DC /* LPWebViewProtocol.h in Headers */,
+				F55185621AC3878D00CE06DC /* UIWebView+LPWebView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1831,19 +1831,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				F5091C2F18C4E1D700C85307 /* CalabashServer.h in Headers */,
-				F59C5CF818E0BB1A0087B51D /* LPRoute.h in Headers */,
-				F59C5CF918E0BB290087B51D /* LPRouter.h in Headers */,
-				F5C0944D1A979CC200AE5991 /* LPWebQuery.h in Headers */,
-				F55185581AC3875200CE06DC /* LPWebViewProtocol.h in Headers */,
-				F55185591AC3875900CE06DC /* UIWebView+LPWebView.h in Headers */,
-				F5F2D5E31ACACF2F0027937B /* LPIsWebView.h in Headers */,
 				F55185711AC389CD00CE06DC /* LPCORSResponse.h in Headers */,
-				F59C5CFA18E0BBAE0087B51D /* LPHTTPResponse.h in Headers */,
 				F59C5CFB18E0BBAE0087B51D /* LPHTTPAsyncFileResponse.h in Headers */,
 				F59C5CFC18E0BBAE0087B51D /* LPHTTPDataResponse.h in Headers */,
 				F59C5CFD18E0BBAE0087B51D /* LPHTTPDynamicFileResponse.h in Headers */,
 				F59C5CFE18E0BBAE0087B51D /* LPHTTPFileResponse.h in Headers */,
+				F59C5CFA18E0BBAE0087B51D /* LPHTTPResponse.h in Headers */,
+				F5F2D5E31ACACF2F0027937B /* LPIsWebView.h in Headers */,
+				F59C5CF818E0BB1A0087B51D /* LPRoute.h in Headers */,
+				F59C5CF918E0BB290087B51D /* LPRouter.h in Headers */,
 				F537397418E52014004133FA /* LPVersionRoute.h in Headers */,
+				F5C0944D1A979CC200AE5991 /* LPWebQuery.h in Headers */,
+				F55185581AC3875200CE06DC /* LPWebViewProtocol.h in Headers */,
+				F55185591AC3875900CE06DC /* UIWebView+LPWebView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -27,9 +27,9 @@
 		B15BF99B19ABB1DD00B38577 /* LPSSKeychainQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E2D1DC18C9120E00A0D9B6 /* LPSSKeychainQuery.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99C19ABB1DD00B38577 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99D19ABB1DD00B38577 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B15BF99E19ABB1DD00B38577 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		B15BF9A019ABB1DD00B38577 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		B15BF99E19ABB1DD00B38577 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF99F19ABB1DD00B38577 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B15BF9A019ABB1DD00B38577 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A119ABB1DD00B38577 /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A219ABB1DD00B38577 /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B15BF9A319ABB1DD00B38577 /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };
@@ -108,9 +108,9 @@
 		B1670E341A3248CC00000A62 /* LPSharedUIATextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F772191A22A398009A2336 /* LPSharedUIATextField.m */; };
 		B1D5BD7919A23BCE0070E8CE /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7A19A23BCE0070E8CE /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B1D5BD7B19A23BCE0070E8CE /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		B1D5BD7D19A23BCE0070E8CE /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		B1D5BD7B19A23BCE0070E8CE /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7C19A23BCE0070E8CE /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B1D5BD7D19A23BCE0070E8CE /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7E19A23BCE0070E8CE /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD7F19A23BCE0070E8CE /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1D5BD8019A23BCE0070E8CE /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };
@@ -212,9 +212,9 @@
 		F50292971ACAD4FE00D07D31 /* LPIsWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5F2D5E11ACACF2F0027937B /* LPIsWebView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F5091BDD18C4E1D700C85307 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDE18C4E1D700C85307 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		F5091BDF18C4E1D700C85307 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		F5091BE118C4E1D700C85307 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		F5091BDF18C4E1D700C85307 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE018C4E1D700C85307 /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5091BE118C4E1D700C85307 /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE218C4E1D700C85307 /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE318C4E1D700C85307 /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BE418C4E1D700C85307 /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };
@@ -291,9 +291,9 @@
 		F50CBF7D1A040564004AC9DA /* LPSSKeychainQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E2D1DC18C9120E00A0D9B6 /* LPSSKeychainQuery.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF811A040564004AC9DA /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF821A040564004AC9DA /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		F50CBF831A040564004AC9DA /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; };
-		F50CBF851A040564004AC9DA /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		F50CBF831A040564004AC9DA /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF841A040564004AC9DA /* LPHTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B814E6565500663205 /* LPHTTPMessage.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F50CBF851A040564004AC9DA /* LPHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9BB14E6565500663205 /* LPHTTPServer.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF861A040564004AC9DA /* NSData+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98414E5215800663205 /* NSData+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF871A040564004AC9DA /* NSNumber+LPCHSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98614E5215800663205 /* NSNumber+LPCHSExtensions.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50CBF881A040564004AC9DA /* LPDDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C98814E5215800663205 /* LPDDRange.m */; };

--- a/calabash/Classes/CocoaHttpServer/LPHTTPAuthenticationRequest.h
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPAuthenticationRequest.h
@@ -1,32 +1,33 @@
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_IPHONE
-  // Note: You may need to add the CFNetwork Framework to your project
-  #import <CFNetwork/CFNetwork.h>
+// Note: You may need to add the CFNetwork Framework to your project
+#import <CFNetwork/CFNetwork.h>
+
 #endif
 
 @class LPHTTPMessage;
 
 
-@interface LPHTTPAuthenticationRequest : NSObject
-{
-	BOOL isBasic;
-	BOOL isDigest;
-	
-	NSString *base64Credentials;
-	
-	NSString *username;
-	NSString *realm;
-	NSString *nonce;
-	NSString *uri;
-	NSString *qop;
-	NSString *nc;
-	NSString *cnonce;
-	NSString *response;
+@interface LPHTTPAuthenticationRequest : NSObject {
+  BOOL isBasic;
+  BOOL isDigest;
+
+  NSString *base64Credentials;
+
+  NSString *username;
+  NSString *realm;
+  NSString *nonce;
+  NSString *uri;
+  NSString *qop;
+  NSString *nc;
+  NSString *cnonce;
+  NSString *response;
 }
 - (id)initWithRequest:(LPHTTPMessage *)request;
 
 - (BOOL)isBasic;
+
 - (BOOL)isDigest;
 
 // Basic
@@ -34,12 +35,19 @@
 
 // Digest
 - (NSString *)username;
+
 - (NSString *)realm;
+
 - (NSString *)nonce;
+
 - (NSString *)uri;
+
 - (NSString *)qop;
+
 - (NSString *)nc;
+
 - (NSString *)cnonce;
+
 - (NSString *)response;
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPAuthenticationRequest.m
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPAuthenticationRequest.m
@@ -1,125 +1,109 @@
 #import "LPHTTPAuthenticationRequest.h"
 #import "LPHTTPMessage.h"
 
-@interface LPHTTPAuthenticationRequest (PrivateAPI)
+#if !__has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+@interface LPHTTPAuthenticationRequest (LPPrivateAPI)
 - (NSString *)quotedSubHeaderFieldValue:(NSString *)param fromHeaderFieldValue:(NSString *)header;
+
 - (NSString *)nonquotedSubHeaderFieldValue:(NSString *)param fromHeaderFieldValue:(NSString *)header;
 @end
 
 
 @implementation LPHTTPAuthenticationRequest
 
-- (id)initWithRequest:(LPHTTPMessage *)request
-{
-	if ((self = [super init]))
-	{
-		NSString *authInfo = [request headerField:@"Authorization"];
-		
-		isBasic = NO;
-		if ([authInfo length] >= 6)
-		{
-			isBasic = [[authInfo substringToIndex:6] caseInsensitiveCompare:@"Basic "] == NSOrderedSame;
-		}
-		
-		isDigest = NO;
-		if ([authInfo length] >= 7)
-		{
-			isDigest = [[authInfo substringToIndex:7] caseInsensitiveCompare:@"Digest "] == NSOrderedSame;
-		}
-		
-		if (isBasic)
-		{
-			NSMutableString *temp = [[[authInfo substringFromIndex:6] mutableCopy] autorelease];
-			CFStringTrimWhitespace((CFMutableStringRef)temp);
-			
-			base64Credentials = [temp copy];
-		}
-		
-		if (isDigest)
-		{
-			username = [[self quotedSubHeaderFieldValue:@"username" fromHeaderFieldValue:authInfo] retain];
-			realm    = [[self quotedSubHeaderFieldValue:@"realm" fromHeaderFieldValue:authInfo] retain];
-			nonce    = [[self quotedSubHeaderFieldValue:@"nonce" fromHeaderFieldValue:authInfo] retain];
-			uri      = [[self quotedSubHeaderFieldValue:@"uri" fromHeaderFieldValue:authInfo] retain];
-			
-			// It appears from RFC 2617 that the qop is to be given unquoted
-			// Tests show that Firefox performs this way, but Safari does not
-			// Thus we'll attempt to retrieve the value as nonquoted, but we'll verify it doesn't start with a quote
-			qop      = [self nonquotedSubHeaderFieldValue:@"qop" fromHeaderFieldValue:authInfo];
-			if(qop && ([qop characterAtIndex:0] == '"'))
-			{
-				qop  = [self quotedSubHeaderFieldValue:@"qop" fromHeaderFieldValue:authInfo];
-			}
-			[qop retain];
-			
-			nc       = [[self nonquotedSubHeaderFieldValue:@"nc" fromHeaderFieldValue:authInfo] retain];
-			cnonce   = [[self quotedSubHeaderFieldValue:@"cnonce" fromHeaderFieldValue:authInfo] retain];
-			response = [[self quotedSubHeaderFieldValue:@"response" fromHeaderFieldValue:authInfo] retain];
-		}
-	}
-	return self;
+- (id)initWithRequest:(LPHTTPMessage *)request {
+  if ((self = [super init])) {
+    NSString *authInfo = [request headerField:@"Authorization"];
+
+    isBasic = NO;
+    if ([authInfo length] >= 6) {
+      isBasic = [[authInfo substringToIndex:6] caseInsensitiveCompare:@"Basic "] == NSOrderedSame;
+    }
+
+    isDigest = NO;
+    if ([authInfo length] >= 7) {
+      isDigest = [[authInfo substringToIndex:7] caseInsensitiveCompare:@"Digest "] == NSOrderedSame;
+    }
+
+    if (isBasic) {
+      NSMutableString *temp = [[authInfo substringFromIndex:6] mutableCopy];
+      CFStringTrimWhitespace((__bridge CFMutableStringRef) temp);
+
+      base64Credentials = [temp copy];
+    }
+
+    if (isDigest) {
+      username = [self quotedSubHeaderFieldValue:@"username" fromHeaderFieldValue:authInfo];
+      realm = [self quotedSubHeaderFieldValue:@"realm" fromHeaderFieldValue:authInfo];
+      nonce = [self quotedSubHeaderFieldValue:@"nonce" fromHeaderFieldValue:authInfo];
+      uri = [self quotedSubHeaderFieldValue:@"uri" fromHeaderFieldValue:authInfo];
+
+      // It appears from RFC 2617 that the qop is to be given unquoted
+      // Tests show that Firefox performs this way, but Safari does not
+      // Thus we'll attempt to retrieve the value as nonquoted, but we'll verify it doesn't start with a quote
+      qop = [self nonquotedSubHeaderFieldValue:@"qop" fromHeaderFieldValue:authInfo];
+      if (qop && ([qop characterAtIndex:0] == '"')) {
+        qop = [self quotedSubHeaderFieldValue:@"qop" fromHeaderFieldValue:authInfo];
+      }
+
+      nc = [self nonquotedSubHeaderFieldValue:@"nc" fromHeaderFieldValue:authInfo];
+      cnonce = [self quotedSubHeaderFieldValue:@"cnonce" fromHeaderFieldValue:authInfo];
+      response = [self quotedSubHeaderFieldValue:@"response" fromHeaderFieldValue:authInfo];
+    }
+  }
+  return self;
 }
 
-- (void)dealloc
-{
-	[base64Credentials release];
-	[username release];
-	[realm release];
-	[nonce release];
-	[uri release];
-	[qop release];
-	[nc release];
-	[cnonce release];
-	[response release];
-	[super dealloc];
-}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Accessors:
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (BOOL)isBasic {
-	return isBasic;
+  return isBasic;
 }
 
 - (BOOL)isDigest {
-	return isDigest;
+  return isDigest;
 }
 
 - (NSString *)base64Credentials {
-	return base64Credentials;
+  return base64Credentials;
 }
 
 - (NSString *)username {
-	return username;
+  return username;
 }
 
 - (NSString *)realm {
-	return realm;
+  return realm;
 }
 
 - (NSString *)nonce {
-	return nonce;
+  return nonce;
 }
 
 - (NSString *)uri {
-	return uri;
+  return uri;
 }
 
 - (NSString *)qop {
-	return qop;
+  return qop;
 }
 
 - (NSString *)nc {
-	return nc;
+  return nc;
 }
 
 - (NSString *)cnonce {
-	return cnonce;
+  return cnonce;
 }
 
 - (NSString *)response {
-	return response;
+  return response;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -129,77 +113,68 @@
 /**
  * Retrieves a "Sub Header Field Value" from a given header field value.
  * The sub header field is expected to be quoted.
- * 
+ *
  * In the following header field:
  * Authorization: Digest username="Mufasa", qop=auth, response="6629fae4939"
  * The sub header field titled 'username' is quoted, and this method would return the value @"Mufasa".
-**/
-- (NSString *)quotedSubHeaderFieldValue:(NSString *)param fromHeaderFieldValue:(NSString *)header
-{
-	NSRange startRange = [header rangeOfString:[NSString stringWithFormat:@"%@=\"", param]];
-	if(startRange.location == NSNotFound)
-	{
-		// The param was not found anywhere in the header
-		return nil;
-	}
-	
-	NSUInteger postStartRangeLocation = startRange.location + startRange.length;
-	NSUInteger postStartRangeLength = [header length] - postStartRangeLocation;
-	NSRange postStartRange = NSMakeRange(postStartRangeLocation, postStartRangeLength);
-	
-	NSRange endRange = [header rangeOfString:@"\"" options:0 range:postStartRange];
-	if(endRange.location == NSNotFound)
-	{
-		// The ending double-quote was not found anywhere in the header
-		return nil;
-	}
-	
-	NSRange subHeaderRange = NSMakeRange(postStartRangeLocation, endRange.location - postStartRangeLocation);
-	return [header substringWithRange:subHeaderRange];
+ **/
+- (NSString *)quotedSubHeaderFieldValue:(NSString *)param fromHeaderFieldValue:(NSString *)header {
+  NSRange startRange = [header rangeOfString:[NSString stringWithFormat:@"%@=\"", param]];
+  if (startRange.location == NSNotFound) {
+    // The param was not found anywhere in the header
+    return nil;
+  }
+
+  NSUInteger postStartRangeLocation = startRange.location + startRange.length;
+  NSUInteger postStartRangeLength = [header length] - postStartRangeLocation;
+  NSRange postStartRange = NSMakeRange(postStartRangeLocation, postStartRangeLength);
+
+  NSRange endRange = [header rangeOfString:@"\"" options:0 range:postStartRange];
+  if (endRange.location == NSNotFound) {
+    // The ending double-quote was not found anywhere in the header
+    return nil;
+  }
+
+  NSRange subHeaderRange = NSMakeRange(postStartRangeLocation, endRange.location - postStartRangeLocation);
+  return [header substringWithRange:subHeaderRange];
 }
 
 /**
  * Retrieves a "Sub Header Field Value" from a given header field value.
  * The sub header field is expected to not be quoted.
- * 
+ *
  * In the following header field:
  * Authorization: Digest username="Mufasa", qop=auth, response="6629fae4939"
  * The sub header field titled 'qop' is nonquoted, and this method would return the value @"auth".
-**/
-- (NSString *)nonquotedSubHeaderFieldValue:(NSString *)param fromHeaderFieldValue:(NSString *)header
-{
-	NSRange startRange = [header rangeOfString:[NSString stringWithFormat:@"%@=", param]];
-	if(startRange.location == NSNotFound)
-	{
-		// The param was not found anywhere in the header
-		return nil;
-	}
-	
-	NSUInteger postStartRangeLocation = startRange.location + startRange.length;
-	NSUInteger postStartRangeLength = [header length] - postStartRangeLocation;
-	NSRange postStartRange = NSMakeRange(postStartRangeLocation, postStartRangeLength);
-	
-	NSRange endRange = [header rangeOfString:@"," options:0 range:postStartRange];
-	if(endRange.location == NSNotFound)
-	{
-		// The ending comma was not found anywhere in the header
-		// However, if the nonquoted param is at the end of the string, there would be no comma
-		// This is only possible if there are no spaces anywhere
-		NSRange endRange2 = [header rangeOfString:@" " options:0 range:postStartRange];
-		if(endRange2.location != NSNotFound)
-		{
-			return nil;
-		}
-		else
-		{
-			return [header substringWithRange:postStartRange];
-		}
-	}
-	else
-	{
-		NSRange subHeaderRange = NSMakeRange(postStartRangeLocation, endRange.location - postStartRangeLocation);
-		return [header substringWithRange:subHeaderRange];
-	}
+ **/
+- (NSString *)nonquotedSubHeaderFieldValue:(NSString *)param fromHeaderFieldValue:(NSString *)header {
+  NSRange startRange = [header rangeOfString:[NSString stringWithFormat:@"%@=", param]];
+  if (startRange.location == NSNotFound) {
+    // The param was not found anywhere in the header
+    return nil;
+  }
+
+  NSUInteger postStartRangeLocation = startRange.location + startRange.length;
+  NSUInteger postStartRangeLength = [header length] - postStartRangeLocation;
+  NSRange postStartRange = NSMakeRange(postStartRangeLocation, postStartRangeLength);
+
+  NSRange endRange = [header rangeOfString:@"," options:0 range:postStartRange];
+  if (endRange.location == NSNotFound) {
+    // The ending comma was not found anywhere in the header
+    // However, if the nonquoted param is at the end of the string, there would be no comma
+    // This is only possible if there are no spaces anywhere
+    NSRange endRange2 = [header rangeOfString:@" " options:0 range:postStartRange];
+    if (endRange2.location != NSNotFound) {
+      return nil;
+    }
+    else {
+      return [header substringWithRange:postStartRange];
+    }
+  }
+  else {
+    NSRange subHeaderRange = NSMakeRange(postStartRangeLocation, endRange.location - postStartRangeLocation);
+    return [header substringWithRange:subHeaderRange];
+  }
 }
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPConnection.h
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPConnection.h
@@ -3,7 +3,7 @@
 @class LPGCDAsyncSocket;
 @class LPHTTPMessage;
 @class LPHTTPServer;
-
+@class LPWebSocket;
 @protocol LPHTTPResponse;
 
 
@@ -13,19 +13,19 @@
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@interface LPHTTPConfig : NSObject
-{
-	LPHTTPServer *server;
-	NSString *documentRoot;
-	dispatch_queue_t queue;
+@interface LPHTTPConfig : NSObject {
+  LPHTTPServer __unsafe_unretained *server;
+  NSString __strong *documentRoot;
+  dispatch_queue_t queue;
 }
 
 - (id)initWithServer:(LPHTTPServer *)server documentRoot:(NSString *)documentRoot;
+
 - (id)initWithServer:(LPHTTPServer *)server documentRoot:(NSString *)documentRoot queue:(dispatch_queue_t)q;
 
-@property (nonatomic, readonly) LPHTTPServer *server;
-@property (nonatomic, readonly) NSString *documentRoot;
-@property (nonatomic, readonly) dispatch_queue_t queue;
+@property(nonatomic, unsafe_unretained, readonly) LPHTTPServer *server;
+@property(nonatomic, strong, readonly) NSString *documentRoot;
+@property(nonatomic, readonly) dispatch_queue_t queue;
 
 @end
 
@@ -33,86 +33,106 @@
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@interface LPHTTPConnection : NSObject
-{
-	dispatch_queue_t connectionQueue;
-	LPGCDAsyncSocket *asyncSocket;
-	LPHTTPConfig *config;
-	
-	BOOL started;
-	
-	LPHTTPMessage *request;
-	unsigned int numHeaderLines;
-	
-	BOOL sentResponseHeaders;
-	
-	NSString *nonce;
-	long lastNC;
-	
-	NSObject<LPHTTPResponse> *httpResponse;
-	
-	NSMutableArray *ranges;
-	NSMutableArray *ranges_headers;
-	NSString *ranges_boundry;
-	int rangeIndex;
-	
-	UInt64 requestContentLength;
-	UInt64 requestContentLengthReceived;
-	UInt64 requestChunkSize;
-	UInt64 requestChunkSizeReceived;
-  
-	NSMutableArray *responseDataSizes;
+@interface LPHTTPConnection : NSObject {
+  dispatch_queue_t connectionQueue;
+  LPGCDAsyncSocket *asyncSocket;
+  LPHTTPConfig *config;
+
+  BOOL started;
+
+  LPHTTPMessage *request;
+  unsigned int numHeaderLines;
+
+  BOOL sentResponseHeaders;
+
+  NSString *nonce;
+  long lastNC;
+
+  NSObject <LPHTTPResponse> *httpResponse;
+
+  NSMutableArray *ranges;
+  NSMutableArray *ranges_headers;
+  NSString *ranges_boundry;
+  int rangeIndex;
+
+  UInt64 requestContentLength;
+  UInt64 requestContentLengthReceived;
+  UInt64 requestChunkSize;
+  UInt64 requestChunkSizeReceived;
+
+  NSMutableArray *responseDataSizes;
 }
 
 - (id)initWithAsyncSocket:(LPGCDAsyncSocket *)newSocket configuration:(LPHTTPConfig *)aConfig;
 
 - (void)start;
+
 - (void)stop;
 
 - (void)startConnection;
 
 - (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path;
+
 - (BOOL)expectsRequestBodyFromMethod:(NSString *)method atPath:(NSString *)path;
 
 - (BOOL)isSecureServer;
+
 - (NSArray *)sslIdentityAndCertificates;
 
 - (BOOL)isPasswordProtected:(NSString *)path;
+
 - (BOOL)useDigestAccessAuthentication;
+
 - (NSString *)realm;
+
 - (NSString *)passwordForUser:(NSString *)username;
 
 - (NSDictionary *)parseParams:(NSString *)query;
+
 - (NSDictionary *)parseGetParams;
 
 - (NSString *)requestURI;
 
 - (NSArray *)directoryIndexFileNames;
+
 - (NSString *)filePathForURI:(NSString *)path;
+
 - (NSString *)filePathForURI:(NSString *)path allowDirectory:(BOOL)allowDirectory;
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+
+- (NSObject <LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+
+- (LPWebSocket *)webSocketForURI:(NSString *)path;
 
 - (void)prepareForBodyWithSize:(UInt64)contentLength;
+
 - (void)processBodyData:(NSData *)postDataChunk;
+
 - (void)finishBody;
 
 - (void)handleVersionNotSupported:(NSString *)version;
+
 - (void)handleAuthenticationFailed;
+
 - (void)handleResourceNotFound;
+
 - (void)handleInvalidRequest:(NSData *)data;
+
 - (void)handleUnknownMethod:(NSString *)method;
 
 - (NSData *)preprocessResponse:(LPHTTPMessage *)response;
+
 - (NSData *)preprocessErrorResponse:(LPHTTPMessage *)response;
 
 - (void)finishResponse;
 
 - (BOOL)shouldDie;
+
 - (void)die;
 
 @end
 
-@interface LPHTTPConnection (AsynchronousHTTPResponse)
-- (void)responseHasAvailableData:(NSObject<LPHTTPResponse> *)sender;
-- (void)responseDidAbort:(NSObject<LPHTTPResponse> *)sender;
+@interface LPHTTPConnection (LPAsynchronousHTTPResponse)
+- (void)responseHasAvailableData:(NSObject <LPHTTPResponse> *)sender;
+
+- (void)responseDidAbort:(NSObject <LPHTTPResponse> *)sender;
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPConnection.m
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPConnection.m
@@ -9,27 +9,31 @@
 #import "NSData+LPCHSExtensions.h"
 #import "LPHTTPFileResponse.h"
 #import "LPHTTPAsyncFileResponse.h"
+#import "LPWebSocket.h"
+#import "LPHTTPLogging.h"
 
+#if !__has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
 
-// Log levels: off, error, warn, info, verbose
-// Other flags: trace
+static LPLogLevel __unused lpHTTPLogLevel = LPLogLevelWarning;
 
 // Define chunk size used to read in data for responses
 // This is how much data will be read from disk into RAM at a time
 #if TARGET_OS_IPHONE
-  #define READ_CHUNKSIZE  (1024 * 128)
+#define READ_CHUNKSIZE  (1024 * 256)
 #else
-  #define READ_CHUNKSIZE  (1024 * 512)
+#define READ_CHUNKSIZE  (1024 * 512)
 #endif
 
 // Define chunk size used to read in POST upload data
 #if TARGET_OS_IPHONE
-  #define POST_CHUNKSIZE  (1024 * 32)
+#define POST_CHUNKSIZE  (1024 * 256)
 #else
-  #define POST_CHUNKSIZE  (1024 * 128)
+#define POST_CHUNKSIZE  (1024 * 512)
 #endif
 
-// Define the various timeouts (in seconds) for various parts of the LPHTTP process
+// Define the various timeouts (in seconds) for various parts of the HTTP process
 #define TIMEOUT_READ_FIRST_HEADER_LINE       30
 #define TIMEOUT_READ_SUBSEQUENT_HEADER_LINE  30
 #define TIMEOUT_READ_BODY                    -1
@@ -47,37 +51,38 @@
 #define MAX_CHUNK_LINE_LENGTH    200
 
 // Define the various tags we'll use to differentiate what it is we're currently doing
-#define LPHTTP_REQUEST_HEADER                10
-#define LPHTTP_REQUEST_BODY                  11
-#define LPHTTP_REQUEST_CHUNK_SIZE            12
-#define LPHTTP_REQUEST_CHUNK_DATA            13
-#define LPHTTP_REQUEST_CHUNK_TRAILER         14
-#define LPHTTP_REQUEST_CHUNK_FOOTER          15
-#define LPHTTP_PARTIAL_RESPONSE              20
-#define LPHTTP_PARTIAL_RESPONSE_HEADER       21
-#define LPHTTP_PARTIAL_RESPONSE_BODY         22
-#define LPHTTP_CHUNKED_RESPONSE_HEADER       30
-#define LPHTTP_CHUNKED_RESPONSE_BODY         31
-#define LPHTTP_CHUNKED_RESPONSE_FOOTER       32
-#define LPHTTP_PARTIAL_RANGE_RESPONSE_BODY   40
-#define LPHTTP_PARTIAL_RANGES_RESPONSE_BODY  50
-#define LPHTTP_RESPONSE                      90
-#define LPHTTP_FINAL_RESPONSE                91
+#define HTTP_REQUEST_HEADER                10
+#define HTTP_REQUEST_BODY                  11
+#define HTTP_REQUEST_CHUNK_SIZE            12
+#define HTTP_REQUEST_CHUNK_DATA            13
+#define HTTP_REQUEST_CHUNK_TRAILER         14
+#define HTTP_REQUEST_CHUNK_FOOTER          15
+#define HTTP_PARTIAL_RESPONSE              20
+#define HTTP_PARTIAL_RESPONSE_HEADER       21
+#define HTTP_PARTIAL_RESPONSE_BODY         22
+#define HTTP_CHUNKED_RESPONSE_HEADER       30
+#define HTTP_CHUNKED_RESPONSE_BODY         31
+#define HTTP_CHUNKED_RESPONSE_FOOTER       32
+#define HTTP_PARTIAL_RANGE_RESPONSE_BODY   40
+#define HTTP_PARTIAL_RANGES_RESPONSE_BODY  50
+#define HTTP_RESPONSE                      90
+#define HTTP_FINAL_RESPONSE                91
 
 // A quick note about the tags:
-// 
-// The LPHTTP_RESPONSE and LPHTTP_FINAL_RESPONSE are designated tags signalling that the response is completely sent.
-// That is, in the onSocket:didWriteDataWithTag: method, if the tag is LPHTTP_RESPONSE or LPHTTP_FINAL_RESPONSE,
+//
+// The HTTP_RESPONSE and HTTP_FINAL_RESPONSE are designated tags signalling that the response is completely sent.
+// That is, in the onSocket:didWriteDataWithTag: method, if the tag is HTTP_RESPONSE or HTTP_FINAL_RESPONSE,
 // it is assumed that the response is now completely sent.
-// Use LPHTTP_RESPONSE if it's the end of a response, and you want to start reading more requests afterwards.
-// Use LPHTTP_FINAL_RESPONSE if you wish to terminate the connection after sending the response.
-// 
+// Use HTTP_RESPONSE if it's the end of a response, and you want to start reading more requests afterwards.
+// Use HTTP_FINAL_RESPONSE if you wish to terminate the connection after sending the response.
+//
 // If you are sending multiple data segments in a custom response, make sure that only the last segment has
-// the LPHTTP_RESPONSE tag. For all other segments prior to the last segment use LPHTTP_PARTIAL_RESPONSE, or some other
+// the HTTP_RESPONSE tag. For all other segments prior to the last segment use HTTP_PARTIAL_RESPONSE, or some other
 // tag of your own invention.
 
 @interface LPHTTPConnection (PrivateAPI)
 - (void)startReadingRequest;
+
 - (void)sendResponseHeadersAndBody;
 @end
 
@@ -87,31 +92,78 @@
 
 @implementation LPHTTPConnection
 
+static dispatch_queue_t recentNonceQueue;
 static NSMutableArray *recentNonces;
 
 /**
  * This method is automatically called (courtesy of Cocoa) before the first instantiation of this class.
  * We use it to initialize any static variables.
-**/
-+ (void)initialize
-{
-	static BOOL initialized = NO;
-	if(!initialized)
-	{
-		// Initialize class variables
-		recentNonces = [[NSMutableArray alloc] initWithCapacity:5];
-		
-		initialized = YES;
-	}
+ **/
++ (void)initialize {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+
+    // Initialize class variables
+    recentNonceQueue = dispatch_queue_create("LPHTTPConnection-Nonce", NULL);
+    recentNonces = [[NSMutableArray alloc] initWithCapacity:5];
+  });
 }
 
 /**
- * This method is designed to be called by a scheduled timer, and will remove a nonce from the recent nonce list.
- * The nonce to remove should be set as the timer's userInfo.
-**/
-+ (void)removeRecentNonce:(NSTimer *)aTimer
-{
-	[recentNonces removeObject:[aTimer userInfo]];
+ * Generates and returns an authentication nonce.
+ * A nonce is a  server-specified string uniquely generated for each 401 response.
+ * The default implementation uses a single nonce for each session.
+ **/
++ (NSString *)generateNonce {
+  // We use the Core Foundation UUID class to generate a nonce value for us
+  // UUIDs (Universally Unique Identifiers) are 128-bit values guaranteed to be unique.
+  CFUUIDRef theUUID = CFUUIDCreate(NULL);
+  NSString *newNonce = (__bridge_transfer NSString *) CFUUIDCreateString(NULL, theUUID);
+  CFRelease(theUUID);
+
+  // We have to remember that the HTTP protocol is stateless.
+  // Even though with version 1.1 persistent connections are the norm, they are not guaranteed.
+  // Thus if we generate a nonce for this connection,
+  // it should be honored for other connections in the near future.
+  //
+  // In fact, this is absolutely necessary in order to support QuickTime.
+  // When QuickTime makes it's initial connection, it will be unauthorized, and will receive a nonce.
+  // It then disconnects, and creates a new connection with the nonce, and proper authentication.
+  // If we don't honor the nonce for the second connection, QuickTime will repeat the process and never connect.
+
+  dispatch_async(recentNonceQueue, ^{
+    @autoreleasepool {
+
+      [recentNonces addObject:newNonce];
+    }
+  });
+
+  double delayInSeconds = TIMEOUT_NONCE;
+  dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
+  dispatch_after(popTime, recentNonceQueue, ^{
+    @autoreleasepool {
+
+      [recentNonces removeObject:newNonce];
+    }
+  });
+
+  return newNonce;
+}
+
+/**
+ * Returns whether or not the given nonce is in the list of recently generated nonce's.
+ **/
++ (BOOL)hasRecentNonce:(NSString *)recentNonce {
+  __block BOOL result = NO;
+
+  dispatch_sync(recentNonceQueue, ^{
+    @autoreleasepool {
+
+      result = [recentNonces containsObject:recentNonce];
+    }
+  });
+
+  return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -120,79 +172,61 @@ static NSMutableArray *recentNonces;
 
 /**
  * Sole Constructor.
- * Associates this new LPHTTP connection with the given AsyncSocket.
- * This LPHTTP connection object will become the socket's delegate and take over responsibility for the socket.
-**/
-- (id)initWithAsyncSocket:(LPGCDAsyncSocket *)newSocket configuration:(LPHTTPConfig *)aConfig
-{
-	if ((self = [super init]))
-	{
-		////LPHTTPLogTrace();
-		
-		if (aConfig.queue)
-		{
-			connectionQueue = aConfig.queue;
-			dispatch_retain(connectionQueue);
-		}
-		else
-		{
-			connectionQueue = dispatch_queue_create("LPHTTPConnection", NULL);
-		}
-		
-		// Take over ownership of the socket
-		asyncSocket = [newSocket retain];
-		[asyncSocket setDelegate:self delegateQueue:connectionQueue];
-		
-		// Store configuration
-		config = [aConfig retain];
-		
-		// Initialize lastNC (last nonce count).
-		// Used with digest access authentication.
-		// These must increment for each request from the client.
-		lastNC = 0;
-		
-		// Create a new LPHTTP message
-		request = [[LPHTTPMessage alloc] initEmptyRequest];
-		
-		numHeaderLines = 0;
-		
-		responseDataSizes = [[NSMutableArray alloc] initWithCapacity:5];
-	}
-	return self;
+ * Associates this new HTTP connection with the given AsyncSocket.
+ * This HTTP connection object will become the socket's delegate and take over responsibility for the socket.
+ **/
+- (id)initWithAsyncSocket:(LPGCDAsyncSocket *)newSocket configuration:(LPHTTPConfig *)aConfig {
+  if ((self = [super init])) {
+    LPHTTPLogTrace();
+
+    if (aConfig.queue) {
+      connectionQueue = aConfig.queue;
+#if !OS_OBJECT_USE_OBJC
+      dispatch_retain(connectionQueue);
+#endif
+    }
+    else {
+      connectionQueue = dispatch_queue_create("LPHTTPConnection", NULL);
+    }
+
+    // Take over ownership of the socket
+    asyncSocket = newSocket;
+    [asyncSocket setDelegate:self delegateQueue:connectionQueue];
+
+    // Store configuration
+    config = aConfig;
+
+    // Initialize lastNC (last nonce count).
+    // Used with digest access authentication.
+    // These must increment for each request from the client.
+    lastNC = 0;
+
+    // Create a new HTTP message
+    request = [[LPHTTPMessage alloc] initEmptyRequest];
+
+    numHeaderLines = 0;
+
+    responseDataSizes = [[NSMutableArray alloc] initWithCapacity:5];
+  }
+  return self;
 }
 
 /**
  * Standard Deconstructor.
-**/
-- (void)dealloc
-{
-	//LPHTTPLogTrace();
-	
-	dispatch_release(connectionQueue);
-	
-	[asyncSocket setDelegate:nil delegateQueue:NULL];
-	[asyncSocket disconnect];
-	[asyncSocket release];
-	
-	[config release];
-	
-	[request release];
-	
-	[nonce release];
-	
-	if ([httpResponse respondsToSelector:@selector(connectionDidClose)])
-	{
-		[httpResponse connectionDidClose];
-	}
-	[httpResponse release];
-	
-	[ranges release];
-	[ranges_headers release];
-	[ranges_boundry release];
-	
-	[responseDataSizes release];
-	
-	[super dealloc];
+ **/
+- (void)dealloc {
+  LPHTTPLogTrace();
+
+#if !OS_OBJECT_USE_OBJC
+  dispatch_release(connectionQueue);
+#endif
+
+  [asyncSocket setDelegate:nil delegateQueue:NULL];
+  [asyncSocket disconnect];
+
+  if ([httpResponse respondsToSelector:@selector(connectionDidClose)]) {
+    [httpResponse connectionDidClose];
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -202,62 +236,60 @@ static NSMutableArray *recentNonces;
 /**
  * Returns whether or not the server will accept messages of a given method
  * at a particular URI.
-**/
-- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to support methods such as POST.
-	// 
-	// Things you may want to consider:
-	// - Does the given path represent a resource that is designed to accept this method?
-	// - If accepting an upload, is the size of the data being uploaded too big?
-	//   To do this you can check the requestContentLength variable.
-	// 
-	// For more information, you can always access the LPHTTPMessage request variable.
-	// 
-	// You should fall through with a call to [super supportsMethod:method atPath:path]
-	// 
-	// See also: expectsRequestBodyFromMethod:atPath:
-	
-	if ([method isEqualToString:@"GET"])
-		return YES;
-	
-	if ([method isEqualToString:@"HEAD"])
-		return YES;
-		
-	return NO;
+ **/
+- (BOOL)supportsMethod:(NSString *)method atPath:(NSString *)path {
+  LPHTTPLogTrace();
+
+  // Override me to support methods such as POST.
+  //
+  // Things you may want to consider:
+  // - Does the given path represent a resource that is designed to accept this method?
+  // - If accepting an upload, is the size of the data being uploaded too big?
+  //   To do this you can check the requestContentLength variable.
+  //
+  // For more information, you can always access the LPHTTPMessage request variable.
+  //
+  // You should fall through with a call to [super supportsMethod:method atPath:path]
+  //
+  // See also: expectsRequestBodyFromMethod:atPath:
+
+  if ([method isEqualToString:@"GET"])
+    return YES;
+
+  if ([method isEqualToString:@"HEAD"])
+    return YES;
+
+  return NO;
 }
 
 /**
  * Returns whether or not the server expects a body from the given method.
- * 
+ *
  * In other words, should the server expect a content-length header and associated body from this method.
  * This would be true in the case of a POST, where the client is sending data,
  * or for something like PUT where the client is supposed to be uploading a file.
-**/
-- (BOOL)expectsRequestBodyFromMethod:(NSString *)method atPath:(NSString *)path
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to add support for other methods that expect the client
-	// to send a body along with the request header.
-	// 
-	// You should fall through with a call to [super expectsRequestBodyFromMethod:method atPath:path]
-	// 
-	// See also: supportsMethod:atPath:
-	
-	if ([method isEqualToString:@"POST"])
-		return YES;
-	
-	if ([method isEqualToString:@"PUT"])
-		return YES;
-	
-	return NO;
+ **/
+- (BOOL)expectsRequestBodyFromMethod:(NSString *)method atPath:(NSString *)path {
+  LPHTTPLogTrace();
+
+  // Override me to add support for other methods that expect the client
+  // to send a body along with the request header.
+  //
+  // You should fall through with a call to [super expectsRequestBodyFromMethod:method atPath:path]
+  //
+  // See also: supportsMethod:atPath:
+
+  if ([method isEqualToString:@"POST"])
+    return YES;
+
+  if ([method isEqualToString:@"PUT"])
+    return YES;
+
+  return NO;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#pragma mark LPHTTPS
+#pragma mark HTTPS
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
@@ -266,29 +298,27 @@ static NSMutableArray *recentNonces;
  * This is the equivalent of having an https server, where it is assumed that all connections must be secure.
  * If this is the case, then unsecure connections will not be allowed on this server, and a separate unsecure server
  * would need to be run on a separate port in order to support unsecure connections.
- * 
+ *
  * Note: In order to support secure connections, the sslIdentityAndCertificates method must be implemented.
-**/
-- (BOOL)isSecureServer
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to create an https server...
-	
-	return NO;
+ **/
+- (BOOL)isSecureServer {
+  LPHTTPLogTrace();
+
+  // Override me to create an https server...
+
+  return NO;
 }
 
 /**
  * This method is expected to returns an array appropriate for use in kCFStreamSSLCertificates SSL Settings.
  * It should be an array of SecCertificateRefs except for the first element in the array, which is a SecIdentityRef.
-**/
-- (NSArray *)sslIdentityAndCertificates
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to provide the proper required SSL identity.
-	
-	return nil;
+ **/
+- (NSArray *)sslIdentityAndCertificates {
+  LPHTTPLogTrace();
+
+  // Override me to provide the proper required SSL identity.
+
+  return nil;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -298,260 +328,204 @@ static NSMutableArray *recentNonces;
 /**
  * Returns whether or not the requested resource is password protected.
  * In this generic implementation, nothing is password protected.
-**/
-- (BOOL)isPasswordProtected:(NSString *)path
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to provide password protection...
-	// You can configure it for the entire server, or based on the current request
-	
-	return NO;
+ **/
+- (BOOL)isPasswordProtected:(NSString *)path {
+  LPHTTPLogTrace();
+
+  // Override me to provide password protection...
+  // You can configure it for the entire server, or based on the current request
+
+  return NO;
 }
 
 /**
  * Returns whether or not the authentication challenge should use digest access authentication.
  * The alternative is basic authentication.
- * 
+ *
  * If at all possible, digest access authentication should be used because it's more secure.
  * Basic authentication sends passwords in the clear and should be avoided unless using SSL/TLS.
-**/
-- (BOOL)useDigestAccessAuthentication
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to customize the authentication scheme
-	// Make sure you understand the security risks of using the weaker basic authentication
-	
-	return YES;
+ **/
+- (BOOL)useDigestAccessAuthentication {
+  LPHTTPLogTrace();
+
+  // Override me to customize the authentication scheme
+  // Make sure you understand the security risks of using the weaker basic authentication
+
+  return YES;
 }
 
 /**
  * Returns the authentication realm.
  * In this generic implmentation, a default realm is used for the entire server.
-**/
-- (NSString *)realm
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to provide a custom realm...
-	// You can configure it for the entire server, or based on the current request
-	
-	return @"defaultRealm@host.com";
+ **/
+- (NSString *)realm {
+  LPHTTPLogTrace();
+
+  // Override me to provide a custom realm...
+  // You can configure it for the entire server, or based on the current request
+
+  return @"defaultRealm@host.com";
 }
 
 /**
  * Returns the password for the given username.
-**/
-- (NSString *)passwordForUser:(NSString *)username
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to provide proper password authentication
-	// You can configure a password for the entire server, or custom passwords for users and/or resources
-	
-	// Security Note:
-	// A nil password means no access at all. (Such as for user doesn't exist)
-	// An empty string password is allowed, and will be treated as any other password. (To support anonymous access)
-	
-	return nil;
-}
+ **/
+- (NSString *)passwordForUser:(NSString *)username {
+  LPHTTPLogTrace();
 
-/**
- * Generates and returns an authentication nonce.
- * A nonce is a  server-specified string uniquely generated for each 401 response.
- * The default implementation uses a single nonce for each session.
-**/
-- (NSString *)generateNonce
-{
-	//LPHTTPLogTrace();
-	
-	// We use the Core Foundation UUID class to generate a nonce value for us
-	// UUIDs (Universally Unique Identifiers) are 128-bit values guaranteed to be unique.
-	CFUUIDRef theUUID = CFUUIDCreate(NULL);
-	NSString *newNonce = [NSMakeCollectable(CFUUIDCreateString(NULL, theUUID)) autorelease];
-	CFRelease(theUUID);
-	
-	// We have to remember that the LPHTTP protocol is stateless.
-	// Even though with version 1.1 persistent connections are the norm, they are not guaranteed.
-	// Thus if we generate a nonce for this connection,
-	// it should be honored for other connections in the near future.
-	// 
-	// In fact, this is absolutely necessary in order to support QuickTime.
-	// When QuickTime makes it's initial connection, it will be unauthorized, and will receive a nonce.
-	// It then disconnects, and creates a new connection with the nonce, and proper authentication.
-	// If we don't honor the nonce for the second connection, QuickTime will repeat the process and never connect.
-	
-	[recentNonces addObject:newNonce];
-	
-	[NSTimer scheduledTimerWithTimeInterval:TIMEOUT_NONCE
-	                                 target:[LPHTTPConnection class]
-	                               selector:@selector(removeRecentNonce:)
-	                               userInfo:newNonce
-	                                repeats:NO];
-	return newNonce;
+  // Override me to provide proper password authentication
+  // You can configure a password for the entire server, or custom passwords for users and/or resources
+
+  // Security Note:
+  // A nil password means no access at all. (Such as for user doesn't exist)
+  // An empty string password is allowed, and will be treated as any other password. (To support anonymous access)
+
+  return nil;
 }
 
 /**
  * Returns whether or not the user is properly authenticated.
-**/
-- (BOOL)isAuthenticated
-{
-	//LPHTTPLogTrace();
-	
-	// Extract the authentication information from the Authorization header
-	LPHTTPAuthenticationRequest *auth = [[[LPHTTPAuthenticationRequest alloc] initWithRequest:request] autorelease];
-	
-	if ([self useDigestAccessAuthentication])
-	{
-		// Digest Access Authentication (RFC 2617)
-		
-		if(![auth isDigest])
-		{
-			// User didn't send proper digest access authentication credentials
-			return NO;
-		}
-		
-		if ([auth username] == nil)
-		{
-			// The client didn't provide a username
-			// Most likely they didn't provide any authentication at all
-			return NO;
-		}
-		
-		NSString *password = [self passwordForUser:[auth username]];
-		if (password == nil)
-		{
-			// No access allowed (username doesn't exist in system)
-			return NO;
-		}
-		
-		NSString *url = [[request url] relativeString];
-		
-		if (![url isEqualToString:[auth uri]])
-		{
-			// Requested URL and Authorization URI do not match
-			// This could be a replay attack
-			// IE - attacker provides same authentication information, but requests a different resource
-			return NO;
-		}
-		
-		// The nonce the client provided will most commonly be stored in our local (cached) nonce variable
-		if (![nonce isEqualToString:[auth nonce]])
-		{
-			// The given nonce may be from another connection
-			// We need to search our list of recent nonce strings that have been recently distributed
-			if ([recentNonces containsObject:[auth nonce]])
-			{
-				// Store nonce in local (cached) nonce variable to prevent array searches in the future
-				[nonce release];
-				nonce = [[auth nonce] copy];
-				
-				// The client has switched to using a different nonce value
-				// This may happen if the client tries to get a file in a directory with different credentials.
-				// The previous credentials wouldn't work, and the client would receive a 401 error
-				// along with a new nonce value. The client then uses this new nonce value and requests the file again.
-				// Whatever the case may be, we need to reset lastNC, since that variable is on a per nonce basis.
-				lastNC = 0;
-			}
-			else
-			{
-				// We have no knowledge of ever distributing such a nonce.
-				// This could be a replay attack from a previous connection in the past.
-				return NO;
-			}
-		}
-		
-		long authNC = strtol([[auth nc] UTF8String], NULL, 16);
-		
-		if (authNC <= lastNC)
-		{
-			// The nc value (nonce count) hasn't been incremented since the last request.
-			// This could be a replay attack.
-			return NO;
-		}
-		lastNC = authNC;
-		
-		NSString *HA1str = [NSString stringWithFormat:@"%@:%@:%@", [auth username], [auth realm], password];
-		NSString *HA2str = [NSString stringWithFormat:@"%@:%@", [request method], [auth uri]];
-		
-		NSString *HA1 = [[[HA1str dataUsingEncoding:NSUTF8StringEncoding] md5Digest] hexStringValue];
-		
-		NSString *HA2 = [[[HA2str dataUsingEncoding:NSUTF8StringEncoding] md5Digest] hexStringValue];
-		
-		NSString *responseStr = [NSString stringWithFormat:@"%@:%@:%@:%@:%@:%@",
-								 HA1, [auth nonce], [auth nc], [auth cnonce], [auth qop], HA2];
-		
-		NSString *response = [[[responseStr dataUsingEncoding:NSUTF8StringEncoding] md5Digest] hexStringValue];
-		
-		return [response isEqualToString:[auth response]];
-	}
-	else
-	{
-		// Basic Authentication
-		
-		if (![auth isBasic])
-		{
-			// User didn't send proper base authentication credentials
-			return NO;
-		}
-		
-		// Decode the base 64 encoded credentials
-		NSString *base64Credentials = [auth base64Credentials];
-		
-		NSData *temp = [[base64Credentials dataUsingEncoding:NSUTF8StringEncoding] base64Decoded];
-		
-		NSString *credentials = [[[NSString alloc] initWithData:temp encoding:NSUTF8StringEncoding] autorelease];
-		
-		// The credentials should be of the form "username:password"
-		// The username is not allowed to contain a colon
-		
-		NSRange colonRange = [credentials rangeOfString:@":"];
-		
-		if (colonRange.length == 0)
-		{
-			// Malformed credentials
-			return NO;
-		}
-		
-		NSString *credUsername = [credentials substringToIndex:colonRange.location];
-		NSString *credPassword = [credentials substringFromIndex:(colonRange.location + colonRange.length)];
-		
-		NSString *password = [self passwordForUser:credUsername];
-		if (password == nil)
-		{
-			// No access allowed (username doesn't exist in system)
-			return NO;
-		}
-		
-		return [password isEqualToString:credPassword];
-	}
+ **/
+- (BOOL)isAuthenticated {
+  LPHTTPLogTrace();
+
+  // Extract the authentication information from the Authorization header
+  LPHTTPAuthenticationRequest *auth = [[LPHTTPAuthenticationRequest alloc] initWithRequest:request];
+
+  if ([self useDigestAccessAuthentication]) {
+    // Digest Access Authentication (RFC 2617)
+
+    if (![auth isDigest]) {
+      // User didn't send proper digest access authentication credentials
+      return NO;
+    }
+
+    if ([auth username] == nil) {
+      // The client didn't provide a username
+      // Most likely they didn't provide any authentication at all
+      return NO;
+    }
+
+    NSString *password = [self passwordForUser:[auth username]];
+    if (password == nil) {
+      // No access allowed (username doesn't exist in system)
+      return NO;
+    }
+
+    NSString *url = [[request url] relativeString];
+
+    if (![url isEqualToString:[auth uri]]) {
+      // Requested URL and Authorization URI do not match
+      // This could be a replay attack
+      // IE - attacker provides same authentication information, but requests a different resource
+      return NO;
+    }
+
+    // The nonce the client provided will most commonly be stored in our local (cached) nonce variable
+    if (![nonce isEqualToString:[auth nonce]]) {
+      // The given nonce may be from another connection
+      // We need to search our list of recent nonce strings that have been recently distributed
+      if ([[self class] hasRecentNonce:[auth nonce]]) {
+        // Store nonce in local (cached) nonce variable to prevent array searches in the future
+        nonce = [[auth nonce] copy];
+
+        // The client has switched to using a different nonce value
+        // This may happen if the client tries to get a file in a directory with different credentials.
+        // The previous credentials wouldn't work, and the client would receive a 401 error
+        // along with a new nonce value. The client then uses this new nonce value and requests the file again.
+        // Whatever the case may be, we need to reset lastNC, since that variable is on a per nonce basis.
+        lastNC = 0;
+      }
+      else {
+        // We have no knowledge of ever distributing such a nonce.
+        // This could be a replay attack from a previous connection in the past.
+        return NO;
+      }
+    }
+
+    long authNC = strtol([[auth nc] UTF8String], NULL, 16);
+
+    if (authNC <= lastNC) {
+      // The nc value (nonce count) hasn't been incremented since the last request.
+      // This could be a replay attack.
+      return NO;
+    }
+    lastNC = authNC;
+
+    NSString *HA1str = [NSString stringWithFormat:@"%@:%@:%@", [auth username], [auth realm], password];
+    NSString *HA2str = [NSString stringWithFormat:@"%@:%@", [request method], [auth uri]];
+
+    NSString *HA1 = [[[HA1str dataUsingEncoding:NSUTF8StringEncoding] md5Digest] hexStringValue];
+
+    NSString *HA2 = [[[HA2str dataUsingEncoding:NSUTF8StringEncoding] md5Digest] hexStringValue];
+
+    NSString *responseStr = [NSString stringWithFormat:@"%@:%@:%@:%@:%@:%@",
+                             HA1, [auth nonce], [auth nc], [auth cnonce], [auth qop], HA2];
+
+    NSString *response = [[[responseStr dataUsingEncoding:NSUTF8StringEncoding] md5Digest] hexStringValue];
+
+    return [response isEqualToString:[auth response]];
+  }
+  else {
+    // Basic Authentication
+
+    if (![auth isBasic]) {
+      // User didn't send proper base authentication credentials
+      return NO;
+    }
+
+    // Decode the base 64 encoded credentials
+    NSString *base64Credentials = [auth base64Credentials];
+
+    NSData *temp = [[base64Credentials dataUsingEncoding:NSUTF8StringEncoding] base64Decoded];
+
+    NSString *credentials = [[NSString alloc] initWithData:temp encoding:NSUTF8StringEncoding];
+
+    // The credentials should be of the form "username:password"
+    // The username is not allowed to contain a colon
+
+    NSRange colonRange = [credentials rangeOfString:@":"];
+
+    if (colonRange.length == 0) {
+      // Malformed credentials
+      return NO;
+    }
+
+    NSString *credUsername = [credentials substringToIndex:colonRange.location];
+    NSString *credPassword = [credentials substringFromIndex:(colonRange.location + colonRange.length)];
+
+    NSString *password = [self passwordForUser:credUsername];
+    if (password == nil) {
+      // No access allowed (username doesn't exist in system)
+      return NO;
+    }
+
+    return [password isEqualToString:credPassword];
+  }
 }
 
 /**
  * Adds a digest access authentication challenge to the given response.
-**/
-- (void)addDigestAuthChallenge:(LPHTTPMessage *)response
-{
-	//LPHTTPLogTrace();
-	
-	NSString *authFormat = @"Digest realm=\"%@\", qop=\"auth\", nonce=\"%@\"";
-	NSString *authInfo = [NSString stringWithFormat:authFormat, [self realm], [self generateNonce]];
-	
-	[response setHeaderField:@"WWW-Authenticate" value:authInfo];
+ **/
+- (void)addDigestAuthChallenge:(LPHTTPMessage *)response {
+  LPHTTPLogTrace();
+
+  NSString *authFormat = @"Digest realm=\"%@\", qop=\"auth\", nonce=\"%@\"";
+  NSString *authInfo = [NSString stringWithFormat:authFormat, [self realm], [[self class] generateNonce]];
+
+  [response setHeaderField:@"WWW-Authenticate" value:authInfo];
 }
 
 /**
  * Adds a basic authentication challenge to the given response.
-**/
-- (void)addBasicAuthChallenge:(LPHTTPMessage *)response
-{
-	//LPHTTPLogTrace();
-	
-	NSString *authFormat = @"Basic realm=\"%@\"";
-	NSString *authInfo = [NSString stringWithFormat:authFormat, [self realm]];
-	
-	[response setHeaderField:@"WWW-Authenticate" value:authInfo];
+ **/
+- (void)addBasicAuthChallenge:(LPHTTPMessage *)response {
+  LPHTTPLogTrace();
+
+  NSString *authFormat = @"Basic realm=\"%@\"";
+  NSString *authInfo = [NSString stringWithFormat:authFormat, [self realm]];
+
+  [response setHeaderField:@"WWW-Authenticate" value:authInfo];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -559,176 +533,158 @@ static NSMutableArray *recentNonces;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Starting point for the LPHTTP connection after it has been fully initialized (including subclasses).
- * This method is called by the LPHTTP server.
-**/
-- (void)start
-{
-	dispatch_async(connectionQueue, ^{
-		
-		if (started) return;
-		started = YES;
-		
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		
-		[self startConnection];
-		
-		[pool drain];
-	});
+ * Starting point for the HTTP connection after it has been fully initialized (including subclasses).
+ * This method is called by the HTTP server.
+ **/
+- (void)start {
+  dispatch_async(connectionQueue, ^{
+    @autoreleasepool {
+
+      if (!self->started) {
+        self->started = YES;
+        [self startConnection];
+      }
+    }
+  });
 }
 
 /**
  * This method is called by the LPHTTPServer if it is asked to stop.
  * The server, in turn, invokes stop on each LPHTTPConnection instance.
-**/
-- (void)stop
-{
-	dispatch_async(connectionQueue, ^{
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		
-		// Disconnect the socket.
-		// The socketDidDisconnect delegate method will handle everything else.
-		[asyncSocket disconnect];
-		
-		[pool drain];
-	});
+ **/
+- (void)stop {
+  dispatch_async(connectionQueue, ^{
+    @autoreleasepool {
+
+      // Disconnect the socket.
+      // The socketDidDisconnect delegate method will handle everything else.
+      [self->asyncSocket disconnect];
+    }
+  });
 }
 
 /**
- * Starting point for the LPHTTP connection.
-**/
-- (void)startConnection
-{
-	// Override me to do any custom work before the connection starts.
-	// 
-	// Be sure to invoke [super startConnection] when you're done.
-	
-	//LPHTTPLogTrace();
-	
-	if ([self isSecureServer])
-	{
-		// We are configured to be an LPHTTPS server.
-		// That is, we secure via SSL/TLS the connection prior to any communication.
-		
-		NSArray *certificates = [self sslIdentityAndCertificates];
-		
-		if ([certificates count] > 0)
-		{
-			// All connections are assumed to be secure. Only secure connections are allowed on this server.
-			NSMutableDictionary *settings = [NSMutableDictionary dictionaryWithCapacity:3];
-			
-			// Configure this connection as the server
-			[settings setObject:[NSNumber numberWithBool:YES]
-						 forKey:(NSString *)kCFStreamSSLIsServer];
-			
-			[settings setObject:certificates
-						 forKey:(NSString *)kCFStreamSSLCertificates];
-			
-			// Configure this connection to use the highest possible SSL level
-			[settings setObject:(NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL
-						 forKey:(NSString *)kCFStreamSSLLevel];
-			
-			[asyncSocket startTLS:settings];
-		}
-	}
-	
-	[self startReadingRequest];
+ * Starting point for the HTTP connection.
+ **/
+- (void)startConnection {
+  // Override me to do any custom work before the connection starts.
+  //
+  // Be sure to invoke [super startConnection] when you're done.
+
+  LPHTTPLogTrace();
+
+  if ([self isSecureServer]) {
+    // We are configured to be an HTTPS server.
+    // That is, we secure via SSL/TLS the connection prior to any communication.
+
+    NSArray *certificates = [self sslIdentityAndCertificates];
+
+    if ([certificates count] > 0) {
+      // All connections are assumed to be secure. Only secure connections are allowed on this server.
+      NSMutableDictionary *settings = [NSMutableDictionary dictionaryWithCapacity:3];
+
+      // Configure this connection as the server
+      [settings setObject:[NSNumber numberWithBool:YES]
+                   forKey:(NSString *) kCFStreamSSLIsServer];
+
+      [settings setObject:certificates
+                   forKey:(NSString *) kCFStreamSSLCertificates];
+
+      // Configure this connection to use the highest possible SSL level
+      [settings setObject:(NSString *) kCFStreamSocketSecurityLevelNegotiatedSSL
+                   forKey:(NSString *) kCFStreamSSLLevel];
+
+      [asyncSocket startTLS:settings];
+    }
+  }
+
+  [self startReadingRequest];
 }
 
 /**
- * Starts reading an LPHTTP request.
-**/
-- (void)startReadingRequest
-{
-	//LPHTTPLogTrace();
-	
-	[asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
-	                withTimeout:TIMEOUT_READ_FIRST_HEADER_LINE
-	                  maxLength:MAX_HEADER_LINE_LENGTH
-	                        tag:LPHTTP_REQUEST_HEADER];
+ * Starts reading an HTTP request.
+ **/
+- (void)startReadingRequest {
+  LPHTTPLogTrace();
+
+  [asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
+                  withTimeout:TIMEOUT_READ_FIRST_HEADER_LINE
+                    maxLength:MAX_HEADER_LINE_LENGTH
+                          tag:HTTP_REQUEST_HEADER];
 }
 
 /**
  * Parses the given query string.
- * 
+ *
  * For example, if the query is "q=John%20Mayer%20Trio&num=50"
  * then this method would return the following dictionary:
- * { 
- *   q = "John Mayer Trio" 
- *   num = "50" 
+ * {
+ *   q = "John Mayer Trio"
+ *   num = "50"
  * }
-**/
-- (NSDictionary *)parseParams:(NSString *)query
-{
-	NSArray *components = [query componentsSeparatedByString:@"&"];
-	NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[components count]];
-	
-	NSUInteger i;
-	for (i = 0; i < [components count]; i++)
-	{ 
-		NSString *component = [components objectAtIndex:i];
-		if ([component length] > 0)
-		{
-			NSRange range = [component rangeOfString:@"="];
-			if (range.location != NSNotFound)
-			{ 
-				NSString *escapedKey = [component substringToIndex:(range.location + 0)]; 
-				NSString *escapedValue = [component substringFromIndex:(range.location + 1)];
-				
-				if ([escapedKey length] > 0)
-				{
-					CFStringRef k, v;
-					
-					k = CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)escapedKey, CFSTR(""));
-					v = CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)escapedValue, CFSTR(""));
-					
-					NSString *key, *value;
-					
-					key   = [NSMakeCollectable(k) autorelease];
-					value = [NSMakeCollectable(v) autorelease];
-					
-					if (key)
-					{
-						if (value)
-							[result setObject:value forKey:key]; 
-						else 
-							[result setObject:[NSNull null] forKey:key]; 
-					}
-				}
-			}
-		}
-	}
-	
-	return result;
+ **/
+- (NSDictionary *)parseParams:(NSString *)query {
+  NSArray *components = [query componentsSeparatedByString:@"&"];
+  NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[components count]];
+
+  NSUInteger i;
+  for (i = 0; i < [components count]; i++) {
+    NSString *component = [components objectAtIndex:i];
+    if ([component length] > 0) {
+      NSRange range = [component rangeOfString:@"="];
+      if (range.location != NSNotFound) {
+        NSString *escapedKey = [component substringToIndex:(range.location + 0)];
+        NSString *escapedValue = [component substringFromIndex:(range.location + 1)];
+
+        if ([escapedKey length] > 0) {
+          CFStringRef k, v;
+
+          k = CFURLCreateStringByReplacingPercentEscapes(NULL, (__bridge CFStringRef) escapedKey, CFSTR(""));
+          v = CFURLCreateStringByReplacingPercentEscapes(NULL, (__bridge CFStringRef) escapedValue, CFSTR(""));
+
+          NSString *key, *value;
+
+          key = (__bridge_transfer NSString *) k;
+          value = (__bridge_transfer NSString *) v;
+
+          if (key) {
+            if (value)
+              [result setObject:value forKey:key];
+            else
+              [result setObject:[NSNull null] forKey:key];
+          }
+        }
+      }
+    }
+  }
+
+  return result;
 }
 
-/** 
- * Parses the query variables in the request URI. 
- * 
- * For example, if the request URI was "/search.html?q=John%20Mayer%20Trio&num=50" 
- * then this method would return the following dictionary: 
- * { 
- *   q = "John Mayer Trio" 
- *   num = "50" 
- * } 
-**/ 
-- (NSDictionary *)parseGetParams 
-{
-	if(![request isHeaderComplete]) return nil;
-	
-	NSDictionary *result = nil;
-	
-	NSURL *url = [request url];
-	if(url)
-	{
-		NSString *query = [url query];
-		if (query)
-		{
-			result = [self parseParams:query];
-		}
-	}
-	
-	return result; 
+/**
+ * Parses the query variables in the request URI.
+ *
+ * For example, if the request URI was "/search.html?q=John%20Mayer%20Trio&num=50"
+ * then this method would return the following dictionary:
+ * {
+ *   q = "John Mayer Trio"
+ *   num = "50"
+ * }
+ **/
+- (NSDictionary *)parseGetParams {
+  if (![request isHeaderComplete]) return nil;
+
+  NSDictionary *result = nil;
+
+  NSURL *url = [request url];
+  if (url) {
+    NSString *query = [url query];
+    if (query) {
+      result = [self parseParams:query];
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -736,798 +692,730 @@ static NSMutableArray *recentNonces;
  * If successfull, the variables 'ranges' and 'rangeIndex' will be updated, and YES will be returned.
  * Otherwise, NO is returned, and the range request should be ignored.
  **/
-- (BOOL)parseRangeRequest:(NSString *)rangeHeader withContentLength:(UInt64)contentLength
-{
-	//LPHTTPLogTrace();
-	
-	// Examples of byte-ranges-specifier values (assuming an entity-body of length 10000):
-	// 
-	// - The first 500 bytes (byte offsets 0-499, inclusive):  bytes=0-499
-	// 
-	// - The second 500 bytes (byte offsets 500-999, inclusive): bytes=500-999
-	// 
-	// - The final 500 bytes (byte offsets 9500-9999, inclusive): bytes=-500
-	// 
-	// - Or bytes=9500-
-	// 
-	// - The first and last bytes only (bytes 0 and 9999):  bytes=0-0,-1
-	// 
-	// - Several legal but not canonical specifications of the second 500 bytes (byte offsets 500-999, inclusive):
-	// bytes=500-600,601-999
-	// bytes=500-700,601-999
-	// 
-	
-	NSRange eqsignRange = [rangeHeader rangeOfString:@"="];
-	
-	if(eqsignRange.location == NSNotFound) return NO;
-	
-	NSUInteger tIndex = eqsignRange.location;
-	NSUInteger fIndex = eqsignRange.location + eqsignRange.length;
-	
-	NSString *rangeType  = [[[rangeHeader substringToIndex:tIndex] mutableCopy] autorelease];
-	NSString *rangeValue = [[[rangeHeader substringFromIndex:fIndex] mutableCopy] autorelease];
-	
-	CFStringTrimWhitespace((CFMutableStringRef)rangeType);
-	CFStringTrimWhitespace((CFMutableStringRef)rangeValue);
-	
-	if([rangeType caseInsensitiveCompare:@"bytes"] != NSOrderedSame) return NO;
-	
-	NSArray *rangeComponents = [rangeValue componentsSeparatedByString:@","];
-	
-	if([rangeComponents count] == 0) return NO;
-	
-	[ranges release];
-	ranges = [[NSMutableArray alloc] initWithCapacity:[rangeComponents count]];
-	
-	rangeIndex = 0;
-	
-	// Note: We store all range values in the form of LPDDRange structs, wrapped in NSValue objects.
-	// Since LPDDRange consists of UInt64 values, the range extends up to 16 exabytes.
-	
-	NSUInteger i;
-	for (i = 0; i < [rangeComponents count]; i++)
-	{
-		NSString *rangeComponent = [rangeComponents objectAtIndex:i];
-		
-		NSRange dashRange = [rangeComponent rangeOfString:@"-"];
-		
-		if (dashRange.location == NSNotFound)
-		{
-			// We're dealing with an individual byte number
-			
-			UInt64 byteIndex;
-			if(![NSNumber parseString:rangeComponent intoUInt64:&byteIndex]) return NO;
-			
-			if(byteIndex >= contentLength) return NO;
-			
-			[ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(byteIndex, 1)]];
-		}
-		else
-		{
-			// We're dealing with a range of bytes
-			
-			tIndex = dashRange.location;
-			fIndex = dashRange.location + dashRange.length;
-			
-			NSString *r1str = [rangeComponent substringToIndex:tIndex];
-			NSString *r2str = [rangeComponent substringFromIndex:fIndex];
-			
-			UInt64 r1, r2;
-			
-			BOOL hasR1 = [NSNumber parseString:r1str intoUInt64:&r1];
-			BOOL hasR2 = [NSNumber parseString:r2str intoUInt64:&r2];
-			
-			if (!hasR1)
-			{
-				// We're dealing with a "-[#]" range
-				// 
-				// r2 is the number of ending bytes to include in the range
-				
-				if(!hasR2) return NO;
-				if(r2 > contentLength) return NO;
-				
-				UInt64 startIndex = contentLength - r2;
-				
-				[ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(startIndex, r2)]];
-			}
-			else if (!hasR2)
-			{
-				// We're dealing with a "[#]-" range
-				// 
-				// r1 is the starting index of the range, which goes all the way to the end
-				
-				if(r1 >= contentLength) return NO;
-				
-				[ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(r1, contentLength - r1)]];
-			}
-			else
-			{
-				// We're dealing with a normal "[#]-[#]" range
-				// 
-				// Note: The range is inclusive. So 0-1 has a length of 2 bytes.
-				
-				if(r1 > r2) return NO;
-				if(r2 >= contentLength) return NO;
-				
-				[ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(r1, r2 - r1 + 1)]];
-			}
-		}
-	}
-	
-	if([ranges count] == 0) return NO;
-	
-	// Now make sure none of the ranges overlap
-	
-	for (i = 0; i < [ranges count] - 1; i++)
-	{
-		LPDDRange range1 = [[ranges objectAtIndex:i] lpDDRangeValue];
-		
-		NSUInteger j;
-		for (j = i+1; j < [ranges count]; j++)
-		{
-			LPDDRange range2 = [[ranges objectAtIndex:j] lpDDRangeValue];
-			
-			LPDDRange iRange = LPDDIntersectionRange(range1, range2);
-			
-			if(iRange.length != 0)
-			{
-				return NO;
-			}
-		}
-	}
-	
-	// Sort the ranges
-	
-	[ranges sortUsingSelector:@selector(lpDDRangeCompare:)];
-	
-	return YES;
+- (BOOL)parseRangeRequest:(NSString *)rangeHeader withContentLength:(UInt64)contentLength {
+  LPHTTPLogTrace();
+
+  // Examples of byte-ranges-specifier values (assuming an entity-body of length 10000):
+  //
+  // - The first 500 bytes (byte offsets 0-499, inclusive):  bytes=0-499
+  //
+  // - The second 500 bytes (byte offsets 500-999, inclusive): bytes=500-999
+  //
+  // - The final 500 bytes (byte offsets 9500-9999, inclusive): bytes=-500
+  //
+  // - Or bytes=9500-
+  //
+  // - The first and last bytes only (bytes 0 and 9999):  bytes=0-0,-1
+  //
+  // - Several legal but not canonical specifications of the second 500 bytes (byte offsets 500-999, inclusive):
+  // bytes=500-600,601-999
+  // bytes=500-700,601-999
+  //
+
+  NSRange eqsignRange = [rangeHeader rangeOfString:@"="];
+
+  if (eqsignRange.location == NSNotFound) return NO;
+
+  NSUInteger tIndex = eqsignRange.location;
+  NSUInteger fIndex = eqsignRange.location + eqsignRange.length;
+
+  NSMutableString *rangeType = [[rangeHeader substringToIndex:tIndex] mutableCopy];
+  NSMutableString *rangeValue = [[rangeHeader substringFromIndex:fIndex] mutableCopy];
+
+  CFStringTrimWhitespace((__bridge CFMutableStringRef) rangeType);
+  CFStringTrimWhitespace((__bridge CFMutableStringRef) rangeValue);
+
+  if ([rangeType caseInsensitiveCompare:@"bytes"] != NSOrderedSame) return NO;
+
+  NSArray *rangeComponents = [rangeValue componentsSeparatedByString:@","];
+
+  if ([rangeComponents count] == 0) return NO;
+
+  ranges = [[NSMutableArray alloc] initWithCapacity:[rangeComponents count]];
+
+  rangeIndex = 0;
+
+  // Note: We store all range values in the form of LPDDRange structs, wrapped in NSValue objects.
+  // Since LPDDRange consists of UInt64 values, the range extends up to 16 exabytes.
+
+  NSUInteger i;
+  for (i = 0; i < [rangeComponents count]; i++) {
+    NSString *rangeComponent = [rangeComponents objectAtIndex:i];
+
+    NSRange dashRange = [rangeComponent rangeOfString:@"-"];
+
+    if (dashRange.location == NSNotFound) {
+      // We're dealing with an individual byte number
+
+      UInt64 byteIndex;
+      if (![NSNumber parseString:rangeComponent intoUInt64:&byteIndex]) return NO;
+
+      if (byteIndex >= contentLength) return NO;
+
+      [ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(byteIndex, 1)]];
+    }
+    else {
+      // We're dealing with a range of bytes
+
+      tIndex = dashRange.location;
+      fIndex = dashRange.location + dashRange.length;
+
+      NSString *r1str = [rangeComponent substringToIndex:tIndex];
+      NSString *r2str = [rangeComponent substringFromIndex:fIndex];
+
+      UInt64 r1, r2;
+
+      BOOL hasR1 = [NSNumber parseString:r1str intoUInt64:&r1];
+      BOOL hasR2 = [NSNumber parseString:r2str intoUInt64:&r2];
+
+      if (!hasR1) {
+        // We're dealing with a "-[#]" range
+        //
+        // r2 is the number of ending bytes to include in the range
+
+        if (!hasR2) return NO;
+        if (r2 > contentLength) return NO;
+
+        UInt64 startIndex = contentLength - r2;
+
+        [ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(startIndex, r2)]];
+      }
+      else if (!hasR2) {
+        // We're dealing with a "[#]-" range
+        //
+        // r1 is the starting index of the range, which goes all the way to the end
+
+        if (r1 >= contentLength) return NO;
+
+        [ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(r1, contentLength - r1)]];
+      }
+      else {
+        // We're dealing with a normal "[#]-[#]" range
+        //
+        // Note: The range is inclusive. So 0-1 has a length of 2 bytes.
+
+        if (r1 > r2) return NO;
+        if (r2 >= contentLength) return NO;
+
+        [ranges addObject:[NSValue valueWithLPDDRange:LPDDMakeRange(r1, r2 - r1 + 1)]];
+      }
+    }
+  }
+
+  if ([ranges count] == 0) return NO;
+
+  // Now make sure none of the ranges overlap
+
+  for (i = 0; i < [ranges count] - 1; i++) {
+    LPDDRange range1 = [[ranges objectAtIndex:i] lpDDRangeValue];
+
+    NSUInteger j;
+    for (j = i + 1; j < [ranges count]; j++) {
+      LPDDRange range2 = [[ranges objectAtIndex:j] lpDDRangeValue];
+
+      LPDDRange iRange = LPDDIntersectionRange(range1, range2);
+
+      if (iRange.length != 0) {
+        return NO;
+      }
+    }
+  }
+
+  // Sort the ranges
+
+  [ranges sortUsingSelector:@selector(lpDDRangeCompare:)];
+
+  return YES;
 }
 
-- (NSString *)requestURI
-{
-	if(request == nil) return nil;
-	
-	return [[request url] relativeString];
+- (NSString *)requestURI {
+  if (request == nil) return nil;
+
+  return [[request url] relativeString];
 }
 
 /**
- * This method is called after a full LPHTTP request has been received.
+ * This method is called after a full HTTP request has been received.
  * The current request is in the LPHTTPMessage request variable.
-**/
-- (void)replyToHTTPRequest
-{
-	//LPHTTPLogTrace();
-	
-	
-	// Check the LPHTTP version
-	// We only support version 1.0 and 1.1
-	
-	NSString *version = [request version];
-	if (![version isEqualToString:LPHTTPVersion1_1] && ![version isEqualToString:LPHTTPVersion1_0])
-	{
-		[self handleVersionNotSupported:version];
-		return;
-	}
-	
-	// Extract requested URI
-	NSString *uri = [self requestURI];
-	
-	// Check for WebSocket request
-//	if (0)
-//	{
-//		//LPHTTPLogVerbose(@"isWebSocket");
-//		
-//		WebSocket *ws = [self webSocketForURI:uri];
-//		
-//		if (ws == nil)
-//		{
-//			[self handleResourceNotFound];
-//		}
-//		else
-//		{
-//			[ws start];
-//			
-//			[[config server] addWebSocket:ws];
-//			
-//			// The WebSocket should now be the delegate of the underlying socket.
-//			// But gracefully handle the situation if it forgot.
-//			if ([asyncSocket delegate] == self)
-//			{
-//				//LPHTTPLogWarn(@"%@[%p]: WebSocket forgot to set itself as socket delegate", THIS_FILE, self);
-//				
-//				// Disconnect the socket.
-//				// The socketDidDisconnect delegate method will handle everything else.
-//				[asyncSocket disconnect];
-//			}
-//			else
-//			{
-//				// The WebSocket is using the socket,
-//				// so make sure we don't disconnect it in the dealloc method.
-//				[asyncSocket release];
-//				asyncSocket = nil;
-//				
-//				[self die];
-//				
-//				// Note: There is a timing issue here that should be pointed out.
-//				// 
-//				// A bug that existed in previous versions happend like so:
-//				// - We invoked [self die]
-//				// - This caused us to get released, and our dealloc method to start executing
-//				// - Meanwhile, AsyncSocket noticed a disconnect, and began to dispatch a socketDidDisconnect at us
-//				// - The dealloc method finishes execution, and our instance gets freed
-//				// - The socketDidDisconnect gets run, and a crash occurs
-//				// 
-//				// So the issue we want to avoid is releasing ourself when there is a possibility
-//				// that AsyncSocket might be gearing up to queue a socketDidDisconnect for us.
-//				// 
-//				// In this particular situation notice that we invoke [asyncSocket delegate].
-//				// This method is synchronous concerning AsyncSocket's internal socketQueue.
-//				// Which means we can be sure, when it returns, that AsyncSocket has already
-//				// queued any delegate methods for us if it was going to.
-//				// And if the delegate methods are queued, then we've been properly retained.
-//				// Meaning we won't get released / dealloc'd until the delegate method has finished executing.
-//				// 
-//				// In this rare situation, the die method will get invoked twice.
-//			}
-//		}
-//		
-//		return;
-//	}
-	
-	// Check Authentication (if needed)
-	// If not properly authenticated for resource, issue Unauthorized response
-	if ([self isPasswordProtected:uri] && ![self isAuthenticated])
-	{
-		[self handleAuthenticationFailed];
-		return;
-	}
-	
-	// Extract the method
-	NSString *method = [request method];
-	
-	// Note: We already checked to ensure the method was supported in onSocket:didReadData:withTag:
-	
-	// Respond properly to LPHTTP 'GET' and 'HEAD' commands
-	httpResponse = [[self httpResponseForMethod:method URI:uri] retain];
-	
-	if (httpResponse == nil)
-	{
-		[self handleResourceNotFound];
-		return;
-	}
-	
-	[self sendResponseHeadersAndBody];
+ **/
+- (void)replyToHTTPRequest {
+  LPHTTPLogTrace();
+
+  if (lpHTTPLogLevel == LPLogLevelVerbose) {
+    NSData *tempData = [request messageData];
+
+    NSString *tempStr = [[NSString alloc] initWithData:tempData encoding:NSUTF8StringEncoding];
+    LPHTTPLogVerbose(@"%@[%p]: Received HTTP request:\n%@", LP_THIS_FILE, self, tempStr);
+  }
+
+  // Check the HTTP version
+  // We only support version 1.0 and 1.1
+
+  NSString *version = [request version];
+  if (![version isEqualToString:LPHTTPVersion1_1] && ![version isEqualToString:LPHTTPVersion1_0]) {
+    [self handleVersionNotSupported:version];
+    return;
+  }
+
+  // Extract requested URI
+  NSString *uri = [self requestURI];
+
+  // Check for LPWebSocket request
+  if ([LPWebSocket isWebSocketRequest:request]) {
+    LPHTTPLogVerbose(@"isWebSocket");
+
+    LPWebSocket *ws = [self webSocketForURI:uri];
+
+    if (ws == nil) {
+      [self handleResourceNotFound];
+    }
+    else {
+      [ws start];
+
+      [[config server] addWebSocket:ws];
+
+      // The LPWebSocket should now be the delegate of the underlying socket.
+      // But gracefully handle the situation if it forgot.
+      if ([asyncSocket delegate] == self) {
+        LPHTTPLogWarn(@"%@[%p]: LPWebSocket forgot to set itself as socket delegate", LP_THIS_FILE, self);
+
+        // Disconnect the socket.
+        // The socketDidDisconnect delegate method will handle everything else.
+        [asyncSocket disconnect];
+      }
+      else {
+        // The LPWebSocket is using the socket,
+        // so make sure we don't disconnect it in the dealloc method.
+        asyncSocket = nil;
+
+        [self die];
+
+        // Note: There is a timing issue here that should be pointed out.
+        //
+        // A bug that existed in previous versions happend like so:
+        // - We invoked [self die]
+        // - This caused us to get released, and our dealloc method to start executing
+        // - Meanwhile, AsyncSocket noticed a disconnect, and began to dispatch a socketDidDisconnect at us
+        // - The dealloc method finishes execution, and our instance gets freed
+        // - The socketDidDisconnect gets run, and a crash occurs
+        //
+        // So the issue we want to avoid is releasing ourself when there is a possibility
+        // that AsyncSocket might be gearing up to queue a socketDidDisconnect for us.
+        //
+        // In this particular situation notice that we invoke [asyncSocket delegate].
+        // This method is synchronous concerning AsyncSocket's internal socketQueue.
+        // Which means we can be sure, when it returns, that AsyncSocket has already
+        // queued any delegate methods for us if it was going to.
+        // And if the delegate methods are queued, then we've been properly retained.
+        // Meaning we won't get released / dealloc'd until the delegate method has finished executing.
+        //
+        // In this rare situation, the die method will get invoked twice.
+      }
+    }
+
+    return;
+  }
+
+  // Check Authentication (if needed)
+  // If not properly authenticated for resource, issue Unauthorized response
+  if ([self isPasswordProtected:uri] && ![self isAuthenticated]) {
+    [self handleAuthenticationFailed];
+    return;
+  }
+
+  // Extract the method
+  NSString *method = [request method];
+
+  // Note: We already checked to ensure the method was supported in onSocket:didReadData:withTag:
+
+  // Respond properly to HTTP 'GET' and 'HEAD' commands
+  httpResponse = [self httpResponseForMethod:method URI:uri];
+
+  if (httpResponse == nil) {
+    [self handleResourceNotFound];
+    return;
+  }
+
+  [self sendResponseHeadersAndBody];
 }
 
 /**
  * Prepares a single-range response.
- * 
+ *
  * Note: The returned LPHTTPMessage is owned by the sender, who is responsible for releasing it.
-**/
-- (LPHTTPMessage *)newUniRangeResponse:(UInt64)contentLength
-{
-	//LPHTTPLogTrace();
-	
-	// Status Code 206 - Partial Content
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:206 description:nil version:LPHTTPVersion1_1];
-	
-	LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
-	
-	NSString *contentLengthStr = [NSString stringWithFormat:@"%qu", range.length];
-	[response setHeaderField:@"Content-Length" value:contentLengthStr];
-	
-	NSString *rangeStr = [NSString stringWithFormat:@"%qu-%qu", range.location, LPDDMaxRange(range) - 1];
-	NSString *contentRangeStr = [NSString stringWithFormat:@"bytes %@/%qu", rangeStr, contentLength];
-	[response setHeaderField:@"Content-Range" value:contentRangeStr];
-	
-	return response;
+ **/
+- (LPHTTPMessage *)newUniRangeResponse:(UInt64)contentLength {
+  LPHTTPLogTrace();
+
+  // Status Code 206 - Partial Content
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:206 description:nil version:LPHTTPVersion1_1];
+
+  LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
+
+  NSString *contentLengthStr = [NSString stringWithFormat:@"%qu", range.length];
+  [response setHeaderField:@"Content-Length" value:contentLengthStr];
+
+  NSString *rangeStr = [NSString stringWithFormat:@"%qu-%qu", range.location, LPDDMaxRange(range) - 1];
+  NSString *contentRangeStr = [NSString stringWithFormat:@"bytes %@/%qu", rangeStr, contentLength];
+  [response setHeaderField:@"Content-Range" value:contentRangeStr];
+
+  return response;
 }
 
 /**
  * Prepares a multi-range response.
- * 
+ *
  * Note: The returned LPHTTPMessage is owned by the sender, who is responsible for releasing it.
-**/
-- (LPHTTPMessage *)newMultiRangeResponse:(UInt64)contentLength
-{
-	//LPHTTPLogTrace();
-	
-	// Status Code 206 - Partial Content
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:206 description:nil version:LPHTTPVersion1_1];
-	
-	// We have to send each range using multipart/byteranges
-	// So each byterange has to be prefix'd and suffix'd with the boundry
-	// Example:
-	// 
-	// LPHTTP/1.1 206 Partial Content
-	// Content-Length: 220
-	// Content-Type: multipart/byteranges; boundary=4554d24e986f76dd6
-	// 
-	// 
-	// --4554d24e986f76dd6
-	// Content-Range: bytes 0-25/4025
-	// 
-	// [...]
-	// --4554d24e986f76dd6
-	// Content-Range: bytes 3975-4024/4025
-	// 
-	// [...]
-	// --4554d24e986f76dd6--
-	
-	ranges_headers = [[NSMutableArray alloc] initWithCapacity:[ranges count]];
-	
-	CFUUIDRef theUUID = CFUUIDCreate(NULL);
-	ranges_boundry = NSMakeCollectable(CFUUIDCreateString(NULL, theUUID));
-	CFRelease(theUUID);
-	
-	NSString *startingBoundryStr = [NSString stringWithFormat:@"\r\n--%@\r\n", ranges_boundry];
-	NSString *endingBoundryStr = [NSString stringWithFormat:@"\r\n--%@--\r\n", ranges_boundry];
-	
-	UInt64 actualContentLength = 0;
-	
-	NSUInteger i;
-	for (i = 0; i < [ranges count]; i++)
-	{
-		LPDDRange range = [[ranges objectAtIndex:i] lpDDRangeValue];
-		
-		NSString *rangeStr = [NSString stringWithFormat:@"%qu-%qu", range.location, LPDDMaxRange(range) - 1];
-		NSString *contentRangeVal = [NSString stringWithFormat:@"bytes %@/%qu", rangeStr, contentLength];
-		NSString *contentRangeStr = [NSString stringWithFormat:@"Content-Range: %@\r\n\r\n", contentRangeVal];
-		
-		NSString *fullHeader = [startingBoundryStr stringByAppendingString:contentRangeStr];
-		NSData *fullHeaderData = [fullHeader dataUsingEncoding:NSUTF8StringEncoding];
-		
-		[ranges_headers addObject:fullHeaderData];
-		
-		actualContentLength += [fullHeaderData length];
-		actualContentLength += range.length;
-	}
-	
-	NSData *endingBoundryData = [endingBoundryStr dataUsingEncoding:NSUTF8StringEncoding];
-	
-	actualContentLength += [endingBoundryData length];
-	
-	NSString *contentLengthStr = [NSString stringWithFormat:@"%qu", actualContentLength];
-	[response setHeaderField:@"Content-Length" value:contentLengthStr];
-	
-	NSString *contentTypeStr = [NSString stringWithFormat:@"multipart/byteranges; boundary=%@", ranges_boundry];
-	[response setHeaderField:@"Content-Type" value:contentTypeStr];
-	
-	return response;
+ **/
+- (LPHTTPMessage *)newMultiRangeResponse:(UInt64)contentLength {
+  LPHTTPLogTrace();
+
+  // Status Code 206 - Partial Content
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:206 description:nil version:LPHTTPVersion1_1];
+
+  // We have to send each range using multipart/byteranges
+  // So each byterange has to be prefix'd and suffix'd with the boundry
+  // Example:
+  //
+  // HTTP/1.1 206 Partial Content
+  // Content-Length: 220
+  // Content-Type: multipart/byteranges; boundary=4554d24e986f76dd6
+  //
+  //
+  // --4554d24e986f76dd6
+  // Content-Range: bytes 0-25/4025
+  //
+  // [...]
+  // --4554d24e986f76dd6
+  // Content-Range: bytes 3975-4024/4025
+  //
+  // [...]
+  // --4554d24e986f76dd6--
+
+  ranges_headers = [[NSMutableArray alloc] initWithCapacity:[ranges count]];
+
+  CFUUIDRef theUUID = CFUUIDCreate(NULL);
+  ranges_boundry = (__bridge_transfer NSString *) CFUUIDCreateString(NULL, theUUID);
+  CFRelease(theUUID);
+
+  NSString *startingBoundryStr = [NSString stringWithFormat:@"\r\n--%@\r\n", ranges_boundry];
+  NSString *endingBoundryStr = [NSString stringWithFormat:@"\r\n--%@--\r\n", ranges_boundry];
+
+  UInt64 actualContentLength = 0;
+
+  NSUInteger i;
+  for (i = 0; i < [ranges count]; i++) {
+    LPDDRange range = [[ranges objectAtIndex:i] lpDDRangeValue];
+
+    NSString *rangeStr = [NSString stringWithFormat:@"%qu-%qu", range.location, LPDDMaxRange(range) - 1];
+    NSString *contentRangeVal = [NSString stringWithFormat:@"bytes %@/%qu", rangeStr, contentLength];
+    NSString *contentRangeStr = [NSString stringWithFormat:@"Content-Range: %@\r\n\r\n", contentRangeVal];
+
+    NSString *fullHeader = [startingBoundryStr stringByAppendingString:contentRangeStr];
+    NSData *fullHeaderData = [fullHeader dataUsingEncoding:NSUTF8StringEncoding];
+
+    [ranges_headers addObject:fullHeaderData];
+
+    actualContentLength += [fullHeaderData length];
+    actualContentLength += range.length;
+  }
+
+  NSData *endingBoundryData = [endingBoundryStr dataUsingEncoding:NSUTF8StringEncoding];
+
+  actualContentLength += [endingBoundryData length];
+
+  NSString *contentLengthStr = [NSString stringWithFormat:@"%qu", actualContentLength];
+  [response setHeaderField:@"Content-Length" value:contentLengthStr];
+
+  NSString *contentTypeStr = [NSString stringWithFormat:@"multipart/byteranges; boundary=%@", ranges_boundry];
+  [response setHeaderField:@"Content-Type" value:contentTypeStr];
+
+  return response;
 }
 
 /**
  * Returns the chunk size line that must precede each chunk of data when using chunked transfer encoding.
  * This consists of the size of the data, in hexadecimal, followed by a CRLF.
-**/
-- (NSData *)chunkedTransferSizeLineForLength:(NSUInteger)length
-{
-	return [[NSString stringWithFormat:@"%lx\r\n", (unsigned long)length] dataUsingEncoding:NSUTF8StringEncoding];
+ **/
+- (NSData *)chunkedTransferSizeLineForLength:(NSUInteger)length {
+  return [[NSString stringWithFormat:@"%lx\r\n", (unsigned long) length] dataUsingEncoding:NSUTF8StringEncoding];
 }
 
 /**
  * Returns the data that signals the end of a chunked transfer.
-**/
-- (NSData *)chunkedTransferFooter
-{
-	// Each data chunk is preceded by a size line (in hex and including a CRLF),
-	// followed by the data itself, followed by another CRLF.
-	// After every data chunk has been sent, a zero size line is sent,
-	// followed by optional footer (which are just more headers),
-	// and followed by a CRLF on a line by itself.
-	
-	return [@"\r\n0\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+ **/
+- (NSData *)chunkedTransferFooter {
+  // Each data chunk is preceded by a size line (in hex and including a CRLF),
+  // followed by the data itself, followed by another CRLF.
+  // After every data chunk has been sent, a zero size line is sent,
+  // followed by optional footer (which are just more headers),
+  // and followed by a CRLF on a line by itself.
+
+  return [@"\r\n0\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
 }
 
-- (void)sendResponseHeadersAndBody
-{
-	if ([httpResponse respondsToSelector:@selector(delayResponseHeaders)])
-	{
-		if ([httpResponse delayResponseHeaders])
-		{
-			return;
-		}
-	}
-	
-	BOOL isChunked = NO;
-	
-	if ([httpResponse respondsToSelector:@selector(isChunked)])
-	{
-		isChunked = [httpResponse isChunked];
-	}
-	
-	// If a response is "chunked", this simply means the LPHTTPResponse object
-	// doesn't know the content-length in advance.
-	
-	UInt64 contentLength = 0;
-	
-	if (!isChunked)
-	{
-		contentLength = [httpResponse contentLength];
-	}
-	
-	// Check for specific range request
-	NSString *rangeHeader = [request headerField:@"Range"];
-	
-	BOOL isRangeRequest = NO;
-	
-	// If the response is "chunked" then we don't know the exact content-length.
-	// This means we'll be unable to process any range requests.
-	// This is because range requests might include a range like "give me the last 100 bytes"
-	
-	if (!isChunked && rangeHeader)
-	{
-		if ([self parseRangeRequest:rangeHeader withContentLength:contentLength])
-		{
-			isRangeRequest = YES;
-		}
-	}
-	
-	LPHTTPMessage *response;
-	
-	if (!isRangeRequest)
-	{
-		// Create response
-		// Default status code: 200 - OK
-		NSInteger status = 200;
-		
-		if ([httpResponse respondsToSelector:@selector(status)])
-		{
-			status = [httpResponse status];
-		}
-		response = [[LPHTTPMessage alloc] initResponseWithStatusCode:status description:@"OK" version:LPHTTPVersion1_1];
-		
-		if (isChunked)
-		{
-			[response setHeaderField:@"Transfer-Encoding" value:@"chunked"];
-		}
-		else
-		{
-			NSString *contentLengthStr = [NSString stringWithFormat:@"%qu", contentLength];
-			[response setHeaderField:@"Content-Length" value:contentLengthStr];
-		}
-	}
-	else
-	{
-		if ([ranges count] == 1)
-		{
-			response = [self newUniRangeResponse:contentLength];
-		}
-		else
-		{
-			response = [self newMultiRangeResponse:contentLength];
-		}
-	}
-	
-	BOOL isZeroLengthResponse = !isChunked && (contentLength == 0);
-    
-	// If they issue a 'HEAD' command, we don't have to include the file
-	// If they issue a 'GET' command, we need to include the file
-	
-	if ([[request method] isEqualToString:@"HEAD"] || isZeroLengthResponse)
-	{
-		NSData *responseData = [self preprocessResponse:response];
-		[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_RESPONSE];
-		
-		sentResponseHeaders = YES;
-	}
-	else
-	{
-		// Write the header response
-		NSData *responseData = [self preprocessResponse:response];
-		[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_PARTIAL_RESPONSE_HEADER];
-		
-		sentResponseHeaders = YES;
-		
-		// Now we need to send the body of the response
-		if (!isRangeRequest)
-		{
-			// Regular request
-			NSData *data = [httpResponse readDataOfLength:READ_CHUNKSIZE];
-			
-			if ([data length] > 0)
-			{
-				[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-				
-				if (isChunked)
-				{
-					NSData *chunkSize = [self chunkedTransferSizeLineForLength:[data length]];
-					[asyncSocket writeData:chunkSize withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_CHUNKED_RESPONSE_HEADER];
-					
-					[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:LPHTTP_CHUNKED_RESPONSE_BODY];
-					
-					if ([httpResponse isDone])
-					{
-						NSData *footer = [self chunkedTransferFooter];
-						[asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_RESPONSE];
-					}
-					else
-					{
-						NSData *footer = [LPGCDAsyncSocket CRLFData];
-						[asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_CHUNKED_RESPONSE_FOOTER];
-					}
-				}
-				else
-				{
-					long tag = [httpResponse isDone] ? LPHTTP_RESPONSE : LPHTTP_PARTIAL_RESPONSE_BODY;
-					[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
-				}
-			}
-		}
-		else
-		{
-			// Client specified a byte range in request
-			
-			if ([ranges count] == 1)
-			{
-				// Client is requesting a single range
-				LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
-				
-				[httpResponse setOffset:range.location];
-				
-				NSUInteger bytesToRead = range.length < READ_CHUNKSIZE ? (NSUInteger)range.length : READ_CHUNKSIZE;
-				
-				NSData *data = [httpResponse readDataOfLength:bytesToRead];
-				
-				if ([data length] > 0)
-				{
-					[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-					
-					long tag = [data length] == range.length ? LPHTTP_RESPONSE : LPHTTP_PARTIAL_RANGE_RESPONSE_BODY;
-					[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
-				}
-			}
-			else
-			{
-				// Client is requesting multiple ranges
-				// We have to send each range using multipart/byteranges
-				
-				// Write range header
-				NSData *rangeHeaderData = [ranges_headers objectAtIndex:0];
-				[asyncSocket writeData:rangeHeaderData withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_PARTIAL_RESPONSE_HEADER];
-				
-				// Start writing range body
-				LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
-				
-				[httpResponse setOffset:range.location];
-				
-				NSUInteger bytesToRead = range.length < READ_CHUNKSIZE ? (NSUInteger)range.length : READ_CHUNKSIZE;
-				
-				NSData *data = [httpResponse readDataOfLength:bytesToRead];
-				
-				if ([data length] > 0)
-				{
-					[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-					
-					[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:LPHTTP_PARTIAL_RANGES_RESPONSE_BODY];
-				}
-			}
-		}
-	}
-	
-	[response release];
+- (void)sendResponseHeadersAndBody {
+  if ([httpResponse respondsToSelector:@selector(delayResponseHeaders)]) {
+    if ([httpResponse delayResponseHeaders]) {
+      return;
+    }
+  }
+
+  BOOL isChunked = NO;
+
+  if ([httpResponse respondsToSelector:@selector(isChunked)]) {
+    isChunked = [httpResponse isChunked];
+  }
+
+  // If a response is "chunked", this simply means the LPHTTPResponse object
+  // doesn't know the content-length in advance.
+
+  UInt64 contentLength = 0;
+
+  if (!isChunked) {
+    contentLength = [httpResponse contentLength];
+  }
+
+  // Check for specific range request
+  NSString *rangeHeader = [request headerField:@"Range"];
+
+  BOOL isRangeRequest = NO;
+
+  // If the response is "chunked" then we don't know the exact content-length.
+  // This means we'll be unable to process any range requests.
+  // This is because range requests might include a range like "give me the last 100 bytes"
+
+  if (!isChunked && rangeHeader) {
+    if ([self parseRangeRequest:rangeHeader withContentLength:contentLength]) {
+      isRangeRequest = YES;
+    }
+  }
+
+  LPHTTPMessage *response;
+
+  if (!isRangeRequest) {
+    // Create response
+    // Default status code: 200 - OK
+    NSInteger status = 200;
+
+    if ([httpResponse respondsToSelector:@selector(status)]) {
+      status = [httpResponse status];
+    }
+    response = [[LPHTTPMessage alloc] initResponseWithStatusCode:status description:nil version:LPHTTPVersion1_1];
+
+    if (isChunked) {
+      [response setHeaderField:@"Transfer-Encoding" value:@"chunked"];
+    }
+    else {
+      NSString *contentLengthStr = [NSString stringWithFormat:@"%qu", contentLength];
+      [response setHeaderField:@"Content-Length" value:contentLengthStr];
+    }
+  }
+  else {
+    if ([ranges count] == 1) {
+      response = [self newUniRangeResponse:contentLength];
+    }
+    else {
+      response = [self newMultiRangeResponse:contentLength];
+    }
+  }
+
+  BOOL isZeroLengthResponse = !isChunked && (contentLength == 0);
+
+  // If they issue a 'HEAD' command, we don't have to include the file
+  // If they issue a 'GET' command, we need to include the file
+
+  if ([[request method] isEqualToString:@"HEAD"] || isZeroLengthResponse) {
+    NSData *responseData = [self preprocessResponse:response];
+    [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_RESPONSE];
+
+    sentResponseHeaders = YES;
+  }
+  else {
+    // Write the header response
+    NSData *responseData = [self preprocessResponse:response];
+    [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_PARTIAL_RESPONSE_HEADER];
+
+    sentResponseHeaders = YES;
+
+    // Now we need to send the body of the response
+    if (!isRangeRequest) {
+      // Regular request
+      NSData *data = [httpResponse readDataOfLength:READ_CHUNKSIZE];
+
+      if ([data length] > 0) {
+        [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+        if (isChunked) {
+          NSData *chunkSize = [self chunkedTransferSizeLineForLength:[data length]];
+          [asyncSocket writeData:chunkSize withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_CHUNKED_RESPONSE_HEADER];
+
+          [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:HTTP_CHUNKED_RESPONSE_BODY];
+
+          if ([httpResponse isDone]) {
+            NSData *footer = [self chunkedTransferFooter];
+            [asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_RESPONSE];
+          }
+          else {
+            NSData *footer = [LPGCDAsyncSocket CRLFData];
+            [asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_CHUNKED_RESPONSE_FOOTER];
+          }
+        }
+        else {
+          long tag = [httpResponse isDone] ? HTTP_RESPONSE : HTTP_PARTIAL_RESPONSE_BODY;
+          [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
+        }
+      }
+    }
+    else {
+      // Client specified a byte range in request
+
+      if ([ranges count] == 1) {
+        // Client is requesting a single range
+        LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
+
+        [httpResponse setOffset:range.location];
+
+        NSUInteger bytesToRead = range.length < READ_CHUNKSIZE ? (NSUInteger) range.length : READ_CHUNKSIZE;
+
+        NSData *data = [httpResponse readDataOfLength:bytesToRead];
+
+        if ([data length] > 0) {
+          [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+          long tag = [data length] == range.length ? HTTP_RESPONSE : HTTP_PARTIAL_RANGE_RESPONSE_BODY;
+          [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
+        }
+      }
+      else {
+        // Client is requesting multiple ranges
+        // We have to send each range using multipart/byteranges
+
+        // Write range header
+        NSData *rangeHeaderData = [ranges_headers objectAtIndex:0];
+        [asyncSocket writeData:rangeHeaderData withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_PARTIAL_RESPONSE_HEADER];
+
+        // Start writing range body
+        LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
+
+        [httpResponse setOffset:range.location];
+
+        NSUInteger bytesToRead = range.length < READ_CHUNKSIZE ? (NSUInteger) range.length : READ_CHUNKSIZE;
+
+        NSData *data = [httpResponse readDataOfLength:bytesToRead];
+
+        if ([data length] > 0) {
+          [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+          [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:HTTP_PARTIAL_RANGES_RESPONSE_BODY];
+        }
+      }
+    }
+  }
+
 }
 
 /**
  * Returns the number of bytes of the http response body that are sitting in asyncSocket's write queue.
- * 
+ *
  * We keep track of this information in order to keep our memory footprint low while
  * working with asynchronous LPHTTPResponse objects.
-**/
-- (NSUInteger)writeQueueSize
-{
-	NSUInteger result = 0;
-	
-	NSUInteger i;
-	for(i = 0; i < [responseDataSizes count]; i++)
-	{
-		result += [[responseDataSizes objectAtIndex:i] unsignedIntegerValue];
-	}
-	
-	return result;
+ **/
+- (NSUInteger)writeQueueSize {
+  NSUInteger result = 0;
+
+  NSUInteger i;
+  for (i = 0; i < [responseDataSizes count]; i++) {
+    result += [[responseDataSizes objectAtIndex:i] unsignedIntegerValue];
+  }
+
+  return result;
 }
 
 /**
  * Sends more data, if needed, without growing the write queue over its approximate size limit.
- * The last chunk of the response body will be sent with a tag of LPHTTP_RESPONSE.
- * 
+ * The last chunk of the response body will be sent with a tag of HTTP_RESPONSE.
+ *
  * This method should only be called for standard (non-range) responses.
-**/
-- (void)continueSendingStandardResponseBody
-{
-	//LPHTTPLogTrace();
-	
-	// This method is called when either asyncSocket has finished writing one of the response data chunks,
-	// or when an asynchronous LPHTTPResponse object informs us that it has more available data for us to send.
-	// In the case of the asynchronous LPHTTPResponse, we don't want to blindly grab the new data,
-	// and shove it onto asyncSocket's write queue.
-	// Doing so could negatively affect the memory footprint of the application.
-	// Instead, we always ensure that we place no more than READ_CHUNKSIZE bytes onto the write queue.
-	// 
-	// Note that this does not affect the rate at which the LPHTTPResponse object may generate data.
-	// The LPHTTPResponse is free to do as it pleases, and this is up to the application's developer.
-	// If the memory footprint is a concern, the developer creating the custom LPHTTPResponse object may freely
-	// use the calls to readDataOfLength as an indication to start generating more data.
-	// This provides an easy way for the LPHTTPResponse object to throttle its data allocation in step with the rate
-	// at which the socket is able to send it.
-	
-	NSUInteger writeQueueSize = [self writeQueueSize];
-	
-	if(writeQueueSize >= READ_CHUNKSIZE) return;
-	
-	NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
-	NSData *data = [httpResponse readDataOfLength:available];
-	
-	if ([data length] > 0)
-	{
-		[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-		
-		BOOL isChunked = NO;
-		
-		if ([httpResponse respondsToSelector:@selector(isChunked)])
-		{
-			isChunked = [httpResponse isChunked];
-		}
-		
-		if (isChunked)
-		{
-			NSData *chunkSize = [self chunkedTransferSizeLineForLength:[data length]];
-			[asyncSocket writeData:chunkSize withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_CHUNKED_RESPONSE_HEADER];
-			
-			[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:LPHTTP_CHUNKED_RESPONSE_BODY];
-			
-			if([httpResponse isDone])
-			{
-				NSData *footer = [self chunkedTransferFooter];
-				[asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_RESPONSE];
-			}
-			else
-			{
-				NSData *footer = [LPGCDAsyncSocket CRLFData];
-				[asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_CHUNKED_RESPONSE_FOOTER];
-			}
-		}
-		else
-		{
-			long tag = [httpResponse isDone] ? LPHTTP_RESPONSE : LPHTTP_PARTIAL_RESPONSE_BODY;
-			[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
-		}
-	}
+ **/
+- (void)continueSendingStandardResponseBody {
+  LPHTTPLogTrace();
+
+  // This method is called when either asyncSocket has finished writing one of the response data chunks,
+  // or when an asynchronous LPHTTPResponse object informs us that it has more available data for us to send.
+  // In the case of the asynchronous LPHTTPResponse, we don't want to blindly grab the new data,
+  // and shove it onto asyncSocket's write queue.
+  // Doing so could negatively affect the memory footprint of the application.
+  // Instead, we always ensure that we place no more than READ_CHUNKSIZE bytes onto the write queue.
+  //
+  // Note that this does not affect the rate at which the LPHTTPResponse object may generate data.
+  // The LPHTTPResponse is free to do as it pleases, and this is up to the application's developer.
+  // If the memory footprint is a concern, the developer creating the custom LPHTTPResponse object may freely
+  // use the calls to readDataOfLength as an indication to start generating more data.
+  // This provides an easy way for the LPHTTPResponse object to throttle its data allocation in step with the rate
+  // at which the socket is able to send it.
+
+  NSUInteger writeQueueSize = [self writeQueueSize];
+
+  if (writeQueueSize >= READ_CHUNKSIZE) return;
+
+  NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
+  NSData *data = [httpResponse readDataOfLength:available];
+
+  if ([data length] > 0) {
+    [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+    BOOL isChunked = NO;
+
+    if ([httpResponse respondsToSelector:@selector(isChunked)]) {
+      isChunked = [httpResponse isChunked];
+    }
+
+    if (isChunked) {
+      NSData *chunkSize = [self chunkedTransferSizeLineForLength:[data length]];
+      [asyncSocket writeData:chunkSize withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_CHUNKED_RESPONSE_HEADER];
+
+      [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:HTTP_CHUNKED_RESPONSE_BODY];
+
+      if ([httpResponse isDone]) {
+        NSData *footer = [self chunkedTransferFooter];
+        [asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_RESPONSE];
+      }
+      else {
+        NSData *footer = [LPGCDAsyncSocket CRLFData];
+        [asyncSocket writeData:footer withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_CHUNKED_RESPONSE_FOOTER];
+      }
+    }
+    else {
+      long tag = [httpResponse isDone] ? HTTP_RESPONSE : HTTP_PARTIAL_RESPONSE_BODY;
+      [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
+    }
+  }
 }
 
 /**
  * Sends more data, if needed, without growing the write queue over its approximate size limit.
- * The last chunk of the response body will be sent with a tag of LPHTTP_RESPONSE.
- * 
+ * The last chunk of the response body will be sent with a tag of HTTP_RESPONSE.
+ *
  * This method should only be called for single-range responses.
-**/
-- (void)continueSendingSingleRangeResponseBody
-{
-	//LPHTTPLogTrace();
-	
-	// This method is called when either asyncSocket has finished writing one of the response data chunks,
-	// or when an asynchronous response informs us that is has more available data for us to send.
-	// In the case of the asynchronous response, we don't want to blindly grab the new data,
-	// and shove it onto asyncSocket's write queue.
-	// Doing so could negatively affect the memory footprint of the application.
-	// Instead, we always ensure that we place no more than READ_CHUNKSIZE bytes onto the write queue.
-	// 
-	// Note that this does not affect the rate at which the LPHTTPResponse object may generate data.
-	// The LPHTTPResponse is free to do as it pleases, and this is up to the application's developer.
-	// If the memory footprint is a concern, the developer creating the custom LPHTTPResponse object may freely
-	// use the calls to readDataOfLength as an indication to start generating more data.
-	// This provides an easy way for the LPHTTPResponse object to throttle its data allocation in step with the rate
-	// at which the socket is able to send it.
-	
-	NSUInteger writeQueueSize = [self writeQueueSize];
-	
-	if(writeQueueSize >= READ_CHUNKSIZE) return;
-	
-	LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
-	
-	UInt64 offset = [httpResponse offset];
-	UInt64 bytesRead = offset - range.location;
-	UInt64 bytesLeft = range.length - bytesRead;
-	
-	if (bytesLeft > 0)
-	{
-		NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
-		NSUInteger bytesToRead = bytesLeft < available ? (NSUInteger)bytesLeft : available;
-		
-		NSData *data = [httpResponse readDataOfLength:bytesToRead];
-		
-		if ([data length] > 0)
-		{
-			[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-			
-			long tag = [data length] == bytesLeft ? LPHTTP_RESPONSE : LPHTTP_PARTIAL_RANGE_RESPONSE_BODY;
-			[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
-		}
-	}
+ **/
+- (void)continueSendingSingleRangeResponseBody {
+  LPHTTPLogTrace();
+
+  // This method is called when either asyncSocket has finished writing one of the response data chunks,
+  // or when an asynchronous response informs us that is has more available data for us to send.
+  // In the case of the asynchronous response, we don't want to blindly grab the new data,
+  // and shove it onto asyncSocket's write queue.
+  // Doing so could negatively affect the memory footprint of the application.
+  // Instead, we always ensure that we place no more than READ_CHUNKSIZE bytes onto the write queue.
+  //
+  // Note that this does not affect the rate at which the LPHTTPResponse object may generate data.
+  // The LPHTTPResponse is free to do as it pleases, and this is up to the application's developer.
+  // If the memory footprint is a concern, the developer creating the custom LPHTTPResponse object may freely
+  // use the calls to readDataOfLength as an indication to start generating more data.
+  // This provides an easy way for the LPHTTPResponse object to throttle its data allocation in step with the rate
+  // at which the socket is able to send it.
+
+  NSUInteger writeQueueSize = [self writeQueueSize];
+
+  if (writeQueueSize >= READ_CHUNKSIZE) return;
+
+  LPDDRange range = [[ranges objectAtIndex:0] lpDDRangeValue];
+
+  UInt64 offset = [httpResponse offset];
+  UInt64 bytesRead = offset - range.location;
+  UInt64 bytesLeft = range.length - bytesRead;
+
+  if (bytesLeft > 0) {
+    NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
+    NSUInteger bytesToRead = bytesLeft < available ? (NSUInteger) bytesLeft : available;
+
+    NSData *data = [httpResponse readDataOfLength:bytesToRead];
+
+    if ([data length] > 0) {
+      [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+      long tag = [data length] == bytesLeft ? HTTP_RESPONSE : HTTP_PARTIAL_RANGE_RESPONSE_BODY;
+      [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:tag];
+    }
+  }
 }
 
 /**
  * Sends more data, if needed, without growing the write queue over its approximate size limit.
- * The last chunk of the response body will be sent with a tag of LPHTTP_RESPONSE.
- * 
+ * The last chunk of the response body will be sent with a tag of HTTP_RESPONSE.
+ *
  * This method should only be called for multi-range responses.
-**/
-- (void)continueSendingMultiRangeResponseBody
-{
-	//LPHTTPLogTrace();
-	
-	// This method is called when either asyncSocket has finished writing one of the response data chunks,
-	// or when an asynchronous LPHTTPResponse object informs us that is has more available data for us to send.
-	// In the case of the asynchronous LPHTTPResponse, we don't want to blindly grab the new data,
-	// and shove it onto asyncSocket's write queue.
-	// Doing so could negatively affect the memory footprint of the application.
-	// Instead, we always ensure that we place no more than READ_CHUNKSIZE bytes onto the write queue.
-	// 
-	// Note that this does not affect the rate at which the LPHTTPResponse object may generate data.
-	// The LPHTTPResponse is free to do as it pleases, and this is up to the application's developer.
-	// If the memory footprint is a concern, the developer creating the custom LPHTTPResponse object may freely
-	// use the calls to readDataOfLength as an indication to start generating more data.
-	// This provides an easy way for the LPHTTPResponse object to throttle its data allocation in step with the rate
-	// at which the socket is able to send it.
-	
-	NSUInteger writeQueueSize = [self writeQueueSize];
-	
-	if(writeQueueSize >= READ_CHUNKSIZE) return;
-	
-	LPDDRange range = [[ranges objectAtIndex:rangeIndex] lpDDRangeValue];
-	
-	UInt64 offset = [httpResponse offset];
-	UInt64 bytesRead = offset - range.location;
-	UInt64 bytesLeft = range.length - bytesRead;
-	
-	if (bytesLeft > 0)
-	{
-		NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
-		NSUInteger bytesToRead = bytesLeft < available ? (NSUInteger)bytesLeft : available;
-		
-		NSData *data = [httpResponse readDataOfLength:bytesToRead];
-		
-		if ([data length] > 0)
-		{
-			[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-			
-			[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:LPHTTP_PARTIAL_RANGES_RESPONSE_BODY];
-		}
-	}
-	else
-	{
-		if (++rangeIndex < [ranges count])
-		{
-			// Write range header
-			NSData *rangeHeader = [ranges_headers objectAtIndex:rangeIndex];
-			[asyncSocket writeData:rangeHeader withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_PARTIAL_RESPONSE_HEADER];
-			
-			// Start writing range body
-			range = [[ranges objectAtIndex:rangeIndex] lpDDRangeValue];
-			
-			[httpResponse setOffset:range.location];
-			
-			NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
-			NSUInteger bytesToRead = range.length < available ? (NSUInteger)range.length : available;
-			
-			NSData *data = [httpResponse readDataOfLength:bytesToRead];
-			
-			if ([data length] > 0)
-			{
-				[responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
-				
-				[asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:LPHTTP_PARTIAL_RANGES_RESPONSE_BODY];
-			}
-		}
-		else
-		{
-			// We're not done yet - we still have to send the closing boundry tag
-			NSString *endingBoundryStr = [NSString stringWithFormat:@"\r\n--%@--\r\n", ranges_boundry];
-			NSData *endingBoundryData = [endingBoundryStr dataUsingEncoding:NSUTF8StringEncoding];
-			
-			[asyncSocket writeData:endingBoundryData withTimeout:TIMEOUT_WRITE_HEAD tag:LPHTTP_RESPONSE];
-		}
-	}
+ **/
+- (void)continueSendingMultiRangeResponseBody {
+  LPHTTPLogTrace();
+
+  // This method is called when either asyncSocket has finished writing one of the response data chunks,
+  // or when an asynchronous LPHTTPResponse object informs us that is has more available data for us to send.
+  // In the case of the asynchronous LPHTTPResponse, we don't want to blindly grab the new data,
+  // and shove it onto asyncSocket's write queue.
+  // Doing so could negatively affect the memory footprint of the application.
+  // Instead, we always ensure that we place no more than READ_CHUNKSIZE bytes onto the write queue.
+  //
+  // Note that this does not affect the rate at which the LPHTTPResponse object may generate data.
+  // The LPHTTPResponse is free to do as it pleases, and this is up to the application's developer.
+  // If the memory footprint is a concern, the developer creating the custom LPHTTPResponse object may freely
+  // use the calls to readDataOfLength as an indication to start generating more data.
+  // This provides an easy way for the LPHTTPResponse object to throttle its data allocation in step with the rate
+  // at which the socket is able to send it.
+
+  NSUInteger writeQueueSize = [self writeQueueSize];
+
+  if (writeQueueSize >= READ_CHUNKSIZE) return;
+
+  LPDDRange range = [[ranges objectAtIndex:rangeIndex] lpDDRangeValue];
+
+  UInt64 offset = [httpResponse offset];
+  UInt64 bytesRead = offset - range.location;
+  UInt64 bytesLeft = range.length - bytesRead;
+
+  if (bytesLeft > 0) {
+    NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
+    NSUInteger bytesToRead = bytesLeft < available ? (NSUInteger) bytesLeft : available;
+
+    NSData *data = [httpResponse readDataOfLength:bytesToRead];
+
+    if ([data length] > 0) {
+      [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+      [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:HTTP_PARTIAL_RANGES_RESPONSE_BODY];
+    }
+  }
+  else {
+    if (++rangeIndex < [ranges count]) {
+      // Write range header
+      NSData *rangeHeader = [ranges_headers objectAtIndex:rangeIndex];
+      [asyncSocket writeData:rangeHeader withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_PARTIAL_RESPONSE_HEADER];
+
+      // Start writing range body
+      range = [[ranges objectAtIndex:rangeIndex] lpDDRangeValue];
+
+      [httpResponse setOffset:range.location];
+
+      NSUInteger available = READ_CHUNKSIZE - writeQueueSize;
+      NSUInteger bytesToRead = range.length < available ? (NSUInteger) range.length : available;
+
+      NSData *data = [httpResponse readDataOfLength:bytesToRead];
+
+      if ([data length] > 0) {
+        [responseDataSizes addObject:[NSNumber numberWithUnsignedInteger:[data length]]];
+
+        [asyncSocket writeData:data withTimeout:TIMEOUT_WRITE_BODY tag:HTTP_PARTIAL_RANGES_RESPONSE_BODY];
+      }
+    }
+    else {
+      // We're not done yet - we still have to send the closing boundry tag
+      NSString *endingBoundryStr = [NSString stringWithFormat:@"\r\n--%@--\r\n", ranges_boundry];
+      NSData *endingBoundryData = [endingBoundryStr dataUsingEncoding:NSUTF8StringEncoding];
+
+      [asyncSocket writeData:endingBoundryData withTimeout:TIMEOUT_WRITE_HEAD tag:HTTP_RESPONSE];
+    }
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1537,121 +1425,109 @@ static NSMutableArray *recentNonces;
 /**
  * Returns an array of possible index pages.
  * For example: {"index.html", "index.htm"}
-**/
-- (NSArray *)directoryIndexFileNames
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to support other index pages.
-	
-	return [NSArray arrayWithObjects:@"index.html", @"index.htm", nil];
+ **/
+- (NSArray *)directoryIndexFileNames {
+  LPHTTPLogTrace();
+
+  // Override me to support other index pages.
+
+  return [NSArray arrayWithObjects:@"index.html", @"index.htm", nil];
 }
 
-- (NSString *)filePathForURI:(NSString *)path
-{
-	return [self filePathForURI:path allowDirectory:NO];
+- (NSString *)filePathForURI:(NSString *)path {
+  return [self filePathForURI:path allowDirectory:NO];
 }
 
 /**
  * Converts relative URI path into full file-system path.
-**/
-- (NSString *)filePathForURI:(NSString *)path allowDirectory:(BOOL)allowDirectory
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to perform custom path mapping.
-	// For example you may want to use a default file other than index.html, or perhaps support multiple types.
-	
-	NSString *documentRoot = [config documentRoot];
-	
-	// Part 0: Validate document root setting.
-	// 
-	// If there is no configured documentRoot,
-	// then it makes no sense to try to return anything.
-	
-	if (documentRoot == nil)
-	{
-		//LPHTTPLogWarn(@"%@[%p]: No configured document root", THIS_FILE, self);
-		return nil;
-	}
-	
-	// Part 1: Strip parameters from the url
-	// 
-	// E.g.: /page.html?q=22&var=abc -> /page.html
-	
-	NSURL *docRoot = [NSURL fileURLWithPath:documentRoot isDirectory:YES];
-	if (docRoot == nil)
-	{
-		//LPHTTPLogWarn(@"%@[%p]: Document root is invalid file path", THIS_FILE, self);
-		return nil;
-	}
-	
-	NSString *relativePath = [[NSURL URLWithString:path relativeToURL:docRoot] relativePath];
-	
-	// Part 2: Append relative path to document root (base path)
-	// 
-	// E.g.: relativePath="/images/icon.png"
-	//       documentRoot="/Users/robbie/Sites"
-	//           fullPath="/Users/robbie/Sites/images/icon.png"
-	// 
-	// We also standardize the path.
-	// 
-	// E.g.: "Users/robbie/Sites/images/../index.html" -> "/Users/robbie/Sites/index.html"
-	
-	NSString *fullPath = [[documentRoot stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
-	
-	if ([relativePath isEqualToString:@"/"])
-	{
-		fullPath = [fullPath stringByAppendingString:@"/"];
-	}
-	
-	// Part 3: Prevent serving files outside the document root.
-	// 
-	// Sneaky requests may include ".." in the path.
-	// 
-	// E.g.: relativePath="../Documents/TopSecret.doc"
-	//       documentRoot="/Users/robbie/Sites"
-	//           fullPath="/Users/robbie/Documents/TopSecret.doc"
-	// 
-	// E.g.: relativePath="../Sites_Secret/TopSecret.doc"
-	//       documentRoot="/Users/robbie/Sites"
-	//           fullPath="/Users/robbie/Sites_Secret/TopSecret"
-	
-	if (![documentRoot hasSuffix:@"/"])
-	{
-		documentRoot = [documentRoot stringByAppendingString:@"/"];
-	}
-	
-	if (![fullPath hasPrefix:documentRoot])
-	{
-		//LPHTTPLogWarn(@"%@[%p]: Request for file outside document root", THIS_FILE, self);
-		return nil;
-	}
-	
-	// Part 4: Search for index page if path is pointing to a directory
-	if (!allowDirectory)
-	{
-		BOOL isDir = NO;
-		if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath isDirectory:&isDir] && isDir)
-		{
-			NSArray *indexFileNames = [self directoryIndexFileNames];
+ **/
+- (NSString *)filePathForURI:(NSString *)path allowDirectory:(BOOL)allowDirectory {
+  LPHTTPLogTrace();
 
-			for (NSString *indexFileName in indexFileNames)
-			{
-				NSString *indexFilePath = [fullPath stringByAppendingPathComponent:indexFileName];
+  // Override me to perform custom path mapping.
+  // For example you may want to use a default file other than index.html, or perhaps support multiple types.
 
-				if ([[NSFileManager defaultManager] fileExistsAtPath:indexFilePath isDirectory:&isDir] && !isDir)
-				{
-					return indexFilePath;
-				}
-			}
+  NSString *documentRoot = [config documentRoot];
 
-			// No matching index files found in directory
-			return nil;
-		}
-	}
+  // Part 0: Validate document root setting.
+  //
+  // If there is no configured documentRoot,
+  // then it makes no sense to try to return anything.
 
-	return fullPath;
+  if (documentRoot == nil) {
+    LPHTTPLogWarn(@"%@[%p]: No configured document root", LP_THIS_FILE, self);
+    return nil;
+  }
+
+  // Part 1: Strip parameters from the url
+  //
+  // E.g.: /page.html?q=22&var=abc -> /page.html
+
+  NSURL *docRoot = [NSURL fileURLWithPath:documentRoot isDirectory:YES];
+  if (docRoot == nil) {
+    LPHTTPLogWarn(@"%@[%p]: Document root is invalid file path", LP_THIS_FILE, self);
+    return nil;
+  }
+
+  NSString *relativePath = [[NSURL URLWithString:path relativeToURL:docRoot] relativePath];
+
+  // Part 2: Append relative path to document root (base path)
+  //
+  // E.g.: relativePath="/images/icon.png"
+  //       documentRoot="/Users/robbie/Sites"
+  //           fullPath="/Users/robbie/Sites/images/icon.png"
+  //
+  // We also standardize the path.
+  //
+  // E.g.: "Users/robbie/Sites/images/../index.html" -> "/Users/robbie/Sites/index.html"
+
+  NSString *fullPath = [[documentRoot stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
+
+  if ([relativePath isEqualToString:@"/"]) {
+    fullPath = [fullPath stringByAppendingString:@"/"];
+  }
+
+  // Part 3: Prevent serving files outside the document root.
+  //
+  // Sneaky requests may include ".." in the path.
+  //
+  // E.g.: relativePath="../Documents/TopSecret.doc"
+  //       documentRoot="/Users/robbie/Sites"
+  //           fullPath="/Users/robbie/Documents/TopSecret.doc"
+  //
+  // E.g.: relativePath="../Sites_Secret/TopSecret.doc"
+  //       documentRoot="/Users/robbie/Sites"
+  //           fullPath="/Users/robbie/Sites_Secret/TopSecret"
+
+  if (![documentRoot hasSuffix:@"/"]) {
+    documentRoot = [documentRoot stringByAppendingString:@"/"];
+  }
+
+  if (![fullPath hasPrefix:documentRoot]) {
+    LPHTTPLogWarn(@"%@[%p]: Request for file outside document root", LP_THIS_FILE, self);
+    return nil;
+  }
+
+  // Part 4: Search for index page if path is pointing to a directory
+  if (!allowDirectory) {
+    BOOL isDir = NO;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath isDirectory:&isDir] && isDir) {
+      NSArray *indexFileNames = [self directoryIndexFileNames];
+
+      for (NSString *indexFileName in indexFileNames) {
+        NSString *indexFilePath = [fullPath stringByAppendingPathComponent:indexFileName];
+
+        if ([[NSFileManager defaultManager] fileExistsAtPath:indexFilePath isDirectory:&isDir] && !isDir) {
+          return indexFilePath;
+        }
+      }
+
+      // No matching index files found in directory
+      return nil;
+    }
+  }
+
+  return fullPath;
 }
 
 /**
@@ -1660,67 +1536,80 @@ static NSMutableArray *recentNonces;
  * The LPHTTPServer comes with two such classes: LPHTTPFileResponse and LPHTTPDataResponse.
  * LPHTTPFileResponse is a wrapper for an NSFileHandle object, and is the preferred way to send a file response.
  * LPHTTPDataResponse is a wrapper for an NSData object, and may be used to send a custom response.
-**/
-- (NSObject<LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to provide custom responses.
-	
-	NSString *filePath = [self filePathForURI:path allowDirectory:NO];
-	
-	BOOL isDir = NO;
-	
-	if (filePath && [[NSFileManager defaultManager] fileExistsAtPath:filePath isDirectory:&isDir] && !isDir)
-	{
-		return [[[LPHTTPFileResponse alloc] initWithFilePath:filePath forConnection:self] autorelease];
-	
-		// Use me instead for asynchronous file IO.
-		// Generally better for larger files.
-		
-	//	return [[[LPHTTPAsyncFileResponse alloc] initWithFilePath:filePath forConnection:self] autorelease];
-	}
-	
-	return nil;
+ **/
+- (NSObject <LPHTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path {
+  LPHTTPLogTrace();
+
+  // Override me to provide custom responses.
+
+  NSString *filePath = [self filePathForURI:path allowDirectory:NO];
+
+  BOOL isDir = NO;
+
+  if (filePath && [[NSFileManager defaultManager] fileExistsAtPath:filePath isDirectory:&isDir] && !isDir) {
+    return [[LPHTTPFileResponse alloc] initWithFilePath:filePath forConnection:self];
+
+    // Use me instead for asynchronous file IO.
+    // Generally better for larger files.
+
+    //	return [[[LPHTTPAsyncFileResponse alloc] initWithFilePath:filePath forConnection:self] autorelease];
+  }
+
+  return nil;
 }
 
+- (LPWebSocket *)webSocketForURI:(NSString *)path {
+  LPHTTPLogTrace();
+
+  // Override me to provide custom LPWebSocket responses.
+  // To do so, simply override the base LPWebSocket implementation, and add your custom functionality.
+  // Then return an instance of your custom LPWebSocket here.
+  //
+  // For example:
+  //
+  // if ([path isEqualToString:@"/myAwesomeWebSocketStream"])
+  // {
+  //     return [[[MyWebSocket alloc] initWithRequest:request socket:asyncSocket] autorelease];
+  // }
+  //
+  // return [super webSocketForURI:path];
+
+  return nil;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Uploads
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * This method is called after receiving all LPHTTP headers, but before reading any of the request body.
-**/
-- (void)prepareForBodyWithSize:(UInt64)contentLength
-{
-	// Override me to allocate buffers, file handles, etc.
+ * This method is called after receiving all HTTP headers, but before reading any of the request body.
+ **/
+- (void)prepareForBodyWithSize:(UInt64)contentLength {
+  // Override me to allocate buffers, file handles, etc.
 }
 
 /**
  * This method is called to handle data read from a POST / PUT.
  * The given data is part of the request body.
-**/
-- (void)processBodyData:(NSData *)postDataChunk
-{
-	// Override me to do something useful with a POST / PUT.
-	// If the post is small, such as a simple form, you may want to simply append the data to the request.
-	// If the post is big, such as a file upload, you may want to store the file to disk.
-	// 
-	// Remember: In order to support LARGE POST uploads, the data is read in chunks.
-	// This prevents a 50 MB upload from being stored in RAM.
-	// The size of the chunks are limited by the POST_CHUNKSIZE definition.
-	// Therefore, this method may be called multiple times for the same POST request.
+ **/
+- (void)processBodyData:(NSData *)postDataChunk {
+  // Override me to do something useful with a POST / PUT.
+  // If the post is small, such as a simple form, you may want to simply append the data to the request.
+  // If the post is big, such as a file upload, you may want to store the file to disk.
+  //
+  // Remember: In order to support LARGE POST uploads, the data is read in chunks.
+  // This prevents a 50 MB upload from being stored in RAM.
+  // The size of the chunks are limited by the POST_CHUNKSIZE definition.
+  // Therefore, this method may be called multiple times for the same POST request.
 }
 
 /**
- * This method is called after the request body has been fully read but before the LPHTTP request is processed.
-**/
-- (void)finishBody
-{
-	// Override me to perform any final operations on an upload.
-	// For example, if you were saving the upload to disk this would be
-	// the hook to flush any pending data to disk and maybe close the file.
+ * This method is called after the request body has been fully read but before the HTTP request is processed.
+ **/
+- (void)finishBody {
+  // Override me to perform any final operations on an upload.
+  // For example, if you were saving the upload to disk this would be
+  // the hook to flush any pending data to disk and maybe close the file.
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1729,130 +1618,118 @@ static NSMutableArray *recentNonces;
 
 /**
  * Called if the HTML version is other than what is supported
-**/
-- (void)handleVersionNotSupported:(NSString *)version
-{
-	// Override me for custom error handling of unsupported http version responses
-	// If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
-	// You can also use preprocessErrorResponse: to add an optional HTML body.
-	
-	//LPHTTPLogWarn(@"LPHTTP Server: Error 505 - Version Not Supported: %@ (%@)", version, [self requestURI]);
-	
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:505 description:nil version:LPHTTPVersion1_1];
-	[response setHeaderField:@"Content-Length" value:@"0"];
-    
-	NSData *responseData = [self preprocessErrorResponse:response];
-	[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:LPHTTP_RESPONSE];
-	
-	[response release];
+ **/
+- (void)handleVersionNotSupported:(NSString *)version {
+  // Override me for custom error handling of unsupported http version responses
+  // If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
+  // You can also use preprocessErrorResponse: to add an optional HTML body.
+
+  LPHTTPLogWarn(@"HTTP Server: Error 505 - Version Not Supported: %@ (%@)", version, [self requestURI]);
+
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:505 description:nil version:LPHTTPVersion1_1];
+  [response setHeaderField:@"Content-Length" value:@"0"];
+
+  NSData *responseData = [self preprocessErrorResponse:response];
+  [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_RESPONSE];
+
 }
 
 /**
  * Called if the authentication information was required and absent, or if authentication failed.
-**/
-- (void)handleAuthenticationFailed
-{
-	// Override me for custom handling of authentication challenges
-	// If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
-	// You can also use preprocessErrorResponse: to add an optional HTML body.
-	
-	//LPHTTPLogInfo(@"LPHTTP Server: Error 401 - Unauthorized (%@)", [self requestURI]);
-		
-	// Status Code 401 - Unauthorized
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:401 description:nil version:LPHTTPVersion1_1];
-	[response setHeaderField:@"Content-Length" value:@"0"];
-	
-	if ([self useDigestAccessAuthentication])
-	{
-		[self addDigestAuthChallenge:response];
-	}
-	else
-	{
-		[self addBasicAuthChallenge:response];
-	}
-	
-	NSData *responseData = [self preprocessErrorResponse:response];
-	[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:LPHTTP_RESPONSE];
-	
-	[response release];
+ **/
+- (void)handleAuthenticationFailed {
+  // Override me for custom handling of authentication challenges
+  // If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
+  // You can also use preprocessErrorResponse: to add an optional HTML body.
+
+  LPHTTPLogInfo(@"HTTP Server: Error 401 - Unauthorized (%@)", [self requestURI]);
+
+  // Status Code 401 - Unauthorized
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:401 description:nil version:LPHTTPVersion1_1];
+  [response setHeaderField:@"Content-Length" value:@"0"];
+
+  if ([self useDigestAccessAuthentication]) {
+    [self addDigestAuthChallenge:response];
+  }
+  else {
+    [self addBasicAuthChallenge:response];
+  }
+
+  NSData *responseData = [self preprocessErrorResponse:response];
+  [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_RESPONSE];
+
 }
 
 /**
- * Called if we receive some sort of malformed LPHTTP request.
- * The data parameter is the invalid LPHTTP header line, including CRLF, as read from LPGCDAsyncSocket.
+ * Called if we receive some sort of malformed HTTP request.
+ * The data parameter is the invalid HTTP header line, including CRLF, as read from LPGCDAsyncSocket.
  * The data parameter may also be nil if the request as a whole was invalid, such as a POST with no Content-Length.
-**/
-- (void)handleInvalidRequest:(NSData *)data
-{
-	// Override me for custom error handling of invalid LPHTTP requests
-	// If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
-	// You can also use preprocessErrorResponse: to add an optional HTML body.
-	
-	//LPHTTPLogWarn(@"LPHTTP Server: Error 400 - Bad Request (%@)", [self requestURI]);
-	
-	// Status Code 400 - Bad Request
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:400 description:nil version:LPHTTPVersion1_1];
-	[response setHeaderField:@"Content-Length" value:@"0"];
-	[response setHeaderField:@"Connection" value:@"close"];
-	
-	NSData *responseData = [self preprocessErrorResponse:response];
-	[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:LPHTTP_FINAL_RESPONSE];
-	
-	[response release];
-	
-	// Note: We used the LPHTTP_FINAL_RESPONSE tag to disconnect after the response is sent.
-	// We do this because we couldn't parse the request,
-	// so we won't be able to recover and move on to another request afterwards.
-	// In other words, we wouldn't know where the first request ends and the second request begins.
+ **/
+- (void)handleInvalidRequest:(NSData *)data {
+  // Override me for custom error handling of invalid HTTP requests
+  // If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
+  // You can also use preprocessErrorResponse: to add an optional HTML body.
+
+  LPHTTPLogWarn(@"HTTP Server: Error 400 - Bad Request (%@)", [self requestURI]);
+
+  // Status Code 400 - Bad Request
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:400 description:nil version:LPHTTPVersion1_1];
+  [response setHeaderField:@"Content-Length" value:@"0"];
+  [response setHeaderField:@"Connection" value:@"close"];
+
+  NSData *responseData = [self preprocessErrorResponse:response];
+  [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_FINAL_RESPONSE];
+
+
+  // Note: We used the HTTP_FINAL_RESPONSE tag to disconnect after the response is sent.
+  // We do this because we couldn't parse the request,
+  // so we won't be able to recover and move on to another request afterwards.
+  // In other words, we wouldn't know where the first request ends and the second request begins.
 }
 
 /**
- * Called if we receive a LPHTTP request with a method other than GET or HEAD.
-**/
-- (void)handleUnknownMethod:(NSString *)method
-{
-	// Override me for custom error handling of 405 method not allowed responses.
-	// If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
-	// You can also use preprocessErrorResponse: to add an optional HTML body.
-	// 
-	// See also: supportsMethod:atPath:
-	
-	//LPHTTPLogWarn(@"LPHTTP Server: Error 405 - Method Not Allowed: %@ (%@)", method, [self requestURI]);
-	
-	// Status code 405 - Method Not Allowed
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:405 description:nil version:LPHTTPVersion1_1];
-	[response setHeaderField:@"Content-Length" value:@"0"];
-	[response setHeaderField:@"Connection" value:@"close"];
-	
-	NSData *responseData = [self preprocessErrorResponse:response];
-	[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:LPHTTP_FINAL_RESPONSE];
-    
-	[response release];
-	
-	// Note: We used the LPHTTP_FINAL_RESPONSE tag to disconnect after the response is sent.
-	// We do this because the method may include an http body.
-	// Since we can't be sure, we should close the connection.
+ * Called if we receive a HTTP request with a method other than GET or HEAD.
+ **/
+- (void)handleUnknownMethod:(NSString *)method {
+  // Override me for custom error handling of 405 method not allowed responses.
+  // If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
+  // You can also use preprocessErrorResponse: to add an optional HTML body.
+  //
+  // See also: supportsMethod:atPath:
+
+  LPHTTPLogWarn(@"HTTP Server: Error 405 - Method Not Allowed: %@ (%@)", method, [self requestURI]);
+
+  // Status code 405 - Method Not Allowed
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:405 description:nil version:LPHTTPVersion1_1];
+  [response setHeaderField:@"Content-Length" value:@"0"];
+  [response setHeaderField:@"Connection" value:@"close"];
+
+  NSData *responseData = [self preprocessErrorResponse:response];
+  [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_FINAL_RESPONSE];
+
+
+  // Note: We used the HTTP_FINAL_RESPONSE tag to disconnect after the response is sent.
+  // We do this because the method may include an http body.
+  // Since we can't be sure, we should close the connection.
 }
 
 /**
  * Called if we're unable to find the requested resource.
-**/
-- (void)handleResourceNotFound
-{
-	// Override me for custom error handling of 404 not found responses
-	// If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
-	// You can also use preprocessErrorResponse: to add an optional HTML body.
-	
-	//LPHTTPLogInfo(@"LPHTTP Server: Error 404 - Not Found (%@)", [self requestURI]);
-	
-	// Status Code 404 - Not Found
-	LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:404 description:nil version:LPHTTPVersion1_1];
-	[response setHeaderField:@"Content-Length" value:@"0"];
-	
-	NSData *responseData = [self preprocessErrorResponse:response];
-	[asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:LPHTTP_RESPONSE];
-	
-	[response release];
+ **/
+- (void)handleResourceNotFound {
+  // Override me for custom error handling of 404 not found responses
+  // If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
+  // You can also use preprocessErrorResponse: to add an optional HTML body.
+
+  LPHTTPLogInfo(@"HTTP Server: Error 404 - Not Found (%@)", [self requestURI]);
+
+  // Status Code 404 - Not Found
+  LPHTTPMessage *response = [[LPHTTPMessage alloc] initResponseWithStatusCode:404 description:nil version:LPHTTPVersion1_1];
+  [response setHeaderField:@"Content-Length" value:@"0"];
+
+  NSData *responseData = [self preprocessErrorResponse:response];
+  [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_RESPONSE];
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1860,131 +1737,124 @@ static NSMutableArray *recentNonces;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Gets the current date and time, formatted properly (according to RFC) for insertion into an LPHTTP header.
-**/
-- (NSString *)dateAsString:(NSDate *)date
-{
-	// From Apple's Documentation (Data Formatting Guide -> Date Formatters -> Cache Formatters for Efficiency):
-	// 
-	// "Creating a date formatter is not a cheap operation. If you are likely to use a formatter frequently,
-	// it is typically more efficient to cache a single instance than to create and dispose of multiple instances.
-	// One approach is to use a static variable."
-	// 
-	// This was discovered to be true in massive form via issue #46:
-	// 
-	// "Was doing some performance benchmarking using instruments and httperf. Using this single optimization
-	// I got a 26% speed improvement - from 1000req/sec to 3800req/sec. Not insignificant.
-	// The culprit? Why, NSDateFormatter, of course!"
-	// 
-	// Thus, we are using a static NSDateFormatter here.
-	
-	static NSDateFormatter *df;
-	
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		
-		// Example: Sun, 06 Nov 1994 08:49:37 GMT
-		
-		df = [[NSDateFormatter alloc] init];
-		[df setFormatterBehavior:NSDateFormatterBehavior10_4];
-		[df setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"GMT"]];
-		[df setDateFormat:@"EEE, dd MMM y HH:mm:ss 'GMT'"];
-		[df setLocale:[[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"] autorelease]];
-		
-		// For some reason, using zzz in the format string produces GMT+00:00
-	});
-	
-	return [df stringFromDate:date];
+ * Gets the current date and time, formatted properly (according to RFC) for insertion into an HTTP header.
+ **/
+- (NSString *)dateAsString:(NSDate *)date {
+  // From Apple's Documentation (Data Formatting Guide -> Date Formatters -> Cache Formatters for Efficiency):
+  //
+  // "Creating a date formatter is not a cheap operation. If you are likely to use a formatter frequently,
+  // it is typically more efficient to cache a single instance than to create and dispose of multiple instances.
+  // One approach is to use a static variable."
+  //
+  // This was discovered to be true in massive form via issue #46:
+  //
+  // "Was doing some performance benchmarking using instruments and httperf. Using this single optimization
+  // I got a 26% speed improvement - from 1000req/sec to 3800req/sec. Not insignificant.
+  // The culprit? Why, NSDateFormatter, of course!"
+  //
+  // Thus, we are using a static NSDateFormatter here.
+
+  static NSDateFormatter *df;
+
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+
+    // Example: Sun, 06 Nov 1994 08:49:37 GMT
+
+    df = [[NSDateFormatter alloc] init];
+    [df setFormatterBehavior:NSDateFormatterBehavior10_4];
+    [df setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"GMT"]];
+    [df setDateFormat:@"EEE, dd MMM y HH:mm:ss 'GMT'"];
+    [df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]];
+
+    // For some reason, using zzz in the format string produces GMT+00:00
+  });
+
+  return [df stringFromDate:date];
 }
 
 /**
  * This method is called immediately prior to sending the response headers.
  * This method adds standard header fields, and then converts the response to an NSData object.
-**/
-- (NSData *)preprocessResponse:(LPHTTPMessage *)response
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to customize the response headers
-	// You'll likely want to add your own custom headers, and then return [super preprocessResponse:response]
-	
-	// Add standard headers
-	NSString *now = [self dateAsString:[NSDate date]];
-	[response setHeaderField:@"Date" value:now];
-	
-	// Add server capability headers
-	[response setHeaderField:@"Accept-Ranges" value:@"bytes"];
-	
-	// Add optional response headers
-	if ([httpResponse respondsToSelector:@selector(httpHeaders)])
-	{
-		NSDictionary *responseHeaders = [httpResponse httpHeaders];
-		
-		NSEnumerator *keyEnumerator = [responseHeaders keyEnumerator];
-		NSString *key;
-		
-		while ((key = [keyEnumerator nextObject]))
-		{
-			NSString *value = [responseHeaders objectForKey:key];
-			
-			[response setHeaderField:key value:value];
-		}
-	}
-	
-	return [response messageData];
+ **/
+- (NSData *)preprocessResponse:(LPHTTPMessage *)response {
+  LPHTTPLogTrace();
+
+  // Override me to customize the response headers
+  // You'll likely want to add your own custom headers, and then return [super preprocessResponse:response]
+
+  // Add standard headers
+  NSString *now = [self dateAsString:[NSDate date]];
+  [response setHeaderField:@"Date" value:now];
+
+  // Add server capability headers
+  [response setHeaderField:@"Accept-Ranges" value:@"bytes"];
+
+  // Add optional response headers
+  if ([httpResponse respondsToSelector:@selector(httpHeaders)]) {
+    NSDictionary *responseHeaders = [httpResponse httpHeaders];
+
+    NSEnumerator *keyEnumerator = [responseHeaders keyEnumerator];
+    NSString *key;
+
+    while ((key = [keyEnumerator nextObject])) {
+      NSString *value = [responseHeaders objectForKey:key];
+
+      [response setHeaderField:key value:value];
+    }
+  }
+
+  return [response messageData];
 }
 
 /**
  * This method is called immediately prior to sending the response headers (for an error).
  * This method adds standard header fields, and then converts the response to an NSData object.
-**/
-- (NSData *)preprocessErrorResponse:(LPHTTPMessage *)response;
-{
-	//LPHTTPLogTrace();
-	
-	// Override me to customize the error response headers
-	// You'll likely want to add your own custom headers, and then return [super preprocessErrorResponse:response]
-	// 
-	// Notes:
-	// You can use [response statusCode] to get the type of error.
-	// You can use [response setBody:data] to add an optional HTML body.
-	// If you add a body, don't forget to update the Content-Length.
-	// 
-	// if ([response statusCode] == 404)
-	// {
-	//     NSString *msg = @"<html><body>Error 404 - Not Found</body></html>";
-	//     NSData *msgData = [msg dataUsingEncoding:NSUTF8StringEncoding];
-	//     
-	//     [response setBody:msgData];
-	//     
-	//     NSString *contentLengthStr = [NSString stringWithFormat:@"%lu", (unsigned long)[msgData length]];
-	//     [response setHeaderField:@"Content-Length" value:contentLengthStr];
-	// }
-	
-	// Add standard headers
-	NSString *now = [self dateAsString:[NSDate date]];
-	[response setHeaderField:@"Date" value:now];
-	
-	// Add server capability headers
-	[response setHeaderField:@"Accept-Ranges" value:@"bytes"];
-	
-	// Add optional response headers
-	if ([httpResponse respondsToSelector:@selector(httpHeaders)])
-	{
-		NSDictionary *responseHeaders = [httpResponse httpHeaders];
-		
-		NSEnumerator *keyEnumerator = [responseHeaders keyEnumerator];
-		NSString *key;
-		
-		while((key = [keyEnumerator nextObject]))
-		{
-			NSString *value = [responseHeaders objectForKey:key];
-			
-			[response setHeaderField:key value:value];
-		}
-	}
-	
-	return [response messageData];
+ **/
+- (NSData *)preprocessErrorResponse:(LPHTTPMessage *)response {
+  LPHTTPLogTrace();
+
+  // Override me to customize the error response headers
+  // You'll likely want to add your own custom headers, and then return [super preprocessErrorResponse:response]
+  //
+  // Notes:
+  // You can use [response statusCode] to get the type of error.
+  // You can use [response setBody:data] to add an optional HTML body.
+  // If you add a body, don't forget to update the Content-Length.
+  //
+  // if ([response statusCode] == 404)
+  // {
+  //     NSString *msg = @"<html><body>Error 404 - Not Found</body></html>";
+  //     NSData *msgData = [msg dataUsingEncoding:NSUTF8StringEncoding];
+  //
+  //     [response setBody:msgData];
+  //
+  //     NSString *contentLengthStr = [NSString stringWithFormat:@"%lu", (unsigned long)[msgData length]];
+  //     [response setHeaderField:@"Content-Length" value:contentLengthStr];
+  // }
+
+  // Add standard headers
+  NSString *now = [self dateAsString:[NSDate date]];
+  [response setHeaderField:@"Date" value:now];
+
+  // Add server capability headers
+  [response setHeaderField:@"Accept-Ranges" value:@"bytes"];
+
+  // Add optional response headers
+  if ([httpResponse respondsToSelector:@selector(httpHeaders)]) {
+    NSDictionary *responseHeaders = [httpResponse httpHeaders];
+
+    NSEnumerator *keyEnumerator = [responseHeaders keyEnumerator];
+    NSString *key;
+
+    while ((key = [keyEnumerator nextObject])) {
+      NSString *value = [responseHeaders objectForKey:key];
+
+      [response setHeaderField:key value:value];
+    }
+  }
+
+  return [response messageData];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1994,476 +1864,423 @@ static NSMutableArray *recentNonces;
 /**
  * This method is called after the socket has successfully read data from the stream.
  * Remember that this method will only be called after the socket reaches a CRLF, or after it's read the proper length.
-**/
-- (void)socket:(LPGCDAsyncSocket *)sock didReadData:(NSData*)data withTag:(long)tag
-{
-	if (tag == LPHTTP_REQUEST_HEADER)
-	{
-		// Append the header line to the http message
-		BOOL result = [request appendData:data];
-		if (!result)
-		{
-			//LPHTTPLogWarn(@"%@[%p]: Malformed request", THIS_FILE, self);
-			
-			[self handleInvalidRequest:data];
-		}
-		else if (![request isHeaderComplete])
-		{
-			// We don't have a complete header yet
-			// That is, we haven't yet received a CRLF on a line by itself, indicating the end of the header
-			if (++numHeaderLines > MAX_HEADER_LINES)
-			{
-				// Reached the maximum amount of header lines in a single LPHTTP request
-				// This could be an attempted DOS attack
-				[asyncSocket disconnect];
-				
-				// Explictly return to ensure we don't do anything after the socket disconnect
-				return;
-			}
-			else
-			{
-				[asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
-				                withTimeout:TIMEOUT_READ_SUBSEQUENT_HEADER_LINE
-				                  maxLength:MAX_HEADER_LINE_LENGTH
-				                        tag:LPHTTP_REQUEST_HEADER];
-			}
-		}
-		else
-		{
-			// We have an entire LPHTTP request header from the client
-			
-			// Extract the method (such as GET, HEAD, POST, etc)
-			NSString *method = [request method];
-			
-			// Extract the uri (such as "/index.html")
-			NSString *uri = [self requestURI];
-			
-			// Check for a Transfer-Encoding field
-			NSString *transferEncoding = [request headerField:@"Transfer-Encoding"];
-      
-			// Check for a Content-Length field
-			NSString *contentLength = [request headerField:@"Content-Length"];
-			
-			// Content-Length MUST be present for upload methods (such as POST or PUT)
-			// and MUST NOT be present for other methods.
-			BOOL expectsUpload = [self expectsRequestBodyFromMethod:method atPath:uri];
-			
-			if (expectsUpload)
-			{
-				if (transferEncoding && ![transferEncoding caseInsensitiveCompare:@"Chunked"])
-				{
-					requestContentLength = -1;
-				}
-				else
-				{
-					if (contentLength == nil)
-					{
-						//LPHTTPLogWarn(@"%@[%p]: Method expects request body, but had no specified Content-Length",
-	//								THIS_FILE, self);
-						
-						[self handleInvalidRequest:nil];
-						return;
-					}
-					
-					if (![NSNumber parseString:(NSString *)contentLength intoUInt64:&requestContentLength])
-					{
-						//LPHTTPLogWarn(@"%@[%p]: Unable to parse Content-Length header into a valid number",
-//									THIS_FILE, self);
-						
-						[self handleInvalidRequest:nil];
-						return;
-					}
-				}
-			}
-			else
-			{
-				if (contentLength != nil)
-				{
-					// Received Content-Length header for method not expecting an upload.
-					// This better be zero...
-					
-					if (![NSNumber parseString:(NSString *)contentLength intoUInt64:&requestContentLength])
-					{
-						//LPHTTPLogWarn(@"%@[%p]: Unable to parse Content-Length header into a valid number",
-//									THIS_FILE, self);
-						
-						[self handleInvalidRequest:nil];
-						return;
-					}
-					
-					if (requestContentLength > 0)
-					{
-						//LPHTTPLogWarn(@"%@[%p]: Method not expecting request body had non-zero Content-Length",
-//									THIS_FILE, self);
-						
-						[self handleInvalidRequest:nil];
-						return;
-					}
-				}
-				
-				requestContentLength = 0;
-				requestContentLengthReceived = 0;
-			}
-			
-			// Check to make sure the given method is supported
-			if (![self supportsMethod:method atPath:uri])
-			{
-				// The method is unsupported - either in general, or for this specific request
-				// Send a 405 - Method not allowed response
-				[self handleUnknownMethod:method];
-				return;
-			}
-			
-			if (expectsUpload)
-			{
-				// Reset the total amount of data received for the upload
-				requestContentLengthReceived = 0;
-				
-				// Prepare for the upload
-				[self prepareForBodyWithSize:requestContentLength];
-				
-				if (requestContentLength > 0)
-				{
-					// Start reading the request body
-					if (requestContentLength == -1)
-					{
-						// Chunked transfer
-						
-						[asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
-						                withTimeout:TIMEOUT_READ_BODY
-						                  maxLength:MAX_CHUNK_LINE_LENGTH
-						                        tag:LPHTTP_REQUEST_CHUNK_SIZE];
-					}
-					else
-					{
-						NSUInteger bytesToRead;
-						if (requestContentLength < POST_CHUNKSIZE)
-							bytesToRead = (NSUInteger)requestContentLength;
-						else
-							bytesToRead = POST_CHUNKSIZE;
-						
-						[asyncSocket readDataToLength:bytesToRead
-						                  withTimeout:TIMEOUT_READ_BODY
-						                          tag:LPHTTP_REQUEST_BODY];
-					}
-				}
-				else
-				{
-					// Empty upload
-					[self finishBody];
-					[self replyToHTTPRequest];
-				}
-			}
-			else
-			{
-				// Now we need to reply to the request
-				[self replyToHTTPRequest];
-			}
-		}
-	}
-	else
-	{
-		BOOL doneReadingRequest = NO;
-		
-		// A chunked message body contains a series of chunks,
-		// followed by a line with "0" (zero),
-		// followed by optional footers (just like headers),
-		// and a blank line.
-		// 
-		// Each chunk consists of two parts:
-		// 
-		// 1. A line with the size of the chunk data, in hex,
-		//    possibly followed by a semicolon and extra parameters you can ignore (none are currently standard),
-		//    and ending with CRLF.
-		// 2. The data itself, followed by CRLF.
-		// 
-		// Part 1 is represented by LPHTTP_REQUEST_CHUNK_SIZE
-		// Part 2 is represented by LPHTTP_REQUEST_CHUNK_DATA and LPHTTP_REQUEST_CHUNK_TRAILER
-		// where the trailer is the CRLF that follows the data.
-		// 
-		// The optional footers and blank line are represented by LPHTTP_REQUEST_CHUNK_FOOTER.
-		
-		if (tag == LPHTTP_REQUEST_CHUNK_SIZE)
-		{
-			// We have just read in a line with the size of the chunk data, in hex, 
-			// possibly followed by a semicolon and extra parameters that can be ignored,
-			// and ending with CRLF.
-			
-			NSString *sizeLine = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
-			
-			requestChunkSize = (UInt64)strtoull([sizeLine UTF8String], NULL, 16);
-			requestChunkSizeReceived = 0;
-			
-			if (errno != 0)
-			{
-				//LPHTTPLogWarn(@"%@[%p]: Method expects chunk size, but received something else", THIS_FILE, self);
-				
-				[self handleInvalidRequest:nil];
-				return;
-			}
-			
-			if (requestChunkSize > 0)
-			{
-				NSUInteger bytesToRead;
-				bytesToRead = (requestChunkSize < POST_CHUNKSIZE) ? (NSUInteger)requestChunkSize : POST_CHUNKSIZE;
-				
-				[asyncSocket readDataToLength:bytesToRead
-				                  withTimeout:TIMEOUT_READ_BODY
-				                          tag:LPHTTP_REQUEST_CHUNK_DATA];
-			}
-			else
-			{
-				// This is the "0" (zero) line,
-				// which is to be followed by optional footers (just like headers) and finally a blank line.
-				
-				[asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
-				                withTimeout:TIMEOUT_READ_BODY
-				                  maxLength:MAX_HEADER_LINE_LENGTH
-				                        tag:LPHTTP_REQUEST_CHUNK_FOOTER];
-			}
-			
-			return;
-		}
-		else if (tag == LPHTTP_REQUEST_CHUNK_DATA)
-		{
-			// We just read part of the actual data.
-			
-			requestContentLengthReceived += [data length];
-			requestChunkSizeReceived += [data length];
-			
-			[self processBodyData:data];
-			
-			UInt64 bytesLeft = requestChunkSize - requestChunkSizeReceived;
-			if (bytesLeft > 0)
-			{
-				NSUInteger bytesToRead = (bytesLeft < POST_CHUNKSIZE) ? (NSUInteger)bytesLeft : POST_CHUNKSIZE;
-				
-				[asyncSocket readDataToLength:bytesToRead
-				                  withTimeout:TIMEOUT_READ_BODY
-				                          tag:LPHTTP_REQUEST_CHUNK_DATA];
-			}
-			else
-			{
-				// We've read in all the data for this chunk.
-				// The data is followed by a CRLF, which we need to read (and basically ignore)
-				
-				[asyncSocket readDataToLength:2
-				                  withTimeout:TIMEOUT_READ_BODY
-				                          tag:LPHTTP_REQUEST_CHUNK_TRAILER];
-			}
-			
-			return;
-		}
-		else if (tag == LPHTTP_REQUEST_CHUNK_TRAILER)
-		{
-			// This should be the CRLF following the data.
-			// Just ensure it's a CRLF.
-			
-			if (![data isEqualToData:[LPGCDAsyncSocket CRLFData]])
-			{
-				//LPHTTPLogWarn(@"%@[%p]: Method expects chunk trailer, but is missing", THIS_FILE, self);
-				
-				[self handleInvalidRequest:nil];
-				return;
-			}
-			
-			// Now continue with the next chunk
-			
-			[asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
-			                withTimeout:TIMEOUT_READ_BODY
-			                  maxLength:MAX_CHUNK_LINE_LENGTH
-			                        tag:LPHTTP_REQUEST_CHUNK_SIZE];
-			
-		}
-		else if (tag == LPHTTP_REQUEST_CHUNK_FOOTER)
-		{
-			if (++numHeaderLines > MAX_HEADER_LINES)
-			{
-				// Reached the maximum amount of header lines in a single LPHTTP request
-				// This could be an attempted DOS attack
-				[asyncSocket disconnect];
-				
-				// Explictly return to ensure we don't do anything after the socket disconnect
-				return;
-			}
-			
-			if ([data length] > 2)
-			{
-				// We read in a footer.
-				// In the future we may want to append these to the request.
-				// For now we ignore, and continue reading the footers, waiting for the final blank line.
-				
-				[asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
-				                withTimeout:TIMEOUT_READ_BODY
-				                  maxLength:MAX_HEADER_LINE_LENGTH
-				                        tag:LPHTTP_REQUEST_CHUNK_FOOTER];
-			}
-			else
-			{
-				doneReadingRequest = YES;
-			}
-		}
-		else  // LPHTTP_REQUEST_BODY
-		{
-			// Handle a chunk of data from the POST body
-			
-			requestContentLengthReceived += [data length];
-			[self processBodyData:data];
-			
-			if (requestContentLengthReceived < requestContentLength)
-			{
-				// We're not done reading the post body yet...
-				
-				UInt64 bytesLeft = requestContentLength - requestContentLengthReceived;
-				
-				NSUInteger bytesToRead = bytesLeft < POST_CHUNKSIZE ? (NSUInteger)bytesLeft : POST_CHUNKSIZE;
-				
-				[asyncSocket readDataToLength:bytesToRead
-				                  withTimeout:TIMEOUT_READ_BODY
-				                          tag:LPHTTP_REQUEST_BODY];
-			}
-			else
-			{
-				doneReadingRequest = YES;
-			}
-		}
-		
-		// Now that the entire body has been received, we need to reply to the request
-		
-		if (doneReadingRequest)
-		{
-			[self finishBody];
-			[self replyToHTTPRequest];
-		}
-	}
+ **/
+- (void)socket:(LPGCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
+  if (tag == HTTP_REQUEST_HEADER) {
+    // Append the header line to the http message
+    BOOL result = [request appendData:data];
+    if (!result) {
+      LPHTTPLogWarn(@"%@[%p]: Malformed request", LP_THIS_FILE, self);
+
+      [self handleInvalidRequest:data];
+    }
+    else if (![request isHeaderComplete]) {
+      // We don't have a complete header yet
+      // That is, we haven't yet received a CRLF on a line by itself, indicating the end of the header
+      if (++numHeaderLines > MAX_HEADER_LINES) {
+        // Reached the maximum amount of header lines in a single HTTP request
+        // This could be an attempted DOS attack
+        [asyncSocket disconnect];
+
+        // Explictly return to ensure we don't do anything after the socket disconnect
+        return;
+      }
+      else {
+        [asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
+                        withTimeout:TIMEOUT_READ_SUBSEQUENT_HEADER_LINE
+                          maxLength:MAX_HEADER_LINE_LENGTH
+                                tag:HTTP_REQUEST_HEADER];
+      }
+    }
+    else {
+      // We have an entire HTTP request header from the client
+
+      // Extract the method (such as GET, HEAD, POST, etc)
+      NSString *method = [request method];
+
+      // Extract the uri (such as "/index.html")
+      NSString *uri = [self requestURI];
+
+      // Check for a Transfer-Encoding field
+      NSString *transferEncoding = [request headerField:@"Transfer-Encoding"];
+
+      // Check for a Content-Length field
+      NSString *contentLength = [request headerField:@"Content-Length"];
+
+      // Content-Length MUST be present for upload methods (such as POST or PUT)
+      // and MUST NOT be present for other methods.
+      BOOL expectsUpload = [self expectsRequestBodyFromMethod:method atPath:uri];
+
+      if (expectsUpload) {
+        if (transferEncoding && ![transferEncoding caseInsensitiveCompare:@"Chunked"]) {
+          requestContentLength = -1;
+        }
+        else {
+          if (contentLength == nil) {
+            LPHTTPLogWarn(@"%@[%p]: Method expects request body, but had no specified Content-Length",
+                          LP_THIS_FILE, self);
+
+            [self handleInvalidRequest:nil];
+            return;
+          }
+
+          if (![NSNumber parseString:(NSString *) contentLength intoUInt64:&requestContentLength]) {
+            LPHTTPLogWarn(@"%@[%p]: Unable to parse Content-Length header into a valid number",
+                          LP_THIS_FILE, self);
+
+            [self handleInvalidRequest:nil];
+            return;
+          }
+        }
+      }
+      else {
+        if (contentLength != nil) {
+          // Received Content-Length header for method not expecting an upload.
+          // This better be zero...
+
+          if (![NSNumber parseString:(NSString *) contentLength intoUInt64:&requestContentLength]) {
+            LPHTTPLogWarn(@"%@[%p]: Unable to parse Content-Length header into a valid number",
+                          LP_THIS_FILE, self);
+
+            [self handleInvalidRequest:nil];
+            return;
+          }
+
+          if (requestContentLength > 0) {
+            LPHTTPLogWarn(@"%@[%p]: Method not expecting request body had non-zero Content-Length",
+                          LP_THIS_FILE, self);
+
+            [self handleInvalidRequest:nil];
+            return;
+          }
+        }
+
+        requestContentLength = 0;
+        requestContentLengthReceived = 0;
+      }
+
+      // Check to make sure the given method is supported
+      if (![self supportsMethod:method atPath:uri]) {
+        // The method is unsupported - either in general, or for this specific request
+        // Send a 405 - Method not allowed response
+        [self handleUnknownMethod:method];
+        return;
+      }
+
+      if (expectsUpload) {
+        // Reset the total amount of data received for the upload
+        requestContentLengthReceived = 0;
+
+        // Prepare for the upload
+        [self prepareForBodyWithSize:requestContentLength];
+
+        if (requestContentLength > 0) {
+          // Start reading the request body
+          if (requestContentLength == -1) {
+            // Chunked transfer
+
+            [asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
+                            withTimeout:TIMEOUT_READ_BODY
+                              maxLength:MAX_CHUNK_LINE_LENGTH
+                                    tag:HTTP_REQUEST_CHUNK_SIZE];
+          }
+          else {
+            NSUInteger bytesToRead;
+            if (requestContentLength < POST_CHUNKSIZE)
+              bytesToRead = (NSUInteger) requestContentLength;
+            else
+              bytesToRead = POST_CHUNKSIZE;
+
+            [asyncSocket readDataToLength:bytesToRead
+                              withTimeout:TIMEOUT_READ_BODY
+                                      tag:HTTP_REQUEST_BODY];
+          }
+        }
+        else {
+          // Empty upload
+          [self finishBody];
+          [self replyToHTTPRequest];
+        }
+      }
+      else {
+        // Now we need to reply to the request
+        [self replyToHTTPRequest];
+      }
+    }
+  }
+  else {
+    BOOL doneReadingRequest = NO;
+
+    // A chunked message body contains a series of chunks,
+    // followed by a line with "0" (zero),
+    // followed by optional footers (just like headers),
+    // and a blank line.
+    //
+    // Each chunk consists of two parts:
+    //
+    // 1. A line with the size of the chunk data, in hex,
+    //    possibly followed by a semicolon and extra parameters you can ignore (none are currently standard),
+    //    and ending with CRLF.
+    // 2. The data itself, followed by CRLF.
+    //
+    // Part 1 is represented by HTTP_REQUEST_CHUNK_SIZE
+    // Part 2 is represented by HTTP_REQUEST_CHUNK_DATA and HTTP_REQUEST_CHUNK_TRAILER
+    // where the trailer is the CRLF that follows the data.
+    //
+    // The optional footers and blank line are represented by HTTP_REQUEST_CHUNK_FOOTER.
+
+    if (tag == HTTP_REQUEST_CHUNK_SIZE) {
+      // We have just read in a line with the size of the chunk data, in hex,
+      // possibly followed by a semicolon and extra parameters that can be ignored,
+      // and ending with CRLF.
+
+      NSString *sizeLine = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+      errno = 0;  // Reset errno before calling strtoull() to ensure it is always zero on success
+      requestChunkSize = (UInt64) strtoull([sizeLine UTF8String], NULL, 16);
+      requestChunkSizeReceived = 0;
+
+      if (errno != 0) {
+        LPHTTPLogWarn(@"%@[%p]: Method expects chunk size, but received something else", LP_THIS_FILE, self);
+
+        [self handleInvalidRequest:nil];
+        return;
+      }
+
+      if (requestChunkSize > 0) {
+        NSUInteger bytesToRead;
+        bytesToRead = (requestChunkSize < POST_CHUNKSIZE) ? (NSUInteger) requestChunkSize : POST_CHUNKSIZE;
+
+        [asyncSocket readDataToLength:bytesToRead
+                          withTimeout:TIMEOUT_READ_BODY
+                                  tag:HTTP_REQUEST_CHUNK_DATA];
+      }
+      else {
+        // This is the "0" (zero) line,
+        // which is to be followed by optional footers (just like headers) and finally a blank line.
+
+        [asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
+                        withTimeout:TIMEOUT_READ_BODY
+                          maxLength:MAX_HEADER_LINE_LENGTH
+                                tag:HTTP_REQUEST_CHUNK_FOOTER];
+      }
+
+      return;
+    }
+    else if (tag == HTTP_REQUEST_CHUNK_DATA) {
+      // We just read part of the actual data.
+
+      requestContentLengthReceived += [data length];
+      requestChunkSizeReceived += [data length];
+
+      [self processBodyData:data];
+
+      UInt64 bytesLeft = requestChunkSize - requestChunkSizeReceived;
+      if (bytesLeft > 0) {
+        NSUInteger bytesToRead = (bytesLeft < POST_CHUNKSIZE) ? (NSUInteger) bytesLeft : POST_CHUNKSIZE;
+
+        [asyncSocket readDataToLength:bytesToRead
+                          withTimeout:TIMEOUT_READ_BODY
+                                  tag:HTTP_REQUEST_CHUNK_DATA];
+      }
+      else {
+        // We've read in all the data for this chunk.
+        // The data is followed by a CRLF, which we need to read (and basically ignore)
+
+        [asyncSocket readDataToLength:2
+                          withTimeout:TIMEOUT_READ_BODY
+                                  tag:HTTP_REQUEST_CHUNK_TRAILER];
+      }
+
+      return;
+    }
+    else if (tag == HTTP_REQUEST_CHUNK_TRAILER) {
+      // This should be the CRLF following the data.
+      // Just ensure it's a CRLF.
+
+      if (![data isEqualToData:[LPGCDAsyncSocket CRLFData]]) {
+        LPHTTPLogWarn(@"%@[%p]: Method expects chunk trailer, but is missing", LP_THIS_FILE, self);
+
+        [self handleInvalidRequest:nil];
+        return;
+      }
+
+      // Now continue with the next chunk
+
+      [asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
+                      withTimeout:TIMEOUT_READ_BODY
+                        maxLength:MAX_CHUNK_LINE_LENGTH
+                              tag:HTTP_REQUEST_CHUNK_SIZE];
+
+    }
+    else if (tag == HTTP_REQUEST_CHUNK_FOOTER) {
+      if (++numHeaderLines > MAX_HEADER_LINES) {
+        // Reached the maximum amount of header lines in a single HTTP request
+        // This could be an attempted DOS attack
+        [asyncSocket disconnect];
+
+        // Explictly return to ensure we don't do anything after the socket disconnect
+        return;
+      }
+
+      if ([data length] > 2) {
+        // We read in a footer.
+        // In the future we may want to append these to the request.
+        // For now we ignore, and continue reading the footers, waiting for the final blank line.
+
+        [asyncSocket readDataToData:[LPGCDAsyncSocket CRLFData]
+                        withTimeout:TIMEOUT_READ_BODY
+                          maxLength:MAX_HEADER_LINE_LENGTH
+                                tag:HTTP_REQUEST_CHUNK_FOOTER];
+      }
+      else {
+        doneReadingRequest = YES;
+      }
+    }
+    else  // HTTP_REQUEST_BODY
+    {
+      // Handle a chunk of data from the POST body
+
+      requestContentLengthReceived += [data length];
+      [self processBodyData:data];
+
+      if (requestContentLengthReceived < requestContentLength) {
+        // We're not done reading the post body yet...
+
+        UInt64 bytesLeft = requestContentLength - requestContentLengthReceived;
+
+        NSUInteger bytesToRead = bytesLeft < POST_CHUNKSIZE ? (NSUInteger) bytesLeft : POST_CHUNKSIZE;
+
+        [asyncSocket readDataToLength:bytesToRead
+                          withTimeout:TIMEOUT_READ_BODY
+                                  tag:HTTP_REQUEST_BODY];
+      }
+      else {
+        doneReadingRequest = YES;
+      }
+    }
+
+    // Now that the entire body has been received, we need to reply to the request
+
+    if (doneReadingRequest) {
+      [self finishBody];
+      [self replyToHTTPRequest];
+    }
+  }
 }
 
 /**
  * This method is called after the socket has successfully written data to the stream.
-**/
-- (void)socket:(LPGCDAsyncSocket *)sock didWriteDataWithTag:(long)tag
-{
-	BOOL doneSendingResponse = NO;
-	
-	if (tag == LPHTTP_PARTIAL_RESPONSE_BODY)
-	{
+ **/
+- (void)socket:(LPGCDAsyncSocket *)sock didWriteDataWithTag:(long)tag {
+  BOOL doneSendingResponse = NO;
+
+  if (tag == HTTP_PARTIAL_RESPONSE_BODY) {
     // Update the amount of data we have in asyncSocket's write queue
-    if ([responseDataSizes count] > 0)
-    {
+    if ([responseDataSizes count] > 0) {
       [responseDataSizes removeObjectAtIndex:0];
     }
-		// We only wrote a part of the response - there may be more
-		[self continueSendingStandardResponseBody];
-	}
-	else if (tag == LPHTTP_CHUNKED_RESPONSE_BODY)
-	{
-		// Update the amount of data we have in asyncSocket's write queue.
-    if ([responseDataSizes count] > 0)
-    {
-      [responseDataSizes removeObjectAtIndex:0];
-    }
-		
-		// Don't continue sending the response yet.
-		// The chunked footer that was sent after the body will tell us if we have more data to send.
-	}
-	else if (tag == LPHTTP_CHUNKED_RESPONSE_FOOTER)
-	{
-		// Normal chunked footer indicating we have more data to send (non final footer).
-		[self continueSendingStandardResponseBody];
-	}
-	else if (tag == LPHTTP_PARTIAL_RANGE_RESPONSE_BODY)
-	{
+
+    // We only wrote a part of the response - there may be more
+    [self continueSendingStandardResponseBody];
+  }
+  else if (tag == HTTP_CHUNKED_RESPONSE_BODY) {
     // Update the amount of data we have in asyncSocket's write queue.
-    if ([responseDataSizes count] > 0)
-    {
+    // This will allow asynchronous responses to continue sending more data.
+    if ([responseDataSizes count] > 0) {
       [responseDataSizes removeObjectAtIndex:0];
     }
-		
-		// We only wrote a part of the range - there may be more
-		[self continueSendingSingleRangeResponseBody];
-	}
-	else if (tag == LPHTTP_PARTIAL_RANGES_RESPONSE_BODY)
-	{
-    // Update the amount of data we have in asyncSocket's write queue.
-    if ([responseDataSizes count] > 0)
-    {
+    // Don't continue sending the response yet.
+    // The chunked footer that was sent after the body will tell us if we have more data to send.
+  }
+  else if (tag == HTTP_CHUNKED_RESPONSE_FOOTER) {
+    // Normal chunked footer indicating we have more data to send (non final footer).
+    [self continueSendingStandardResponseBody];
+  }
+  else if (tag == HTTP_PARTIAL_RANGE_RESPONSE_BODY) {
+    // Update the amount of data we have in asyncSocket's write queue
+    if ([responseDataSizes count] > 0) {
       [responseDataSizes removeObjectAtIndex:0];
     }
-		
-		// We only wrote part of the range - there may be more, or there may be more ranges
-		[self continueSendingMultiRangeResponseBody];
-	}
-	else if (tag == LPHTTP_RESPONSE || tag == LPHTTP_FINAL_RESPONSE)
-	{
-		// Update the amount of data we have in asyncSocket's write queue
-		if ([responseDataSizes count] > 0)
-		{
-			[responseDataSizes removeObjectAtIndex:0];
-		}
-		
-		doneSendingResponse = YES;
-	}
-	
-	if (doneSendingResponse)
-	{
-		// Inform the http response that we're done
-		if ([httpResponse respondsToSelector:@selector(connectionDidClose)])
-		{
-			[httpResponse connectionDidClose];
-		}
-		
-		// Cleanup after the last request
-		[self finishResponse];
-		
-		
-		if (tag == LPHTTP_FINAL_RESPONSE)
-		{
-			// Terminate the connection
-			[asyncSocket disconnect];
-			
-			// Explictly return to ensure we don't do anything after the socket disconnect
-			return;
-		}
-		else
-		{
-			if ([self shouldDie])
-			{
-				// The only time we should invoke [self die] is from socketDidDisconnect,
-				// or if the socket gets taken over by someone else like a WebSocket.
-				
-				[asyncSocket disconnect];
-			}
-			else
-			{
-				// Prepare for the next request
-				
-				// If this assertion fails, it likely means you overrode the
-				// finishBody method and forgot to call [super finishBody].
-				NSAssert(request == nil, @"Request not properly released in finishBody");
-				
-				request = [[LPHTTPMessage alloc] initEmptyRequest];
-				
-				numHeaderLines = 0;
-				sentResponseHeaders = NO;
-				
-				// And start listening for more requests
-				[self startReadingRequest];
-			}
-		}
-	}
+    // We only wrote a part of the range - there may be more
+    [self continueSendingSingleRangeResponseBody];
+  }
+  else if (tag == HTTP_PARTIAL_RANGES_RESPONSE_BODY) {
+    // Update the amount of data we have in asyncSocket's write queue
+    if ([responseDataSizes count] > 0) {
+      [responseDataSizes removeObjectAtIndex:0];
+    }
+    // We only wrote part of the range - there may be more, or there may be more ranges
+    [self continueSendingMultiRangeResponseBody];
+  }
+  else if (tag == HTTP_RESPONSE || tag == HTTP_FINAL_RESPONSE) {
+    // Update the amount of data we have in asyncSocket's write queue
+    if ([responseDataSizes count] > 0) {
+      [responseDataSizes removeObjectAtIndex:0];
+    }
+
+    doneSendingResponse = YES;
+  }
+
+  if (doneSendingResponse) {
+    // Inform the http response that we're done
+    if ([httpResponse respondsToSelector:@selector(connectionDidClose)]) {
+      [httpResponse connectionDidClose];
+    }
+
+
+    if (tag == HTTP_FINAL_RESPONSE) {
+      // Cleanup after the last request
+      [self finishResponse];
+
+      // Terminate the connection
+      [asyncSocket disconnect];
+
+      // Explictly return to ensure we don't do anything after the socket disconnects
+      return;
+    }
+    else {
+      if ([self shouldDie]) {
+        // Cleanup after the last request
+        // Note: Don't do this before calling shouldDie, as it needs the request object still.
+        [self finishResponse];
+
+        // The only time we should invoke [self die] is from socketDidDisconnect,
+        // or if the socket gets taken over by someone else like a LPWebSocket.
+
+        [asyncSocket disconnect];
+      }
+      else {
+        // Cleanup after the last request
+        [self finishResponse];
+
+        // Prepare for the next request
+
+        // If this assertion fails, it likely means you overrode the
+        // finishBody method and forgot to call [super finishBody].
+        NSAssert(request == nil, @"Request not properly released in finishBody");
+
+        request = [[LPHTTPMessage alloc] initEmptyRequest];
+
+        numHeaderLines = 0;
+        sentResponseHeaders = NO;
+
+        // And start listening for more requests
+        [self startReadingRequest];
+      }
+    }
+  }
 }
 
 /**
  * Sent after the socket has been disconnected.
-**/
-- (void)socketDidDisconnect:(LPGCDAsyncSocket *)sock withError:(NSError *)err;
-{
-	//LPHTTPLogTrace();
-	
-	[asyncSocket release];
-	asyncSocket = nil;
-	
-	[self die];
+ **/
+- (void)socketDidDisconnect:(LPGCDAsyncSocket *)sock withError:(NSError *)err {
+  LPHTTPLogTrace();
+
+  asyncSocket = nil;
+
+  [self die];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2473,80 +2290,68 @@ static NSMutableArray *recentNonces;
 /**
  * This method may be called by asynchronous LPHTTPResponse objects.
  * That is, LPHTTPResponse objects that return YES in their "- (BOOL)isAsynchronous" method.
- * 
+ *
  * This informs us that the response object has generated more data that we may be able to send.
-**/
-- (void)responseHasAvailableData:(NSObject<LPHTTPResponse> *)sender
-{
-	//LPHTTPLogTrace();
-	
-	// We always dispatch this asynchronously onto our connectionQueue,
-	// even if the connectionQueue is the current queue.
-	// 
-	// We do this to give the LPHTTPResponse classes the flexibility to call
-	// this method whenever they want, even from within a readDataOfLength method.
-	
-	dispatch_async(connectionQueue, ^{
-		
-		if (sender != httpResponse)
-		{
-			//LPHTTPLogWarn(@"%@[%p]: %@ - Sender is not current httpResponse", THIS_FILE, self, THIS_METHOD);
-			return;
-		}
-		
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		
-		if (!sentResponseHeaders)
-		{
-			[self sendResponseHeadersAndBody];
-		}
-		else
-		{
-			if (ranges == nil)
-			{
-				[self continueSendingStandardResponseBody];
-			}
-			else
-			{
-				if ([ranges count] == 1)
-					[self continueSendingSingleRangeResponseBody];
-				else
-					[self continueSendingMultiRangeResponseBody];
-			}
-		}
-		
-		[pool drain];
-	});
+ **/
+- (void)responseHasAvailableData:(NSObject <LPHTTPResponse> *)sender {
+  LPHTTPLogTrace();
+
+  // We always dispatch this asynchronously onto our connectionQueue,
+  // even if the connectionQueue is the current queue.
+  //
+  // We do this to give the LPHTTPResponse classes the flexibility to call
+  // this method whenever they want, even from within a readDataOfLength method.
+
+  dispatch_async(connectionQueue, ^{
+    @autoreleasepool {
+
+      if (sender != self->httpResponse) {
+        LPHTTPLogWarn(@"%@[%p]: %@ - Sender is not current httpResponse", LP_THIS_FILE, self, LP_THIS_METHOD);
+        return;
+      }
+
+      if (!self->sentResponseHeaders) {
+        [self sendResponseHeadersAndBody];
+      }
+      else {
+        if (self->ranges == nil) {
+          [self continueSendingStandardResponseBody];
+        }
+        else {
+          if ([self->ranges count] == 1)
+            [self continueSendingSingleRangeResponseBody];
+          else
+            [self continueSendingMultiRangeResponseBody];
+        }
+      }
+    }
+  });
 }
 
 /**
  * This method is called if the response encounters some critical error,
  * and it will be unable to fullfill the request.
-**/
-- (void)responseDidAbort:(NSObject<LPHTTPResponse> *)sender
-{
-	//LPHTTPLogTrace();
-	
-	// We always dispatch this asynchronously onto our connectionQueue,
-	// even if the connectionQueue is the current queue.
-	// 
-	// We do this to give the LPHTTPResponse classes the flexibility to call
-	// this method whenever they want, even from within a readDataOfLength method.
-	
-	dispatch_async(connectionQueue, ^{
-		
-		if (sender != httpResponse)
-		{
-			//LPHTTPLogWarn(@"%@[%p]: %@ - Sender is not current httpResponse", THIS_FILE, self, THIS_METHOD);
-			return;
-		}
-		
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		
-		[asyncSocket disconnectAfterWriting];
-		
-		[pool drain];
-	});
+ **/
+- (void)responseDidAbort:(NSObject <LPHTTPResponse> *)sender {
+  LPHTTPLogTrace();
+
+  // We always dispatch this asynchronously onto our connectionQueue,
+  // even if the connectionQueue is the current queue.
+  //
+  // We do this to give the LPHTTPResponse classes the flexibility to call
+  // this method whenever they want, even from within a readDataOfLength method.
+
+  dispatch_async(connectionQueue, ^{
+    @autoreleasepool {
+
+      if (sender != self->httpResponse) {
+        LPHTTPLogWarn(@"%@[%p]: %@ - Sender is not current httpResponse", LP_THIS_FILE, self, LP_THIS_METHOD);
+        return;
+      }
+
+      [self->asyncSocket disconnectAfterWriting];
+    }
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2557,98 +2362,86 @@ static NSMutableArray *recentNonces;
  * This method is called after each response has been fully sent.
  * Since a single connection may handle multiple request/responses, this method may be called multiple times.
  * That is, it will be called after completion of each response.
-**/
-- (void)finishResponse
-{
-	//LPHTTPLogTrace();
-	
-	// Override me if you want to perform any custom actions after a response has been fully sent.
-	// This is the place to release memory or resources associated with the last request.
-	// 
-	// If you override this method, you should take care to invoke [super finishResponse] at some point.
-	
-	[request release];
-	request = nil;
-	
-	[httpResponse release];
-	httpResponse = nil;
-	
-	[ranges release];
-	[ranges_headers release];
-	[ranges_boundry release];
-	ranges = nil;
-	ranges_headers = nil;
-	ranges_boundry = nil;
+ **/
+- (void)finishResponse {
+  LPHTTPLogTrace();
+
+  // Override me if you want to perform any custom actions after a response has been fully sent.
+  // This is the place to release memory or resources associated with the last request.
+  //
+  // If you override this method, you should take care to invoke [super finishResponse] at some point.
+
+  request = nil;
+
+  httpResponse = nil;
+
+  ranges = nil;
+  ranges_headers = nil;
+  ranges_boundry = nil;
 }
 
 /**
  * This method is called after each successful response has been fully sent.
  * It determines whether the connection should stay open and handle another request.
-**/
-- (BOOL)shouldDie
-{
-	//LPHTTPLogTrace();
-	
-	// Override me if you have any need to force close the connection.
-	// You may do so by simply returning YES.
-	// 
-	// If you override this method, you should take care to fall through with [super shouldDie]
-	// instead of returning NO.
-	
-	
-	BOOL shouldDie = NO;
-	
-	NSString *version = [request version];
-	if ([version isEqualToString:LPHTTPVersion1_1])
-	{
-		// LPHTTP version 1.1
-		// Connection should only be closed if request included "Connection: close" header
-		
-		NSString *connection = [request headerField:@"Connection"];
-		
-		shouldDie = (connection && ([connection caseInsensitiveCompare:@"close"] == NSOrderedSame));
-	}
-	else if ([version isEqualToString:LPHTTPVersion1_0])
-	{
-		// LPHTTP version 1.0
-		// Connection should be closed unless request included "Connection: Keep-Alive" header
-		
-		NSString *connection = [request headerField:@"Connection"];
-		
-		if (connection == nil)
-			shouldDie = YES;
-		else
-			shouldDie = [connection caseInsensitiveCompare:@"Keep-Alive"] != NSOrderedSame;
-	}
-	
-	return shouldDie;
+ **/
+- (BOOL)shouldDie {
+  LPHTTPLogTrace();
+
+  // Override me if you have any need to force close the connection.
+  // You may do so by simply returning YES.
+  //
+  // If you override this method, you should take care to fall through with [super shouldDie]
+  // instead of returning NO.
+
+
+  BOOL shouldDie = NO;
+
+  NSString *version = [request version];
+  if ([version isEqualToString:LPHTTPVersion1_1]) {
+    // HTTP version 1.1
+    // Connection should only be closed if request included "Connection: close" header
+
+    NSString *connection = [request headerField:@"Connection"];
+
+    shouldDie = (connection && ([connection caseInsensitiveCompare:@"close"] == NSOrderedSame));
+  }
+  else if ([version isEqualToString:LPHTTPVersion1_0]) {
+    // HTTP version 1.0
+    // Connection should be closed unless request included "Connection: Keep-Alive" header
+
+    NSString *connection = [request headerField:@"Connection"];
+
+    if (connection == nil)
+      shouldDie = YES;
+    else
+      shouldDie = [connection caseInsensitiveCompare:@"Keep-Alive"] != NSOrderedSame;
+  }
+
+  return shouldDie;
 }
 
-- (void)die
-{
-	//LPHTTPLogTrace();
-	
-	// Override me if you want to perform any custom actions when a connection is closed.
-	// Then call [super die] when you're done.
-	// 
-	// See also the finishResponse method.
-	// 
-	// Important: There is a rare timing condition where this method might get invoked twice.
-	// If you override this method, you should be prepared for this situation.
-	
-	// Inform the http response that we're done
-	if ([httpResponse respondsToSelector:@selector(connectionDidClose)])
-	{
-		[httpResponse connectionDidClose];
-	}
-	
-	// Release the http response so we don't call it's connectionDidClose method again in our dealloc method
-	[httpResponse release];
-	httpResponse = nil;
-	
-	// Post notification of dead connection
-	// This will allow our server to release us from its array of connections
-	[[NSNotificationCenter defaultCenter] postNotificationName:LPHTTPConnectionDidDieNotification object:self];
+- (void)die {
+  LPHTTPLogTrace();
+
+  // Override me if you want to perform any custom actions when a connection is closed.
+  // Then call [super die] when you're done.
+  //
+  // See also the finishResponse method.
+  //
+  // Important: There is a rare timing condition where this method might get invoked twice.
+  // If you override this method, you should be prepared for this situation.
+
+  // Inform the http response that we're done
+  if ([httpResponse respondsToSelector:@selector(connectionDidClose)]) {
+    [httpResponse connectionDidClose];
+  }
+
+  // Release the http response so we don't call it's connectionDidClose method again in our dealloc method
+  httpResponse = nil;
+
+  // Post notification of dead connection
+  // This will allow our server to release us from its array of connections
+  [[NSNotificationCenter defaultCenter] postNotificationName:LPHTTPConnectionDidDieNotification object:self];
 }
 
 @end
@@ -2663,47 +2456,37 @@ static NSMutableArray *recentNonces;
 @synthesize documentRoot;
 @synthesize queue;
 
-- (id)initWithServer:(LPHTTPServer *)aServer documentRoot:(NSString *)aDocumentRoot
-{
-	if ((self = [super init]))
-	{
-		server = [aServer retain];
-		documentRoot = [aDocumentRoot retain];
-	}
-	return self;
+- (id)initWithServer:(LPHTTPServer *)aServer documentRoot:(NSString *)aDocumentRoot {
+  if ((self = [super init])) {
+    server = aServer;
+    documentRoot = aDocumentRoot;
+  }
+  return self;
 }
 
-- (id)initWithServer:(LPHTTPServer *)aServer documentRoot:(NSString *)aDocumentRoot queue:(dispatch_queue_t)q
-{
-	if ((self = [super init]))
-	{
-		server = [aServer retain];
-		
-		documentRoot = [aDocumentRoot stringByStandardizingPath];
-		if ([documentRoot hasSuffix:@"/"])
-		{
-			documentRoot = [documentRoot stringByAppendingString:@"/"];
-		}
-		[documentRoot retain];
-		
-		if (q)
-		{
-			dispatch_retain(q);
-			queue = q;
-		}
-	}
-	return self;
+- (id)initWithServer:(LPHTTPServer *)aServer documentRoot:(NSString *)aDocumentRoot queue:(dispatch_queue_t)q {
+  if ((self = [super init])) {
+    server = aServer;
+    
+    documentRoot = [aDocumentRoot stringByStandardizingPath];
+    if ([documentRoot hasSuffix:@"/"]) {
+      documentRoot = [documentRoot stringByAppendingString:@"/"];
+    }
+    
+    if (q) {
+      queue = q;
+#if !OS_OBJECT_USE_OBJC
+      dispatch_retain(queue);
+#endif
+    }
+  }
+  return self;
 }
 
-- (void)dealloc
-{
-	[server release];
-	[documentRoot release];
-	
-	if (queue)
-		dispatch_release(queue);
-	
-	[super dealloc];
+- (void)dealloc {
+#if !OS_OBJECT_USE_OBJC
+  if (queue) dispatch_release(queue);
+#endif
 }
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPMessage.h
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPMessage.h
@@ -1,11 +1,11 @@
 /**
- * The LPHTTPMessage class is a simple Objective-C wrapper around Apple's CFHTTPMessage class.
-**/
+ * The HTTPMessage class is a simple Objective-C wrapper around Apple's CFHTTPMessage class.
+ **/
 
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_IPHONE
-  // Note: You may need to add the CFNetwork Framework to your project
+// Note: You may need to add the CFNetwork Framework to your project
   #import <CFNetwork/CFNetwork.h>
 #endif
 
@@ -13,9 +13,8 @@
 #define LPHTTPVersion1_1  ((NSString *)kCFHTTPVersion1_1)
 
 
-@interface LPHTTPMessage : NSObject
-{
-	CFHTTPMessageRef message;
+@interface LPHTTPMessage : NSObject {
+  CFHTTPMessageRef message;
 }
 
 - (id)initEmptyRequest;
@@ -31,11 +30,13 @@
 - (NSString *)version;
 
 - (NSString *)method;
+
 - (NSURL *)url;
 
 - (NSInteger)statusCode;
 
 - (NSDictionary *)allHeaderFields;
+
 - (NSString *)headerField:(NSString *)headerField;
 
 - (void)setHeaderField:(NSString *)headerField value:(NSString *)headerFieldValue;
@@ -43,6 +44,7 @@
 - (NSData *)messageData;
 
 - (NSData *)body;
+
 - (void)setBody:(NSData *)body;
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPMessage.m
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPMessage.m
@@ -1,102 +1,93 @@
 #import "LPHTTPMessage.h"
 
+#if !__has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 
 @implementation LPHTTPMessage
 
-- (id)initEmptyRequest
-{
-	if ((self = [super init]))
-	{
-		message = CFHTTPMessageCreateEmpty(NULL, YES);
-	}
-	return self;
+- (id)initEmptyRequest {
+  if ((self = [super init])) {
+    message = CFHTTPMessageCreateEmpty(NULL, YES);
+  }
+  return self;
 }
 
-- (id)initRequestWithMethod:(NSString *)method URL:(NSURL *)url version:(NSString *)version
-{
-	if ((self = [super init]))
-	{
-		message = CFHTTPMessageCreateRequest(NULL, (CFStringRef)method, (CFURLRef)url, (CFStringRef)version);
-	}
-	return self;
+- (id)initRequestWithMethod:(NSString *)method URL:(NSURL *)url version:(NSString *)version {
+  if ((self = [super init])) {
+    message = CFHTTPMessageCreateRequest(NULL,
+                                         (__bridge CFStringRef) method,
+                                         (__bridge CFURLRef) url,
+                                         (__bridge CFStringRef) version);
+  }
+  return self;
 }
 
-- (id)initResponseWithStatusCode:(NSInteger)code description:(NSString *)description version:(NSString *)version
-{
-	if ((self = [super init]))
-	{
-		message = CFHTTPMessageCreateResponse(NULL, (CFIndex)code, (CFStringRef)description, (CFStringRef)version);
-	}
-	return self;
+- (id)initResponseWithStatusCode:(NSInteger)code description:(NSString *)description version:(NSString *)version {
+  if ((self = [super init])) {
+    message = CFHTTPMessageCreateResponse(NULL,
+                                          (CFIndex) code,
+                                          (__bridge CFStringRef) description,
+                                          (__bridge CFStringRef) version);
+  }
+  return self;
 }
 
-- (void)dealloc
-{
-	if (message)
-	{
-		CFRelease(message);
-	}
-	[super dealloc];
+- (void)dealloc {
+  if (message) {
+    CFRelease(message);
+  }
 }
 
-- (BOOL)appendData:(NSData *)data
-{
-	return CFHTTPMessageAppendBytes(message, [data bytes], [data length]);
+- (BOOL)appendData:(NSData *)data {
+  return CFHTTPMessageAppendBytes(message, [data bytes], [data length]);
 }
 
-- (BOOL)isHeaderComplete
-{
-	return CFHTTPMessageIsHeaderComplete(message);
+- (BOOL)isHeaderComplete {
+  return CFHTTPMessageIsHeaderComplete(message);
 }
 
-- (NSString *)version
-{
-	return [NSMakeCollectable(CFHTTPMessageCopyVersion(message)) autorelease];
+- (NSString *)version {
+  return (__bridge_transfer NSString *) CFHTTPMessageCopyVersion(message);
 }
 
-- (NSString *)method
-{
-	return [NSMakeCollectable(CFHTTPMessageCopyRequestMethod(message)) autorelease];
+- (NSString *)method {
+  return (__bridge_transfer NSString *) CFHTTPMessageCopyRequestMethod(message);
 }
 
-- (NSURL *)url
-{
-	return [NSMakeCollectable(CFHTTPMessageCopyRequestURL(message)) autorelease];
+- (NSURL *)url {
+  return (__bridge_transfer NSURL *) CFHTTPMessageCopyRequestURL(message);
 }
 
-- (NSInteger)statusCode
-{
-	return (NSInteger)CFHTTPMessageGetResponseStatusCode(message);
+- (NSInteger)statusCode {
+  return (NSInteger) CFHTTPMessageGetResponseStatusCode(message);
 }
 
-- (NSDictionary *)allHeaderFields
-{
-	return [NSMakeCollectable(CFHTTPMessageCopyAllHeaderFields(message)) autorelease];
+- (NSDictionary *)allHeaderFields {
+  return (__bridge_transfer NSDictionary *) CFHTTPMessageCopyAllHeaderFields(message);
 }
 
-- (NSString *)headerField:(NSString *)headerField
-{
-	return [NSMakeCollectable(CFHTTPMessageCopyHeaderFieldValue(message, (CFStringRef)headerField)) autorelease];
+- (NSString *)headerField:(NSString *)headerField {
+  return (__bridge_transfer NSString *) CFHTTPMessageCopyHeaderFieldValue(message, (__bridge CFStringRef) headerField);
 }
 
-- (void)setHeaderField:(NSString *)headerField value:(NSString *)headerFieldValue
-{
-	CFHTTPMessageSetHeaderFieldValue(message, (CFStringRef)headerField, (CFStringRef)headerFieldValue);
+- (void)setHeaderField:(NSString *)headerField value:(NSString *)headerFieldValue {
+  CFHTTPMessageSetHeaderFieldValue(message,
+                                   (__bridge CFStringRef) headerField,
+                                   (__bridge CFStringRef) headerFieldValue);
 }
 
-- (NSData *)messageData
-{
-	return [NSMakeCollectable(CFHTTPMessageCopySerializedMessage(message)) autorelease];
+- (NSData *)messageData {
+  return (__bridge_transfer NSData *) CFHTTPMessageCopySerializedMessage(message);
 }
 
-- (NSData *)body
-{
-	return [NSMakeCollectable(CFHTTPMessageCopyBody(message)) autorelease];
+- (NSData *)body {
+  return (__bridge_transfer NSData *) CFHTTPMessageCopyBody(message);
 }
 
-- (void)setBody:(NSData *)body
-{
-	CFHTTPMessageSetBody(message, (CFDataRef)body);
+- (void)setBody:(NSData *)body {
+  CFHTTPMessageSetBody(message, (__bridge CFDataRef) body);
 }
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPServer.h
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPServer.h
@@ -1,201 +1,216 @@
 #import <Foundation/Foundation.h>
 
 @class LPGCDAsyncSocket;
-
+@class LPWebSocket;
 
 #if TARGET_OS_IPHONE
-  #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 40000 // iPhone 4.0
-    #define IMPLEMENTED_PROTOCOLS <NSNetServiceDelegate>
-  #else
-    #define IMPLEMENTED_PROTOCOLS 
-  #endif
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 40000 // iPhone 4.0
+#define LP_HTTP_IMPLEMENTED_PROTOCOLS <NSNetServiceDelegate>
 #else
-  #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 // Mac OS X 10.6
-    #define IMPLEMENTED_PROTOCOLS <NSNetServiceDelegate>
-  #else
-    #define IMPLEMENTED_PROTOCOLS 
-  #endif
+#define LP_HTTP_IMPLEMENTED_PROTOCOLS
+#endif
+#else
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 // Mac OS X 10.6
+#define LP_HTTP_IMPLEMENTED_PROTOCOLS <NSNetServiceDelegate>
+#else
+#define LP_HTTP_IMPLEMENTED_PROTOCOLS
+#endif
 #endif
 
 
-@interface LPHTTPServer : NSObject IMPLEMENTED_PROTOCOLS
-{
-	// Underlying asynchronous TCP/IP socket
-	dispatch_queue_t serverQueue;
-	dispatch_queue_t connectionQueue;
-	LPGCDAsyncSocket *asyncSocket;
-	
-	// LPHTTP server configuration
-	NSString *documentRoot;
-	Class connectionClass;
-	NSString *interface;
-	UInt16 port;
-	
-	// NSNetService and related variables
-	NSNetService *netService;
-	NSString *domain;
-	NSString *type;
-	NSString *name;
-	NSString *publishedName;
-	NSDictionary *txtRecordDictionary;
-	
-	// Connection management
-	NSMutableArray *connections;
-	NSMutableArray *webSockets;
-	NSLock *connectionsLock;
-	NSLock *webSocketsLock;
-	
-	BOOL isRunning;
+@interface LPHTTPServer : NSObject LP_HTTP_IMPLEMENTED_PROTOCOLS {
+  // Underlying asynchronous TCP/IP socket
+  LPGCDAsyncSocket *asyncSocket;
+
+  // Dispatch queues
+  dispatch_queue_t serverQueue;
+  dispatch_queue_t connectionQueue;
+  void *IsOnServerQueueKey;
+  void *IsOnConnectionQueueKey;
+
+  // HTTP server configuration
+  NSString *documentRoot;
+  Class connectionClass;
+  NSString *interface;
+  UInt16 port;
+
+  // NSNetService and related variables
+  NSNetService *netService;
+  NSString *domain;
+  NSString *type;
+  NSString *name;
+  NSString *publishedName;
+  NSDictionary *txtRecordDictionary;
+
+  // Connection management
+  NSMutableArray *connections;
+  NSMutableArray *webSockets;
+  NSLock *connectionsLock;
+  NSLock *webSocketsLock;
+
+  BOOL isRunning;
 }
 
 /**
  * Specifies the document root to serve files from.
  * For example, if you set this to "/Users/<your_username>/Sites",
  * then it will serve files out of the local Sites directory (including subdirectories).
- * 
+ *
  * The default value is nil.
  * The default server configuration will not serve any files until this is set.
- * 
+ *
  * If you change the documentRoot while the server is running,
  * the change will affect future incoming http connections.
-**/
+ **/
 - (NSString *)documentRoot;
+
 - (void)setDocumentRoot:(NSString *)value;
 
 /**
- * The connection class is the class used to handle incoming LPHTTP connections.
- * 
+ * The connection class is the class used to handle incoming HTTP connections.
+ *
  * The default value is [LPHTTPConnection class].
  * You can override LPHTTPConnection, and then set this to [MyHTTPConnection class].
- * 
+ *
  * If you change the connectionClass while the server is running,
  * the change will affect future incoming http connections.
-**/
+ **/
 - (Class)connectionClass;
+
 - (void)setConnectionClass:(Class)value;
 
 /**
  * Set what interface you'd like the server to listen on.
  * By default this is nil, which causes the server to listen on all available interfaces like en1, wifi etc.
- * 
+ *
  * The interface may be specified by name (e.g. "en1" or "lo0") or by IP address (e.g. "192.168.4.34").
  * You may also use the special strings "localhost" or "loopback" to specify that
  * the socket only accept connections from the local machine.
-**/
+ **/
 - (NSString *)interface;
+
 - (void)setInterface:(NSString *)value;
 
 /**
- * The port number to run the LPHTTP server on.
- * 
+ * The port number to run the HTTP server on.
+ *
  * The default port number is zero, meaning the server will automatically use any available port.
  * This is the recommended port value, as it avoids possible port conflicts with other applications.
  * Technologies such as Bonjour can be used to allow other applications to automatically discover the port number.
- * 
+ *
  * Note: As is common on most OS's, you need root privledges to bind to port numbers below 1024.
- * 
+ *
  * You can change the port property while the server is running, but it won't affect the running server.
  * To actually change the port the server is listening for connections on you'll need to restart the server.
- * 
+ *
  * The listeningPort method will always return the port number the running server is listening for connections on.
  * If the server is not running this method returns 0.
-**/
+ **/
 - (UInt16)port;
+
 - (UInt16)listeningPort;
+
 - (void)setPort:(UInt16)value;
 
 /**
  * Bonjour domain for publishing the service.
  * The default value is "local.".
- * 
+ *
  * Note: Bonjour publishing requires you set a type.
- * 
+ *
  * If you change the domain property after the bonjour service has already been published (server already started),
  * you'll need to invoke the republishBonjour method to update the broadcasted bonjour service.
-**/
+ **/
 - (NSString *)domain;
+
 - (void)setDomain:(NSString *)value;
 
 /**
  * Bonjour name for publishing the service.
  * The default value is "".
- * 
+ *
  * If using an empty string ("") for the service name when registering,
  * the system will automatically use the "Computer Name".
  * Using an empty string will also handle name conflicts
  * by automatically appending a digit to the end of the name.
- * 
+ *
  * Note: Bonjour publishing requires you set a type.
- * 
+ *
  * If you change the name after the bonjour service has already been published (server already started),
  * you'll need to invoke the republishBonjour method to update the broadcasted bonjour service.
- * 
+ *
  * The publishedName method will always return the actual name that was published via the bonjour service.
  * If the service is not running this method returns nil.
-**/
+ **/
 - (NSString *)name;
+
 - (NSString *)publishedName;
+
 - (void)setName:(NSString *)value;
 
 /**
  * Bonjour type for publishing the service.
  * The default value is nil.
  * The service will not be published via bonjour unless the type is set.
- * 
- * If you wish to publish the service as a traditional LPHTTP server, you should set the type to be "_http._tcp.".
- * 
+ *
+ * If you wish to publish the service as a traditional HTTP server, you should set the type to be "_http._tcp.".
+ *
  * If you change the type after the bonjour service has already been published (server already started),
  * you'll need to invoke the republishBonjour method to update the broadcasted bonjour service.
-**/
+ **/
 - (NSString *)type;
+
 - (void)setType:(NSString *)value;
 
 /**
  * Republishes the service via bonjour if the server is running.
  * If the service was not previously published, this method will publish it (if the server is running).
-**/
+ **/
 - (void)republishBonjour;
 
 /**
- * 
-**/
+ *
+ **/
 - (NSDictionary *)TXTRecordDictionary;
+
 - (void)setTXTRecordDictionary:(NSDictionary *)dict;
 
 /**
  * Attempts to starts the server on the configured port, interface, etc.
- * 
+ *
  * If an error occurs, this method returns NO and sets the errPtr (if given).
  * Otherwise returns YES on success.
- * 
+ *
  * Some examples of errors that might occur:
  * - You specified the server listen on a port which is already in use by another application.
  * - You specified the server listen on a port number below 1024, which requires root priviledges.
- * 
+ *
  * Code Example:
- * 
+ *
  * NSError *err = nil;
  * if (![httpServer start:&err])
  * {
  *     NSLog(@"Error starting http server: %@", err);
  * }
-**/
+ **/
 - (BOOL)start:(NSError **)errPtr;
 
 /**
  * Stops the server, preventing it from accepting any new connections.
  * You may specify whether or not you want to close the existing client connections.
- * 
+ *
  * The default stop method (with no arguments) will close any existing connections. (It invokes [self stop:NO])
-**/
+ **/
 - (void)stop;
+
 - (void)stop:(BOOL)keepExistingConnections;
 
 - (BOOL)isRunning;
 
-
+- (void)addWebSocket:(LPWebSocket *)ws;
 
 - (NSUInteger)numberOfHTTPConnections;
+
 - (NSUInteger)numberOfWebSocketConnections;
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPHTTPServer.m
+++ b/calabash/Classes/CocoaHttpServer/LPHTTPServer.m
@@ -1,17 +1,24 @@
 #import "LPHTTPServer.h"
 #import "LPGCDAsyncSocket.h"
 #import "LPHTTPConnection.h"
+#import "LPWebSocket.h"
+#import "LPHTTPLogging.h"
 
+#if !__has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
 
-// Log levels: off, error, warn, info, verbose
-// Other flags: trace
+static LPLogLevel __unused lpHTTPLogLevel = LPLogLevelWarning;
+
 
 @interface LPHTTPServer (PrivateAPI)
 
 - (void)unpublishBonjour;
+
 - (void)publishBonjour;
 
 + (void)startBonjourThreadIfNeeded;
+
 + (void)performBonjourBlock:(dispatch_block_t)block;
 
 @end
@@ -24,102 +31,93 @@
 
 /**
  * Standard Constructor.
- * Instantiates an LPHTTP server, but does not start it.
-**/
-- (id)init
-{
-	if ((self = [super init]))
-	{
-		//LPHTTPLogTrace();
-		
-		// Initialize underlying dispatch queue and LPGCD based tcp socket
-		serverQueue = dispatch_queue_create("LPHTTPServer", NULL);
-		asyncSocket = [[LPGCDAsyncSocket alloc] initWithDelegate:self delegateQueue:serverQueue];
-		
-		// Use default connection class of LPHTTPConnection
-//		connectionQueue = dispatch_queue_create("LPHTTPConnection", NULL);
-        connectionQueue=dispatch_get_main_queue();
-		connectionClass = [LPHTTPConnection self];
-		
-		// By default bind on all available interfaces, en1, wifi etc
-		interface = nil;
-		
-		// Use a default port of 0
-		// This will allow the kernel to automatically pick an open port for us
-		port = 0;
-		
-		// Configure default values for bonjour service
-		
-		// Bonjour domain. Use the local domain by default
-		domain = @"local.";
-		
-		// If using an empty string ("") for the service name when registering,
-		// the system will automatically use the "Computer Name".
-		// Passing in an empty string will also handle name conflicts
-		// by automatically appending a digit to the end of the name.
-		name = @"";
-		
-		// Initialize arrays to hold all the LPHTTP and webSocket connections
-		connections = [[NSMutableArray alloc] init];
-		webSockets  = [[NSMutableArray alloc] init];
-		
-		connectionsLock = [[NSLock alloc] init];
-		webSocketsLock  = [[NSLock alloc] init];
-		
-		// Register for notifications of closed connections
-		[[NSNotificationCenter defaultCenter] addObserver:self
-		                                         selector:@selector(connectionDidDie:)
-		                                             name:LPHTTPConnectionDidDieNotification
-		                                           object:nil];
-		
-		// Register for notifications of closed websocket connections
-//		[[NSNotificationCenter defaultCenter] addObserver:self
-//		                                         selector:@selector(webSocketDidDie:)
-//		                                             name:WebSocketDidDieNotification
-//		                                           object:nil];
-		
-		isRunning = NO;
-	}
-	return self;
+ * Instantiates an HTTP server, but does not start it.
+ **/
+- (id)init {
+  if ((self = [super init])) {
+    LPHTTPLogTrace();
+
+    // Setup underlying dispatch queues
+    serverQueue = dispatch_queue_create("LPHTTPServer", NULL);
+    connectionQueue = dispatch_queue_create("LPHTTPConnection", NULL);
+
+    IsOnServerQueueKey = &IsOnServerQueueKey;
+    IsOnConnectionQueueKey = &IsOnConnectionQueueKey;
+
+    void *nonNullUnusedPointer = (__bridge void *) self; // Whatever, just not null
+
+    dispatch_queue_set_specific(serverQueue, IsOnServerQueueKey, nonNullUnusedPointer, NULL);
+    dispatch_queue_set_specific(connectionQueue, IsOnConnectionQueueKey, nonNullUnusedPointer, NULL);
+
+    // Initialize underlying GCD based tcp socket
+    asyncSocket = [[LPGCDAsyncSocket alloc] initWithDelegate:self delegateQueue:serverQueue];
+
+    // Use default connection class of LPHTTPConnection
+    connectionClass = [LPHTTPConnection self];
+
+    // By default bind on all available interfaces, en1, wifi etc
+    interface = nil;
+
+    // Use a default port of 0
+    // This will allow the kernel to automatically pick an open port for us
+    port = 0;
+
+    // Configure default values for bonjour service
+
+    // Bonjour domain. Use the local domain by default
+    domain = @"local.";
+
+    // If using an empty string ("") for the service name when registering,
+    // the system will automatically use the "Computer Name".
+    // Passing in an empty string will also handle name conflicts
+    // by automatically appending a digit to the end of the name.
+    name = @"";
+
+    // Initialize arrays to hold all the HTTP and webSocket connections
+    connections = [[NSMutableArray alloc] init];
+    webSockets = [[NSMutableArray alloc] init];
+
+    connectionsLock = [[NSLock alloc] init];
+    webSocketsLock = [[NSLock alloc] init];
+
+    // Register for notifications of closed connections
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(connectionDidDie:)
+                                                 name:LPHTTPConnectionDidDieNotification
+                                               object:nil];
+
+    // Register for notifications of closed websocket connections
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(webSocketDidDie:)
+                                                 name:LPWebSocketDidDieNotification
+                                               object:nil];
+
+    isRunning = NO;
+  }
+  return self;
 }
 
 /**
  * Standard Deconstructor.
  * Stops the server, and clients, and releases any resources connected with this instance.
-**/
-- (void)dealloc
-{
-	//LPHTTPLogTrace();
-	
-	// Remove notification observer
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
-	
-	// Stop the server if it's running
-	[self stop];
-	
-	// Release all instance variables
-	
-	dispatch_release(serverQueue);
-	//dispatch_release(connectionQueue);
-	
-	[asyncSocket setDelegate:nil delegateQueue:NULL];
-	[asyncSocket release];
-	
-	[documentRoot release];
-	[interface release];
-	
-	[netService release];
-	[domain release];
-	[name release];
-	[type release];
-	[txtRecordDictionary release];
-	
-	[connections release];
-	[webSockets release];
-	[connectionsLock release];
-	[webSocketsLock release];
-	
-	[super dealloc];
+ **/
+- (void)dealloc {
+  LPHTTPLogTrace();
+
+  // Remove notification observer
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+  // Stop the server if it's running
+  [self stop];
+
+  // Release all instance variables
+
+#if !OS_OBJECT_USE_OBJC
+  dispatch_release(serverQueue);
+  dispatch_release(connectionQueue);
+#endif
+
+  [asyncSocket setDelegate:nil delegateQueue:NULL];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -130,40 +128,35 @@
  * The document root is filesystem root for the webserver.
  * Thus requests for /index.html will be referencing the index.html file within the document root directory.
  * All file requests are relative to this document root.
-**/
-- (NSString *)documentRoot
-{
-	__block NSString *result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = [documentRoot retain];
-	});
-	
-	return [result autorelease];
+ **/
+- (NSString *)documentRoot {
+  __block NSString *result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->documentRoot;
+  });
+
+  return result;
 }
 
-- (void)setDocumentRoot:(NSString *)value
-{
-	//LPHTTPLogTrace();
-	
-	// Document root used to be of type NSURL.
-	// Add type checking for early warning to developers upgrading from older versions.
-	
-	if (value && ![value isKindOfClass:[NSString class]])
-	{
-		//LPHTTPLogWarn(@"%@: %@ - Expecting NSString parameter, received %@ parameter",
-		//			THIS_FILE, THIS_METHOD, NSStringFromClass([value class]));
-		return;
-	}
-	
-	NSString *valueCopy = [value copy];
-	
-	dispatch_async(serverQueue, ^{
-		[documentRoot release];
-		documentRoot = [valueCopy retain];
-	});
-	
-	[valueCopy release];
+- (void)setDocumentRoot:(NSString *)value {
+  LPHTTPLogTrace();
+
+  // Document root used to be of type NSURL.
+  // Add type checking for early warning to developers upgrading from older versions.
+
+  if (value && ![value isKindOfClass:[NSString class]]) {
+    LPHTTPLogWarn(@"%@: %@ - Expecting NSString parameter, received %@ parameter",
+                  LP_THIS_FILE, LP_THIS_METHOD, NSStringFromClass([value class]));
+    return;
+  }
+
+  NSString *valueCopy = [value copy];
+
+  dispatch_async(serverQueue, ^{
+    self->documentRoot = valueCopy;
+  });
+
 }
 
 /**
@@ -171,331 +164,303 @@
  * That is, when a new connection is created, an instance of this class will be intialized.
  * The default connection class is LPHTTPConnection.
  * If you use a different connection class, it is assumed that the class extends LPHTTPConnection
-**/
-- (Class)connectionClass
-{
-	__block Class result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = connectionClass;
-	});
-	
-	return result;
+ **/
+- (Class)connectionClass {
+  __block Class result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->connectionClass;
+  });
+
+  return result;
 }
 
-- (void)setConnectionClass:(Class)value
-{
-	//LPHTTPLogTrace();
-	
-	dispatch_async(serverQueue, ^{
-		connectionClass = value;
-	});
+- (void)setConnectionClass:(Class)value {
+  LPHTTPLogTrace();
+
+  dispatch_async(serverQueue, ^{
+    self->connectionClass = value;
+  });
 }
 
 /**
  * What interface to bind the listening socket to.
-**/
-- (NSString *)interface
-{
-	__block NSString *result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = [interface retain];
-	});
-	
-	return [result autorelease];
+ **/
+- (NSString *)interface {
+  __block NSString *result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->interface;
+  });
+
+  return result;
 }
 
-- (void)setInterface:(NSString *)value
-{
-	NSString *valueCopy = [value copy];
-	
-	dispatch_async(serverQueue, ^{
-		[interface release];
-		interface = [valueCopy retain];
-	});
-	
-	[valueCopy release];
+- (void)setInterface:(NSString *)value {
+  NSString *valueCopy = [value copy];
+
+  dispatch_async(serverQueue, ^{
+    self->interface = valueCopy;
+  });
+
 }
 
 /**
  * The port to listen for connections on.
  * By default this port is initially set to zero, which allows the kernel to pick an available port for us.
- * After the LPHTTP server has started, the port being used may be obtained by this method.
-**/
-- (UInt16)port
-{
-	__block UInt16 result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = port;
-	});
-	
-    return result;
+ * After the HTTP server has started, the port being used may be obtained by this method.
+ **/
+- (UInt16)port {
+  __block UInt16 result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->port;
+  });
+
+  return result;
 }
 
-- (UInt16)listeningPort
-{
-	__block UInt16 result;
-	
-	dispatch_sync(serverQueue, ^{
-		if (isRunning)
-			result = [asyncSocket localPort];
-		else
-			result = 0;
-	});
-	
-	return result;
+- (UInt16)listeningPort {
+  __block UInt16 result;
+
+  dispatch_sync(serverQueue, ^{
+    if (self->isRunning)
+      result = [self->asyncSocket localPort];
+    else
+      result = 0;
+  });
+
+  return result;
 }
 
-- (void)setPort:(UInt16)value
-{
-	//LPHTTPLogTrace();
-	
-	dispatch_async(serverQueue, ^{
-		port = value;
-	});
+- (void)setPort:(UInt16)value {
+  LPHTTPLogTrace();
+
+  dispatch_async(serverQueue, ^{
+    self->port = value;
+  });
 }
 
 /**
  * Domain on which to broadcast this service via Bonjour.
  * The default domain is @"local".
-**/
-- (NSString *)domain
-{
-	__block NSString *result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = [domain retain];
-	});
-	
-    return [domain autorelease];
+ **/
+- (NSString *)domain {
+  __block NSString *result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->domain;
+  });
+
+  return result;
 }
 
-- (void)setDomain:(NSString *)value
-{
-	//LPHTTPLogTrace();
-	
-	NSString *valueCopy = [value copy];
-	
-	dispatch_async(serverQueue, ^{
-		[domain release];
-		domain = [valueCopy retain];
-	});
-	
-	[valueCopy release];
+- (void)setDomain:(NSString *)value {
+  LPHTTPLogTrace();
+
+  NSString *valueCopy = [value copy];
+
+  dispatch_async(serverQueue, ^{
+    self->domain = valueCopy;
+  });
+
 }
 
 /**
  * The name to use for this service via Bonjour.
  * The default name is an empty string,
  * which should result in the published name being the host name of the computer.
-**/
-- (NSString *)name
-{
-	__block NSString *result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = [name retain];
-	});
-	
-	return [name autorelease];
+ **/
+- (NSString *)name {
+  __block NSString *result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->name;
+  });
+
+  return result;
 }
 
-- (NSString *)publishedName
-{
-	__block NSString *result;
-	
-	dispatch_sync(serverQueue, ^{
-		
-		if (netService == nil)
-		{
-			result = nil;
-		}
-		else
-		{
-			
-			dispatch_block_t bonjourBlock = ^{
-				result = [[netService name] copy];
-			};
-			
-			[[self class] performBonjourBlock:bonjourBlock];
-		}
-	});
-	
-	return [result autorelease];
+- (NSString *)publishedName {
+  __block NSString *result;
+
+  dispatch_sync(serverQueue, ^{
+
+    if (self->netService == nil) {
+      result = nil;
+    }
+    else {
+
+      dispatch_block_t bonjourBlock = ^{
+        result = [[self->netService name] copy];
+      };
+
+      [[self class] performBonjourBlock:bonjourBlock];
+    }
+  });
+
+  return result;
 }
 
-- (void)setName:(NSString *)value
-{
-	NSString *valueCopy = [value copy];
-	
-	dispatch_async(serverQueue, ^{
-		[name release];
-		name = [valueCopy retain];
-	});
-	
-	[valueCopy release];
+- (void)setName:(NSString *)value {
+  NSString *valueCopy = [value copy];
+
+  dispatch_async(serverQueue, ^{
+    self->name = valueCopy;
+  });
+
 }
 
 /**
  * The type of service to publish via Bonjour.
  * No type is set by default, and one must be set in order for the service to be published.
-**/
-- (NSString *)type
-{
-	__block NSString *result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = [type retain];
-	});
-	
-	return [result autorelease];
+ **/
+- (NSString *)type {
+  __block NSString *result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->type;
+  });
+
+  return result;
 }
 
-- (void)setType:(NSString *)value
-{
-	NSString *valueCopy = [value copy];
-	
-	dispatch_async(serverQueue, ^{
-		[type release];
-		type = [valueCopy retain];
-	});
-	
-	[valueCopy release];
+- (void)setType:(NSString *)value {
+  NSString *valueCopy = [value copy];
+
+  dispatch_async(serverQueue, ^{
+    self->type = valueCopy;
+  });
+
 }
 
 /**
  * The extra data to use for this service via Bonjour.
-**/
-- (NSDictionary *)TXTRecordDictionary
-{
-	__block NSDictionary *result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = [txtRecordDictionary retain];
-	});
-	
-	return [result autorelease];
+ **/
+- (NSDictionary *)TXTRecordDictionary {
+  __block NSDictionary *result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->txtRecordDictionary;
+  });
+
+  return result;
 }
-- (void)setTXTRecordDictionary:(NSDictionary *)value
-{
-	//LPHTTPLogTrace();
-	
-	NSDictionary *valueCopy = [value copy];
-	
-	dispatch_async(serverQueue, ^{
-	
-		[txtRecordDictionary release];
-		txtRecordDictionary = [valueCopy retain];
-		
-		// Update the txtRecord of the netService if it has already been published
-		if (netService)
-		{
-			NSNetService *theNetService = netService;
-			NSData *txtRecordData = nil;
-			if (txtRecordDictionary)
-				txtRecordData = [NSNetService dataFromTXTRecordDictionary:txtRecordDictionary];
-			
-			dispatch_block_t bonjourBlock = ^{
-				[theNetService setTXTRecordData:txtRecordData];
-			};
-			
-			[[self class] performBonjourBlock:bonjourBlock];
-		}
-	});
-	
-	[valueCopy release];
+
+- (void)setTXTRecordDictionary:(NSDictionary *)value {
+  LPHTTPLogTrace();
+
+  NSDictionary *valueCopy = [value copy];
+
+  dispatch_async(serverQueue, ^{
+
+    self->txtRecordDictionary = valueCopy;
+
+    // Update the txtRecord of the netService if it has already been published
+    if (self->netService) {
+      NSNetService *theNetService = self->netService;
+      NSData *txtRecordData = nil;
+      if (self->txtRecordDictionary)
+        txtRecordData = [NSNetService dataFromTXTRecordDictionary:self->txtRecordDictionary];
+
+      dispatch_block_t bonjourBlock = ^{
+        [theNetService setTXTRecordData:txtRecordData];
+      };
+
+      [[self class] performBonjourBlock:bonjourBlock];
+    }
+  });
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Server Control
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)start:(NSError **)errPtr
-{
-	//LPHTTPLogTrace();
-	
-	__block BOOL success = YES;
-	__block NSError *err = nil;
-	
-	dispatch_sync(serverQueue, ^{
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		
-		success = [asyncSocket acceptOnInterface:interface port:port error:&err];
-		if (success)
-		{
-			NSLog(@"Started LPHTTP server on port %hu", [asyncSocket localPort]);
-			
-			isRunning = YES;
-			[self publishBonjour];
-		}
-		else
-		{
-			//LPHTTPLogError(@"%@: Failed to start LPHTTP Server: %@", THIS_FILE, err);
-			[err retain];
-		}
-		
-		[pool drain];
-	});
-	
-	if (errPtr)
-		*errPtr = [err autorelease];
-	else
-		[err release];
-	
-	return success;
+- (BOOL)start:(NSError *__autoreleasing*)errPtr {
+  LPHTTPLogTrace();
+
+  __block BOOL success = YES;
+  __block NSError *err = nil;
+
+  dispatch_sync(serverQueue, ^{
+    @autoreleasepool {
+
+      success = [self->asyncSocket acceptOnInterface:self->interface port:self->port error:&err];
+      if (success) {
+        LPHTTPLogInfo(@"%@: Started HTTP server on port %hu", LP_THIS_FILE, [self->asyncSocket localPort]);
+
+        self->isRunning = YES;
+        [self publishBonjour];
+      }
+      else {
+        LPHTTPLogError(@"%@: Failed to start HTTP Server: %@", LP_THIS_FILE, err);
+      }
+    }
+  });
+
+  if (errPtr)
+    *errPtr = err;
+
+  return success;
 }
 
-- (void)stop
-{
-	[self stop:NO];
+- (void)stop {
+  [self stop:NO];
 }
 
-- (void)stop:(BOOL)keepExistingConnections
-{
-	//LPHTTPLogTrace();
-	
-	dispatch_sync(serverQueue, ^{
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-		
-		// First stop publishing the service via bonjour
-		[self unpublishBonjour];
-		
-		// Stop listening / accepting incoming connections
-		[asyncSocket disconnect];
-		isRunning = NO;
-		
-		if (!keepExistingConnections)
-		{
-			// Stop all LPHTTP connections the server owns
-			[connectionsLock lock];
-			for (LPHTTPConnection *connection in connections)
-			{
-				[connection stop];
-			}
-			[connections removeAllObjects];
-			[connectionsLock unlock];
-			
-			// Stop all WebSocket connections the server owns
-			
-		}
-		
-		[pool drain];
-	});
+- (void)stop:(BOOL)keepExistingConnections {
+  LPHTTPLogTrace();
+
+  dispatch_sync(serverQueue, ^{
+    @autoreleasepool {
+
+      // First stop publishing the service via bonjour
+      [self unpublishBonjour];
+
+      // Stop listening / accepting incoming connections
+      [self->asyncSocket disconnect];
+      self->isRunning = NO;
+
+      if (!keepExistingConnections) {
+        // Stop all HTTP connections the server owns
+        [self->connectionsLock lock];
+        for (LPHTTPConnection *connection in self->connections) {
+          [connection stop];
+        }
+        [self->connections removeAllObjects];
+        [self->connectionsLock unlock];
+
+        // Stop all LPWebSocket connections the server owns
+        [self->webSocketsLock lock];
+        for (LPWebSocket *webSocket in self->webSockets) {
+          [webSocket stop];
+        }
+        [self->webSockets removeAllObjects];
+        [self->webSocketsLock unlock];
+      }
+    }
+  });
 }
 
-- (BOOL)isRunning
-{
-	__block BOOL result;
-	
-	dispatch_sync(serverQueue, ^{
-		result = isRunning;
-	});
-	
-	return result;
+- (BOOL)isRunning {
+  __block BOOL result;
+
+  dispatch_sync(serverQueue, ^{
+    result = self->isRunning;
+  });
+
+  return result;
 }
 
+- (void)addWebSocket:(LPWebSocket *)ws {
+  [webSocketsLock lock];
+
+  LPHTTPLogTrace();
+  [webSockets addObject:ws];
+
+  [webSocketsLock unlock];
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Server Status
@@ -503,165 +468,151 @@
 
 /**
  * Returns the number of http client connections that are currently connected to the server.
-**/
-- (NSUInteger)numberOfHTTPConnections
-{
-	NSUInteger result = 0;
-	
-	[connectionsLock lock];
-	result = [connections count];
-	[connectionsLock unlock];
-	
-	return result;
+ **/
+- (NSUInteger)numberOfHTTPConnections {
+  NSUInteger result = 0;
+
+  [connectionsLock lock];
+  result = [connections count];
+  [connectionsLock unlock];
+
+  return result;
 }
 
 /**
  * Returns the number of websocket client connections that are currently connected to the server.
-**/
-- (NSUInteger)numberOfWebSocketConnections
-{
-	NSUInteger result = 0;
-	
-	[webSocketsLock lock];
-	result = [webSockets count];
-	[webSocketsLock unlock];
-	
-	return result;
+ **/
+- (NSUInteger)numberOfWebSocketConnections {
+  NSUInteger result = 0;
+
+  [webSocketsLock lock];
+  result = [webSockets count];
+  [webSocketsLock unlock];
+
+  return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Incoming Connections
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (LPHTTPConfig *)config
-{
-	// Override me if you want to provide a custom config to the new connection.
-	// 
-	// Generally this involves overriding the LPHTTPConfig class to include any custom settings,
-	// and then having this method return an instance of 'MyHTTPConfig'.
-	
-	// Note: Think you can make the server faster by putting each connection on its own queue?
-	// Then benchmark it before and after and discover for yourself the shocking truth!
-	// 
-	// Try the apache benchmark tool (already installed on your Mac):
-	// $  ab -n 1000 -c 1 http://localhost:<port>/some_path.html
-	
-	return [[[LPHTTPConfig alloc] initWithServer:self documentRoot:documentRoot queue:connectionQueue] autorelease];
+- (LPHTTPConfig *)config {
+  // Override me if you want to provide a custom config to the new connection.
+  //
+  // Generally this involves overriding the LPHTTPConfig class to include any custom settings,
+  // and then having this method return an instance of 'MyHTTPConfig'.
+
+  // Note: Think you can make the server faster by putting each connection on its own queue?
+  // Then benchmark it before and after and discover for yourself the shocking truth!
+  //
+  // Try the apache benchmark tool (already installed on your Mac):
+  // $  ab -n 1000 -c 1 http://localhost:<port>/some_path.html
+
+  return [[LPHTTPConfig alloc] initWithServer:self documentRoot:documentRoot queue:connectionQueue];
 }
 
-- (void)socket:(LPGCDAsyncSocket *)sock didAcceptNewSocket:(LPGCDAsyncSocket *)newSocket
-{
-	LPHTTPConnection *newConnection = (LPHTTPConnection *)[[connectionClass alloc] initWithAsyncSocket:newSocket
-	                                                                                 configuration:[self config]];
-	[connectionsLock lock];
-	[connections addObject:newConnection];
-	[connectionsLock unlock];
-	
-	[newConnection start];
-	[newConnection release];
+- (void)socket:(LPGCDAsyncSocket *)sock didAcceptNewSocket:(LPGCDAsyncSocket *)newSocket {
+  LPHTTPConnection *newConnection = (LPHTTPConnection *) [[connectionClass alloc] initWithAsyncSocket:newSocket
+                                                                                        configuration:[self config]];
+  [connectionsLock lock];
+  [connections addObject:newConnection];
+  [connectionsLock unlock];
+
+  [newConnection start];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Bonjour
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (void)publishBonjour
-{
-	//LPHTTPLogTrace();
-	
-	NSAssert(dispatch_get_current_queue() == serverQueue, @"Invalid queue");
-	
-	if (type)
-	{
-		netService = [[NSNetService alloc] initWithDomain:domain type:type name:name port:[asyncSocket localPort]];
-		[netService setDelegate:self];
-		
-		NSNetService *theNetService = netService;
-		NSData *txtRecordData = nil;
-		if (txtRecordDictionary)
-			txtRecordData = [NSNetService dataFromTXTRecordDictionary:txtRecordDictionary];
-		
-		dispatch_block_t bonjourBlock = ^{
-			
-			[theNetService removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-			[theNetService scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-			[theNetService publish];
-			
-			// Do not set the txtRecordDictionary prior to publishing!!!
-			// This will cause the OS to crash!!!
-			if (txtRecordData)
-			{
-				[theNetService setTXTRecordData:txtRecordData];
-			}
-		};
-		
-		[[self class] startBonjourThreadIfNeeded];
-		[[self class] performBonjourBlock:bonjourBlock];
-	}
+- (void)publishBonjour {
+  LPHTTPLogTrace();
+
+  NSAssert(dispatch_get_specific(IsOnServerQueueKey) != NULL, @"Must be on serverQueue");
+
+  if (type) {
+    netService = [[NSNetService alloc] initWithDomain:domain type:type name:name port:[asyncSocket localPort]];
+    [netService setDelegate:self];
+
+    NSNetService *theNetService = netService;
+    NSData *txtRecordData = nil;
+    if (txtRecordDictionary)
+      txtRecordData = [NSNetService dataFromTXTRecordDictionary:txtRecordDictionary];
+
+    dispatch_block_t bonjourBlock = ^{
+
+      [theNetService removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+      [theNetService scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+      [theNetService publish];
+
+      // Do not set the txtRecordDictionary prior to publishing!!!
+      // This will cause the OS to crash!!!
+      if (txtRecordData) {
+        [theNetService setTXTRecordData:txtRecordData];
+      }
+    };
+
+    [[self class] startBonjourThreadIfNeeded];
+    [[self class] performBonjourBlock:bonjourBlock];
+  }
 }
 
-- (void)unpublishBonjour
-{
-	//LPHTTPLogTrace();
-	
-	NSAssert(dispatch_get_current_queue() == serverQueue, @"Invalid queue");
-	
-	if (netService)
-	{
-		NSNetService *theNetService = netService;
-		
-		dispatch_block_t bonjourBlock = ^{
-			
-			[theNetService stop];
-			[theNetService release];
-		};
-		
-		[[self class] performBonjourBlock:bonjourBlock];
-		
-		netService = nil;
-	}
+- (void)unpublishBonjour {
+  LPHTTPLogTrace();
+
+  NSAssert(dispatch_get_specific(IsOnServerQueueKey) != NULL, @"Must be on serverQueue");
+
+  if (netService) {
+    NSNetService *theNetService = netService;
+
+    dispatch_block_t bonjourBlock = ^{
+
+      [theNetService stop];
+    };
+
+    [[self class] performBonjourBlock:bonjourBlock];
+
+    netService = nil;
+  }
 }
 
 /**
  * Republishes the service via bonjour if the server is running.
  * If the service was not previously published, this method will publish it (if the server is running).
-**/
-- (void)republishBonjour
-{
-	//LPHTTPLogTrace();
-	
-	dispatch_async(serverQueue, ^{
-		
-		[self unpublishBonjour];
-		[self publishBonjour];
-	});
+ **/
+- (void)republishBonjour {
+  LPHTTPLogTrace();
+
+  dispatch_async(serverQueue, ^{
+
+    [self unpublishBonjour];
+    [self publishBonjour];
+  });
 }
 
 /**
  * Called when our bonjour service has been successfully published.
  * This method does nothing but output a log message telling us about the published service.
-**/
-- (void)netServiceDidPublish:(NSNetService *)ns
-{
-	// Override me to do something here...
-	// 
-	// Note: This method is invoked on our bonjour thread.
-	
-	NSLog(@"Bonjour Service Published: domain(%@) type(%@) name(%@)", [ns domain], [ns type], [ns name]);
+ **/
+- (void)netServiceDidPublish:(NSNetService *)ns {
+  // Override me to do something here...
+  //
+  // Note: This method is invoked on our bonjour thread.
+
+  LPHTTPLogInfo(@"Bonjour Service Published: domain(%@) type(%@) name(%@)", [ns domain], [ns type], [ns name]);
 }
 
 /**
  * Called if our bonjour service failed to publish itself.
  * This method does nothing but output a log message telling us about the published service.
-**/
-- (void)netService:(NSNetService *)ns didNotPublish:(NSDictionary *)errorDict
-{
-	// Override me to do something here...
-	// 
-	// Note: This method in invoked on our bonjour thread.
-	
-	//LPHTTPLogWarn(@"Failed to Publish Service: domain(%@) type(%@) name(%@) - %@",
-//	                                         [ns domain], [ns type], [ns name], errorDict);
+ **/
+- (void)netService:(NSNetService *)ns didNotPublish:(NSDictionary *)errorDict {
+  // Override me to do something here...
+  //
+  // Note: This method in invoked on our bonjour thread.
+
+  LPHTTPLogWarn(@"Failed to Publish Service: domain(%@) type(%@) name(%@) - %@",
+                [ns domain], [ns type], [ns name], errorDict);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -671,33 +622,31 @@
 /**
  * This method is automatically called when a notification of type LPHTTPConnectionDidDieNotification is posted.
  * It allows us to remove the connection from our array.
-**/
-- (void)connectionDidDie:(NSNotification *)notification
-{
-	// Note: This method is called on the connection queue that posted the notification
-	
-	[connectionsLock lock];
-	
-	//LPHTTPLogTrace();
-	[connections removeObject:[notification object]];
-	
-	[connectionsLock unlock];
+ **/
+- (void)connectionDidDie:(NSNotification *)notification {
+  // Note: This method is called on the connection queue that posted the notification
+
+  [connectionsLock lock];
+
+  LPHTTPLogTrace();
+  [connections removeObject:[notification object]];
+
+  [connectionsLock unlock];
 }
 
 /**
- * This method is automatically called when a notification of type WebSocketDidDieNotification is posted.
+ * This method is automatically called when a notification of type LPWebSocketDidDieNotification is posted.
  * It allows us to remove the websocket from our array.
-**/
-- (void)webSocketDidDie:(NSNotification *)notification
-{
-	// Note: This method is called on the connection queue that posted the notification
-	
-	[webSocketsLock lock];
-	
-	//LPHTTPLogTrace();
-	[webSockets removeObject:[notification object]];
-	
-	[webSocketsLock unlock];
+ **/
+- (void)webSocketDidDie:(NSNotification *)notification {
+  // Note: This method is called on the connection queue that posted the notification
+
+  [webSocketsLock lock];
+
+  LPHTTPLogTrace();
+  [webSockets removeObject:[notification object]];
+
+  [webSocketsLock unlock];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -707,69 +656,69 @@
 /**
  * NSNetService is runloop based, so it requires a thread with a runloop.
  * This gives us two options:
- * 
+ *
  * - Use the main thread
  * - Setup our own dedicated thread
- * 
+ *
  * Since we have various blocks of code that need to synchronously access the netservice objects,
  * using the main thread becomes troublesome and a potential for deadlock.
-**/
+ **/
 
 static NSThread *bonjourThread;
 
-+ (void)startBonjourThreadIfNeeded
-{
-	//LPHTTPLogTrace();
-	
-	static dispatch_once_t predicate;
-	dispatch_once(&predicate, ^{
-		
-		//LPHTTPLogVerbose(@"%@: Starting bonjour thread...", THIS_FILE);
-		
-		bonjourThread = [[NSThread alloc] initWithTarget:self
-		                                        selector:@selector(bonjourThread)
-		                                          object:nil];
-		[bonjourThread start];
-	});
++ (void)startBonjourThreadIfNeeded {
+  LPHTTPLogTrace();
+
+  static dispatch_once_t predicate;
+  dispatch_once(&predicate, ^{
+
+    LPHTTPLogVerbose(@"%@: Starting bonjour thread...", LP_THIS_FILE);
+
+    bonjourThread = [[NSThread alloc] initWithTarget:self
+                                            selector:@selector(bonjourThread)
+                                              object:nil];
+    [bonjourThread start];
+  });
 }
 
-+ (void)bonjourThread
-{
-	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-	
-	//LPHTTPLogVerbose(@"%@: BonjourThread: Started", THIS_FILE);
++ (void)bonjourThread {
+  @autoreleasepool {
 
+    LPHTTPLogVerbose(@"%@: BonjourThread: Started", LP_THIS_FILE);
+
+    // We can't run the run loop unless it has an associated input source or a timer.
+    // So we'll just create a timer that will never fire - unless the server runs for 10,000 years.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-	// We can't run the run loop unless it has an associated input source or a timer.
-	// So we'll just create a timer that will never fire - unless the server runs for 10,000 years.
-	[NSTimer scheduledTimerWithTimeInterval:DBL_MAX target:self selector:@selector(ignore:) userInfo:nil repeats:YES];
+    [NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
+                                     target:self
+                                   selector:@selector(donothingatall:)
+                                   userInfo:nil
+                                    repeats:YES];
 #pragma clang diagnostic pop
 
-	[[NSRunLoop currentRunLoop] run];
-	
-	//LPHTTPLogVerbose(@"%@: BonjourThread: Aborted", THIS_FILE);
-	
-	[pool drain];
+    [[NSRunLoop currentRunLoop] run];
+
+    LPHTTPLogVerbose(@"%@: BonjourThread: Aborted", LP_THIS_FILE);
+
+  }
 }
 
-+ (void)executeBonjourBlock:(dispatch_block_t)block
-{
-	//LPHTTPLogTrace();
-	
-	NSAssert([NSThread currentThread] == bonjourThread, @"Executed on incorrect thread");
-	
-	block();
++ (void)executeBonjourBlock:(dispatch_block_t)block {
+  LPHTTPLogTrace();
+
+  NSAssert([NSThread currentThread] == bonjourThread, @"Executed on incorrect thread");
+
+  block();
 }
 
-+ (void)performBonjourBlock:(dispatch_block_t)block
-{
-	//LPHTTPLogTrace();
-	
-	[self performSelector:@selector(executeBonjourBlock:)
-	             onThread:bonjourThread
-	           withObject:block
-	        waitUntilDone:YES];
++ (void)performBonjourBlock:(dispatch_block_t)block {
+  LPHTTPLogTrace();
+
+  [self performSelector:@selector(executeBonjourBlock:)
+               onThread:bonjourThread
+             withObject:block
+          waitUntilDone:YES];
 }
 
 @end

--- a/calabash/Classes/CocoaHttpServer/LPWebSocket.h
+++ b/calabash/Classes/CocoaHttpServer/LPWebSocket.h
@@ -1,0 +1,107 @@
+#import <Foundation/Foundation.h>
+
+@class LPHTTPMessage;
+@class LPGCDAsyncSocket;
+
+
+#define LPWebSocketDidDieNotification  @"LPWebSocketDidDie"
+
+@interface LPWebSocket : NSObject {
+  dispatch_queue_t websocketQueue;
+
+  LPHTTPMessage *request;
+  LPGCDAsyncSocket *asyncSocket;
+
+  NSData *term;
+
+  BOOL isStarted;
+  BOOL isOpen;
+  BOOL isVersion76;
+
+  id __unsafe_unretained delegate;
+}
+
++ (BOOL)isWebSocketRequest:(LPHTTPMessage *)request;
+
+- (id)initWithRequest:(LPHTTPMessage *)request socket:(LPGCDAsyncSocket *)socket;
+
+/**
+* Delegate option.
+*
+* In most cases it will be easier to subclass LPWebSocket,
+* but some circumstances may lead one to prefer standard delegate callbacks instead.
+**/
+@property(/* atomic */ unsafe_unretained) id delegate;
+
+/**
+* The LPWebSocket class is thread-safe, generally via it's GCD queue.
+* All public API methods are thread-safe,
+* and the subclass API methods are thread-safe as they are all invoked on the same GCD queue.
+**/
+@property(nonatomic, readonly) dispatch_queue_t websocketQueue;
+
+/**
+* Public API
+*
+* These methods are automatically called by the HTTPServer.
+* You may invoke the stop method yourself to close the LPWebSocket manually.
+**/
+- (void)start;
+
+- (void)stop;
+
+/**
+* Public API
+*
+* Sends a message over the LPWebSocket.
+* This method is thread-safe.
+**/
+- (void)sendMessage:(NSString *)msg;
+
+/**
+* Public API
+*
+* Sends a message over the LPWebSocket.
+* This method is thread-safe.
+**/
+- (void)sendData:(NSData *)msg;
+
+/**
+* Subclass API
+*
+* These methods are designed to be overriden by subclasses.
+**/
+- (void)didOpen;
+
+- (void)didReceiveMessage:(NSString *)msg;
+
+- (void)didClose;
+
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+* There are two ways to create your own custom LPWebSocket:
+*
+* - Subclass it and override the methods you're interested in.
+* - Use traditional delegate paradigm along with your own custom class.
+*
+* They both exist to allow for maximum flexibility.
+* In most cases it will be easier to subclass LPWebSocket.
+* However some circumstances may lead one to prefer standard delegate callbacks instead.
+* One such example, you're already subclassing another class, so subclassing LPWebSocket isn't an option.
+**/
+
+@protocol LPWebSocketDelegate
+@optional
+
+- (void)webSocketDidOpen:(LPWebSocket *)ws;
+
+- (void)webSocket:(LPWebSocket *)ws didReceiveMessage:(NSString *)msg;
+
+- (void)webSocketDidClose:(LPWebSocket *)ws;
+
+@end

--- a/calabash/Classes/CocoaHttpServer/LPWebSocket.m
+++ b/calabash/Classes/CocoaHttpServer/LPWebSocket.m
@@ -1,0 +1,729 @@
+#import "LPWebSocket.h"
+#import "LPHTTPMessage.h"
+#import "LPGCDAsyncSocket.h"
+#import "NSNumber+LPCHSExtensions.h"
+#import "NSData+LPCHSExtensions.h"
+#import "LPHTTPLogging.h"
+
+#if !__has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+static LPLogLevel __unused lpHTTPLogLevel = LPLogLevelWarning;
+
+#define TIMEOUT_NONE          -1
+#define TIMEOUT_REQUEST_BODY  10
+
+#define TAG_HTTP_REQUEST_BODY      100
+#define TAG_HTTP_RESPONSE_HEADERS  200
+#define TAG_HTTP_RESPONSE_BODY     201
+
+#define TAG_PREFIX                 300
+#define TAG_MSG_PLUS_SUFFIX        301
+#define TAG_MSG_WITH_LENGTH        302
+#define TAG_MSG_MASKING_KEY        303
+#define TAG_PAYLOAD_PREFIX         304
+#define TAG_PAYLOAD_LENGTH         305
+#define TAG_PAYLOAD_LENGTH16       306
+#define TAG_PAYLOAD_LENGTH64       307
+
+#define WS_OP_CONTINUATION_FRAME   0
+#define WS_OP_TEXT_FRAME           1
+#define WS_OP_BINARY_FRAME         2
+#define WS_OP_CONNECTION_CLOSE     8
+#define WS_OP_PING                 9
+#define WS_OP_PONG                 10
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+static inline BOOL WS_OP_IS_FINAL_FRAGMENT(UInt8 frame) {
+  return (frame & 0x80) ? YES : NO;
+}
+#pragma clang diagnostic pop
+
+static inline BOOL WS_PAYLOAD_IS_MASKED(UInt8 frame) {
+  return (frame & 0x80) ? YES : NO;
+}
+
+static inline NSUInteger WS_PAYLOAD_LENGTH(UInt8 frame) {
+  return frame & 0x7F;
+}
+
+@interface LPWebSocket (PrivateAPI)
+
+- (void)readRequestBody;
+
+- (void)sendResponseBody;
+
+- (void)sendResponseHeaders;
+
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@implementation LPWebSocket {
+  BOOL isRFC6455;
+  BOOL nextFrameMasked;
+  NSUInteger nextOpCode;
+  NSData *maskingKey;
+}
+
++ (BOOL)isWebSocketRequest:(LPHTTPMessage *)request {
+  // Request (Draft 75):
+  //
+  // GET /demo HTTP/1.1
+  // Upgrade: LPWebSocket
+  // Connection: Upgrade
+  // Host: example.com
+  // Origin: http://example.com
+  // LPWebSocket-Protocol: sample
+  //
+  //
+  // Request (Draft 76):
+  //
+  // GET /demo HTTP/1.1
+  // Upgrade: LPWebSocket
+  // Connection: Upgrade
+  // Host: example.com
+  // Origin: http://example.com
+  // Sec-LPWebSocket-Protocol: sample
+  // Sec-LPWebSocket-Key1: 4 @1  46546xW%0l 1 5
+  // Sec-LPWebSocket-Key2: 12998 5 Y3 1  .P00
+  //
+  // ^n:ds[4U
+
+  // Look for Upgrade: and Connection: headers.
+  // If we find them, and they have the proper value,
+  // we can safely assume this is a websocket request.
+
+  NSString *upgradeHeaderValue = [request headerField:@"Upgrade"];
+  NSString *connectionHeaderValue = [request headerField:@"Connection"];
+
+  BOOL isWebSocket = YES;
+
+  if (!upgradeHeaderValue || !connectionHeaderValue) {
+    isWebSocket = NO;
+  }
+  else if (![upgradeHeaderValue caseInsensitiveCompare:@"LPWebSocket"] == NSOrderedSame) {
+    isWebSocket = NO;
+  }
+  else if ([connectionHeaderValue rangeOfString:@"Upgrade" options:NSCaseInsensitiveSearch].location == NSNotFound) {
+    isWebSocket = NO;
+  }
+
+  LPHTTPLogVerbose(@"%@: %@ - %@", LP_THIS_FILE, LP_THIS_METHOD, (isWebSocket ? @"YES" : @"NO"));
+
+  return isWebSocket;
+}
+
++ (BOOL)isVersion76Request:(LPHTTPMessage *)request {
+  NSString *key1 = [request headerField:@"Sec-LPWebSocket-Key1"];
+  NSString *key2 = [request headerField:@"Sec-LPWebSocket-Key2"];
+
+  BOOL isVersion76;
+
+  if (!key1 || !key2) {
+    isVersion76 = NO;
+  }
+  else {
+    isVersion76 = YES;
+  }
+
+  LPHTTPLogVerbose(@"%@: %@ - %@", LP_THIS_FILE, LP_THIS_METHOD, (isVersion76 ? @"YES" : @"NO"));
+
+  return isVersion76;
+}
+
++ (BOOL)isRFC6455Request:(LPHTTPMessage *)request {
+  NSString *key = [request headerField:@"Sec-LPWebSocket-Key"];
+  BOOL isRFC6455 = (key != nil);
+
+  LPHTTPLogVerbose(@"%@: %@ - %@", LP_THIS_FILE, LP_THIS_METHOD, (isRFC6455 ? @"YES" : @"NO"));
+
+  return isRFC6455;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark Setup and Teardown
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@synthesize websocketQueue;
+
+- (id)initWithRequest:(LPHTTPMessage *)aRequest socket:(LPGCDAsyncSocket *)socket {
+  LPHTTPLogTrace();
+
+  if (aRequest == nil) {
+    return nil;
+  }
+
+  if ((self = [super init])) {
+
+    if (lpHTTPLogLevel == LPLogLevelVerbose) {
+      NSData *requestHeaders = [aRequest messageData];
+
+      NSString __unused *temp = [[NSString alloc] initWithData:requestHeaders encoding:NSUTF8StringEncoding];
+      LPHTTPLogVerbose(@"%@[%p] Request Headers:\n%@", LP_THIS_FILE, self, temp);
+    }
+
+    websocketQueue = dispatch_queue_create("LPWebSocket", NULL);
+    request = aRequest;
+
+    asyncSocket = socket;
+    [asyncSocket setDelegate:self delegateQueue:websocketQueue];
+
+    isOpen = NO;
+    isVersion76 = [[self class] isVersion76Request:request];
+    isRFC6455 = [[self class] isRFC6455Request:request];
+
+    term = [[NSData alloc] initWithBytes:"\xFF" length:1];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  LPHTTPLogTrace();
+
+#if !OS_OBJECT_USE_OBJC
+  dispatch_release(websocketQueue);
+#endif
+
+  [asyncSocket setDelegate:nil delegateQueue:NULL];
+  [asyncSocket disconnect];
+}
+
+- (id)delegate {
+  __block id result = nil;
+
+  dispatch_sync(websocketQueue, ^{
+    result = self->delegate;
+  });
+
+  return result;
+}
+
+- (void)setDelegate:(id)newDelegate {
+  dispatch_async(websocketQueue, ^{
+    self->delegate = newDelegate;
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark Start and Stop
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+* Starting point for the LPWebSocket after it has been fully initialized (including subclasses).
+* This method is called by the HTTPConnection it is spawned from.
+**/
+- (void)start {
+  // This method is not exactly designed to be overriden.
+  // Subclasses are encouraged to override the didOpen method instead.
+
+  dispatch_async(websocketQueue, ^{
+    @autoreleasepool {
+
+      if (self->isStarted) return;
+      self->isStarted = YES;
+
+      if (self->isVersion76) {
+        [self readRequestBody];
+      }
+      else {
+        [self sendResponseHeaders];
+        [self didOpen];
+      }
+    }
+  });
+}
+
+/**
+* This method is called by the HTTPServer if it is asked to stop.
+* The server, in turn, invokes stop on each LPWebSocket instance.
+**/
+- (void)stop {
+  // This method is not exactly designed to be overriden.
+  // Subclasses are encouraged to override the didClose method instead.
+
+  dispatch_async(websocketQueue, ^{
+    @autoreleasepool {
+
+      [self->asyncSocket disconnect];
+    }
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark HTTP Response
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+- (void)readRequestBody {
+  LPHTTPLogTrace();
+
+  NSAssert(isVersion76, @"LPWebSocket version 75 doesn't contain a request body");
+
+  [asyncSocket readDataToLength:8 withTimeout:TIMEOUT_NONE tag:TAG_HTTP_REQUEST_BODY];
+}
+
+- (NSString *)originResponseHeaderValue {
+  LPHTTPLogTrace();
+
+  NSString *origin = [request headerField:@"Origin"];
+
+  if (origin == nil) {
+    NSString *port = [NSString stringWithFormat:@"%hu", [asyncSocket localPort]];
+
+    return [NSString stringWithFormat:@"http://localhost:%@", port];
+  }
+  else {
+    return origin;
+  }
+}
+
+- (NSString *)locationResponseHeaderValue {
+  LPHTTPLogTrace();
+
+  NSString *location;
+
+  NSString *scheme = [asyncSocket isSecure] ? @"wss" : @"ws";
+  NSString *host = [request headerField:@"Host"];
+
+  NSString *requestUri = [[request url] relativeString];
+
+  if (host == nil) {
+    NSString *port = [NSString stringWithFormat:@"%hu", [asyncSocket localPort]];
+
+    location = [NSString stringWithFormat:@"%@://localhost:%@%@", scheme, port, requestUri];
+  }
+  else {
+    location = [NSString stringWithFormat:@"%@://%@%@", scheme, host, requestUri];
+  }
+
+  return location;
+}
+
+- (NSString *)secWebSocketKeyResponseHeaderValue {
+  NSString *key = [request headerField:@"Sec-LPWebSocket-Key"];
+  NSString *guid = @"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+  return [[key stringByAppendingString:guid] dataUsingEncoding:NSUTF8StringEncoding].sha1Digest.base64Encoded;
+}
+
+- (void)sendResponseHeaders {
+  LPHTTPLogTrace();
+
+  // Request (Draft 75):
+  //
+  // GET /demo HTTP/1.1
+  // Upgrade: LPWebSocket
+  // Connection: Upgrade
+  // Host: example.com
+  // Origin: http://example.com
+  // LPWebSocket-Protocol: sample
+  //
+  //
+  // Request (Draft 76):
+  //
+  // GET /demo HTTP/1.1
+  // Upgrade: LPWebSocket
+  // Connection: Upgrade
+  // Host: example.com
+  // Origin: http://example.com
+  // Sec-LPWebSocket-Protocol: sample
+  // Sec-LPWebSocket-Key2: 12998 5 Y3 1  .P00
+  // Sec-LPWebSocket-Key1: 4 @1  46546xW%0l 1 5
+  //
+  // ^n:ds[4U
+
+
+  // Response (Draft 75):
+  //
+  // HTTP/1.1 101 Web Socket Protocol Handshake
+  // Upgrade: LPWebSocket
+  // Connection: Upgrade
+  // LPWebSocket-Origin: http://example.com
+  // LPWebSocket-Location: ws://example.com/demo
+  // LPWebSocket-Protocol: sample
+  //
+  //
+  // Response (Draft 76):
+  //
+  // HTTP/1.1 101 LPWebSocket Protocol Handshake
+  // Upgrade: LPWebSocket
+  // Connection: Upgrade
+  // Sec-LPWebSocket-Origin: http://example.com
+  // Sec-LPWebSocket-Location: ws://example.com/demo
+  // Sec-LPWebSocket-Protocol: sample
+  //
+  // 8jKS'y:G*Co,Wxa-
+
+
+  LPHTTPMessage *wsResponse = [[LPHTTPMessage alloc] initResponseWithStatusCode:101
+                                                                    description:@"Web Socket Protocol Handshake"
+                                                                        version:LPHTTPVersion1_1];
+
+  [wsResponse setHeaderField:@"Upgrade" value:@"LPWebSocket"];
+  [wsResponse setHeaderField:@"Connection" value:@"Upgrade"];
+
+  // Note: It appears that LPWebSocket-Origin and LPWebSocket-Location
+  // are required for Google's Chrome implementation to work properly.
+  //
+  // If we don't send either header, Chrome will never report the LPWebSocket as open.
+  // If we only send one of the two, Chrome will immediately close the LPWebSocket.
+  //
+  // In addition to this it appears that Chrome's implementation is very picky of the values of the headers.
+  // They have to match exactly with what Chrome sent us or it will close the LPWebSocket.
+
+  NSString *originValue = [self originResponseHeaderValue];
+  NSString *locationValue = [self locationResponseHeaderValue];
+
+  NSString *originField = isVersion76 ? @"Sec-LPWebSocket-Origin" : @"LPWebSocket-Origin";
+  NSString *locationField = isVersion76 ? @"Sec-LPWebSocket-Location" : @"LPWebSocket-Location";
+
+  [wsResponse setHeaderField:originField value:originValue];
+  [wsResponse setHeaderField:locationField value:locationValue];
+
+  NSString *acceptValue = [self secWebSocketKeyResponseHeaderValue];
+  if (acceptValue) {
+    [wsResponse setHeaderField:@"Sec-LPWebSocket-Accept" value:acceptValue];
+  }
+
+  NSData *responseHeaders = [wsResponse messageData];
+
+
+  if (lpHTTPLogLevel == LPLogLevelVerbose) {
+    NSString __unused *temp = [[NSString alloc] initWithData:responseHeaders encoding:NSUTF8StringEncoding];
+    LPHTTPLogVerbose(@"%@[%p] Response Headers:\n%@", LP_THIS_FILE, self, temp);
+  }
+
+  [asyncSocket writeData:responseHeaders withTimeout:TIMEOUT_NONE tag:TAG_HTTP_RESPONSE_HEADERS];
+}
+
+- (NSData *)processKey:(NSString *)key {
+  LPHTTPLogTrace();
+
+  unichar c;
+  NSUInteger i;
+  NSUInteger length = [key length];
+
+  // Concatenate the digits into a string,
+  // and count the number of spaces.
+
+  NSMutableString *numStr = [NSMutableString stringWithCapacity:10];
+  long long numSpaces = 0;
+
+  for (i = 0; i < length; i++) {
+    c = [key characterAtIndex:i];
+
+    if (c >= '0' && c <= '9') {
+      [numStr appendFormat:@"%C", c];
+    }
+    else if (c == ' ') {
+      numSpaces++;
+    }
+  }
+
+  long long num = strtoll([numStr UTF8String], NULL, 10);
+
+  long long resultHostNum;
+
+  if (numSpaces == 0)
+    resultHostNum = 0;
+  else
+    resultHostNum = num / numSpaces;
+
+  LPHTTPLogVerbose(@"key(%@) -> %qi / %qi = %qi", key, num, numSpaces, resultHostNum);
+
+  // Convert result to 4 byte big-endian (network byte order)
+  // and then convert to raw data.
+
+  UInt32 result = OSSwapHostToBigInt32((uint32_t) resultHostNum);
+
+  return [NSData dataWithBytes:&result length:4];
+}
+
+- (void)sendResponseBody:(NSData *)d3 {
+  LPHTTPLogTrace();
+
+  NSAssert(isVersion76, @"LPWebSocket version 75 doesn't contain a response body");
+  NSAssert([d3 length] == 8, @"Invalid requestBody length");
+
+  NSString *key1 = [request headerField:@"Sec-LPWebSocket-Key1"];
+  NSString *key2 = [request headerField:@"Sec-LPWebSocket-Key2"];
+
+  NSData *d1 = [self processKey:key1];
+  NSData *d2 = [self processKey:key2];
+
+  // Concatenated d1, d2 & d3
+
+  NSMutableData *d0 = [NSMutableData dataWithCapacity:(4 + 4 + 8)];
+  [d0 appendData:d1];
+  [d0 appendData:d2];
+  [d0 appendData:d3];
+
+  // Hash the data using MD5
+
+  NSData *responseBody = [d0 md5Digest];
+
+  [asyncSocket writeData:responseBody withTimeout:TIMEOUT_NONE tag:TAG_HTTP_RESPONSE_BODY];
+
+  if (lpHTTPLogLevel == LPLogLevelVerbose) {
+    NSString __unused *s1 = [[NSString alloc] initWithData:d1 encoding:NSASCIIStringEncoding];
+    NSString __unused *s2 = [[NSString alloc] initWithData:d2 encoding:NSASCIIStringEncoding];
+    NSString __unused *s3 = [[NSString alloc] initWithData:d3 encoding:NSASCIIStringEncoding];
+
+    NSString __unused *s0 = [[NSString alloc] initWithData:d0 encoding:NSASCIIStringEncoding];
+
+    NSString __unused *sH = [[NSString alloc] initWithData:responseBody encoding:NSASCIIStringEncoding];
+
+    LPHTTPLogVerbose(@"key1 result : raw(%@) str(%@)", d1, s1);
+    LPHTTPLogVerbose(@"key2 result : raw(%@) str(%@)", d2, s2);
+    LPHTTPLogVerbose(@"key3 passed : raw(%@) str(%@)", d3, s3);
+    LPHTTPLogVerbose(@"key0 concat : raw(%@) str(%@)", d0, s0);
+    LPHTTPLogVerbose(@"responseBody: raw(%@) str(%@)", responseBody, sH);
+
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark Core Functionality
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+- (void)didOpen {
+  LPHTTPLogTrace();
+
+  // Override me to perform any custom actions once the LPWebSocket has been opened.
+  // This method is invoked on the websocketQueue.
+  //
+  // Don't forget to invoke [super didOpen] in your method.
+
+  // Start reading for messages
+  [asyncSocket readDataToLength:1 withTimeout:TIMEOUT_NONE tag:(isRFC6455 ? TAG_PAYLOAD_PREFIX : TAG_PREFIX)];
+
+  // Notify delegate
+  if ([delegate respondsToSelector:@selector(webSocketDidOpen:)]) {
+    [delegate webSocketDidOpen:self];
+  }
+}
+
+- (void)sendMessage:(NSString *)msg {
+  NSData *msgData = [msg dataUsingEncoding:NSUTF8StringEncoding];
+  [self sendData:msgData];
+}
+
+- (void)sendData:(NSData *)msgData {
+  LPHTTPLogTrace();
+
+  NSMutableData *data = nil;
+
+  if (isRFC6455) {
+    NSUInteger length = msgData.length;
+    if (length <= 125) {
+      data = [NSMutableData dataWithCapacity:(length + 2)];
+      [data appendBytes:"\x81" length:1];
+      UInt8 len = (UInt8) length;
+      [data appendBytes:&len length:1];
+      [data appendData:msgData];
+    }
+    else if (length <= 0xFFFF) {
+      data = [NSMutableData dataWithCapacity:(length + 4)];
+      [data appendBytes:"\x81\x7E" length:2];
+      UInt16 len = (UInt16) length;
+      [data appendBytes:(UInt8[]) {len >> 8, len & 0xFF} length:2];
+      [data appendData:msgData];
+    }
+    else {
+      data = [NSMutableData dataWithCapacity:(length + 10)];
+      [data appendBytes:"\x81\x7F" length:2];
+      [data appendBytes:(UInt8[]) {0, 0, 0, 0, (UInt8) (length >> 24), (UInt8) (length >> 16), (UInt8) (length >> 8), length & 0xFF} length:8];
+      [data appendData:msgData];
+    }
+  }
+  else {
+    data = [NSMutableData dataWithCapacity:([msgData length] + 2)];
+
+    [data appendBytes:"\x00" length:1];
+    [data appendData:msgData];
+    [data appendBytes:"\xFF" length:1];
+  }
+
+  // Remember: LPGCDAsyncSocket is thread-safe
+
+  [asyncSocket writeData:data withTimeout:TIMEOUT_NONE tag:0];
+}
+
+- (void)didReceiveMessage:(NSString *)msg {
+  LPHTTPLogTrace();
+
+  // Override me to process incoming messages.
+  // This method is invoked on the websocketQueue.
+  //
+  // For completeness, you should invoke [super didReceiveMessage:msg] in your method.
+
+  // Notify delegate
+  if ([delegate respondsToSelector:@selector(webSocket:didReceiveMessage:)]) {
+    [delegate webSocket:self didReceiveMessage:msg];
+  }
+}
+
+- (void)didClose {
+  LPHTTPLogTrace();
+
+  // Override me to perform any cleanup when the socket is closed
+  // This method is invoked on the websocketQueue.
+  //
+  // Don't forget to invoke [super didClose] at the end of your method.
+
+  // Notify delegate
+  if ([delegate respondsToSelector:@selector(webSocketDidClose:)]) {
+    [delegate webSocketDidClose:self];
+  }
+
+  // Notify HTTPServer
+  [[NSNotificationCenter defaultCenter] postNotificationName:LPWebSocketDidDieNotification object:self];
+}
+
+#pragma mark LPWebSocket Frame
+
+- (BOOL)isValidWebSocketFrame:(UInt8)frame {
+  NSUInteger rsv = frame & 0x70;
+  NSUInteger opcode = frame & 0x0F;
+  if (rsv || (3 <= opcode && opcode <= 7) || (0xB <= opcode && opcode <= 0xF)) {
+    return NO;
+  }
+  return YES;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark AsyncSocket Delegate
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// 0                   1                   2                   3
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-------+-+-------------+-------------------------------+
+// |F|R|R|R| opcode|M| Payload len |    Extended payload length    |
+// |I|S|S|S|  (4)  |A|     (7)     |             (16/64)           |
+// |N|V|V|V|       |S|             |   (if payload len==126/127)   |
+// | |1|2|3|       |K|             |                               |
+// +-+-+-+-+-------+-+-------------+ - - - - - - - - - - - - - - - +
+// |     Extended payload length continued, if payload len == 127  |
+// + - - - - - - - - - - - - - - - +-------------------------------+
+// |                               |Masking-key, if MASK set to 1  |
+// +-------------------------------+-------------------------------+
+// | Masking-key (continued)       |          Payload Data         |
+// +-------------------------------- - - - - - - - - - - - - - - - +
+// :                     Payload Data continued ...                :
+// + - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
+// |                     Payload Data continued ...                |
+// +---------------------------------------------------------------+
+
+- (void)socket:(LPGCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
+  LPHTTPLogTrace();
+
+  if (tag == TAG_HTTP_REQUEST_BODY) {
+    [self sendResponseHeaders];
+    [self sendResponseBody:data];
+    [self didOpen];
+  }
+  else if (tag == TAG_PREFIX) {
+    UInt8 *pFrame = (UInt8 *) [data bytes];
+    UInt8 frame = *pFrame;
+
+    if (frame <= 0x7F) {
+      [asyncSocket readDataToData:term withTimeout:TIMEOUT_NONE tag:TAG_MSG_PLUS_SUFFIX];
+    }
+    else {
+      // Unsupported frame type
+      [self didClose];
+    }
+  }
+  else if (tag == TAG_PAYLOAD_PREFIX) {
+    UInt8 *pFrame = (UInt8 *) [data bytes];
+    UInt8 frame = *pFrame;
+
+    if ([self isValidWebSocketFrame:frame]) {
+      nextOpCode = (frame & 0x0F);
+      [asyncSocket readDataToLength:1 withTimeout:TIMEOUT_NONE tag:TAG_PAYLOAD_LENGTH];
+    }
+    else {
+      // Unsupported frame type
+      [self didClose];
+    }
+  }
+  else if (tag == TAG_PAYLOAD_LENGTH) {
+    UInt8 frame = *(UInt8 *) [data bytes];
+    BOOL masked = WS_PAYLOAD_IS_MASKED(frame);
+    NSUInteger length = WS_PAYLOAD_LENGTH(frame);
+    nextFrameMasked = masked;
+    maskingKey = nil;
+    if (length <= 125) {
+      if (nextFrameMasked) {
+        [asyncSocket readDataToLength:4 withTimeout:TIMEOUT_NONE tag:TAG_MSG_MASKING_KEY];
+      }
+      [asyncSocket readDataToLength:length withTimeout:TIMEOUT_NONE tag:TAG_MSG_WITH_LENGTH];
+    }
+    else if (length == 126) {
+      [asyncSocket readDataToLength:2 withTimeout:TIMEOUT_NONE tag:TAG_PAYLOAD_LENGTH16];
+    }
+    else {
+      [asyncSocket readDataToLength:8 withTimeout:TIMEOUT_NONE tag:TAG_PAYLOAD_LENGTH64];
+    }
+  }
+  else if (tag == TAG_PAYLOAD_LENGTH16) {
+    UInt8 *pFrame = (UInt8 *) [data bytes];
+    NSUInteger length = ((NSUInteger) pFrame[0] << 8) | (NSUInteger) pFrame[1];
+    if (nextFrameMasked) {
+      [asyncSocket readDataToLength:4 withTimeout:TIMEOUT_NONE tag:TAG_MSG_MASKING_KEY];
+    }
+    [asyncSocket readDataToLength:length withTimeout:TIMEOUT_NONE tag:TAG_MSG_WITH_LENGTH];
+  }
+  else if (tag == TAG_PAYLOAD_LENGTH64) {
+    // FIXME: 64bit data size in memory?
+    [self didClose];
+  }
+  else if (tag == TAG_MSG_WITH_LENGTH) {
+    NSUInteger msgLength = [data length];
+    if (nextFrameMasked && maskingKey) {
+      NSMutableData *masked = data.mutableCopy;
+      UInt8 *pData = (UInt8 *) masked.mutableBytes;
+      UInt8 *pMask = (UInt8 *) maskingKey.bytes;
+      for (NSUInteger i = 0; i < msgLength; i++) {
+        pData[i] = pData[i] ^ pMask[i % 4];
+      }
+      data = masked;
+    }
+    if (nextOpCode == WS_OP_TEXT_FRAME) {
+      NSString *msg = [[NSString alloc] initWithBytes:[data bytes] length:msgLength encoding:NSUTF8StringEncoding];
+      [self didReceiveMessage:msg];
+    }
+    else {
+      [self didClose];
+      return;
+    }
+
+    // Read next frame
+    [asyncSocket readDataToLength:1 withTimeout:TIMEOUT_NONE tag:TAG_PAYLOAD_PREFIX];
+  }
+  else if (tag == TAG_MSG_MASKING_KEY) {
+    maskingKey = data.copy;
+  }
+  else {
+    NSUInteger msgLength = [data length] - 1; // Excluding ending 0xFF frame
+
+    NSString *msg = [[NSString alloc] initWithBytes:[data bytes] length:msgLength encoding:NSUTF8StringEncoding];
+
+    [self didReceiveMessage:msg];
+
+
+    // Read next message
+    [asyncSocket readDataToLength:1 withTimeout:TIMEOUT_NONE tag:TAG_PREFIX];
+  }
+}
+
+- (void)socketDidDisconnect:(LPGCDAsyncSocket *)sock withError:(NSError *)error {
+  LPHTTPLogVerbose(@"%@[%p]: socketDidDisconnect:withError: %@", LP_THIS_FILE, self, error);
+
+  [self didClose];
+}
+
+@end


### PR DESCRIPTION
### Motivation

CocoaHTTPServer sources are out-of-date.

### Tests

* [XTC Web Views](https://testcloud.xamarin.com/test/170904d9-95ac-48b4-a160-d8d31889a48f/)

```
34 scenarios (34 passed)
133 steps (133 passed)
3m16.836s
```

* [XTC Smoke Test](https://testcloud.xamarin.com/test/f972e655-4b34-4ea5-a835-e484906f9fba/)

```
53 scenarios (53 passed)
219 steps (219 passed)
9m26.592s
```

* Briar

```
120 scenarios (5 pending, 115 passed)
566 steps (5 pending, 561 passed)
35m15.975s
```
@krukow @sapieneptus @rasmuskl @john7doe 

Also adds LPWebSocket (part of CocoaHTTPServer) which might be of interest to @acroos.


