### PR TITLE
Backdoor route should return a 'results' key

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -61,7 +61,14 @@
     result = (__bridge id)buffer;
 
     if (!result) {result = [NSNull null];}
-    return  @{ @"result" : result, @"outcome" : @"SUCCESS" };
+    return
+    @{
+      @"results": result,
+      // Legacy API:  Starting in Calabash 2.0 and Calabash 0.15.0, the 'result'
+      // key will be dropped.
+      @"result" : result,
+      @"outcome" : @"SUCCESS"
+      };
 
   } else {
 


### PR DESCRIPTION
### Motivation

To be consistent will all other routes, the backdoor route should return SUCCESS with a 'results' key not 'result'.

To be backward compatible, I simply added another key 'results'.

