### PR TITLE
Expand backdoor route to handle arbitrary method signatures

### DIFF
--- a/XCTest/Tests/Routes/LPBackdoorRouteTest.m
+++ b/XCTest/Tests/Routes/LPBackdoorRouteTest.m
@@ -49,4 +49,51 @@
   expect(dictionary[@"outcome"]).to.equal(@"FAILURE");
 }
 
+- (void) testMissingSelector {
+  NSDictionary *data = @{};
+
+  NSDictionary *actual = [self.route JSONResponseForMethod:nil
+                                                       URI:nil
+                                                      data:data];
+
+  expect([actual count]).to.equal(3);
+  expect(actual[@"reason"]).to.equal(@"Missing selector name");
+  expect(actual[@"details"]).notTo.equal(nil);
+  expect(actual[@"outcome"]).to.equal(@"FAILURE");
+}
+
+- (void) testArgAndArgumentsKey {
+  NSDictionary *data =
+  @{
+    @"arg" : @"an arg",
+    @"arguments" : @[@"a", @"b", @"c"],
+    @"selector" : @"selector:"
+    };
+
+  NSDictionary *actual = [self.route JSONResponseForMethod:nil
+                                                       URI:nil
+                                                      data:data];
+
+  expect([actual count]).to.equal(3);
+  expect(actual[@"reason"]).to.equal(@"Incompatible keys: 'arg' and 'arguments'");
+  expect(actual[@"details"]).notTo.equal(nil);
+  expect(actual[@"outcome"]).to.equal(@"FAILURE");
+}
+
+- (void) testMissingArgOrArgumentsKey {
+  NSDictionary *data =
+  @{
+    @"selector" : @"selector:"
+    };
+
+  NSDictionary *actual = [self.route JSONResponseForMethod:nil
+                                                       URI:nil
+                                                      data:data];
+
+  expect([actual count]).to.equal(3);
+  expect(actual[@"reason"]).to.equal(@"Missing argument(s) for selector");
+  expect(actual[@"details"]).notTo.equal(nil);
+  expect(actual[@"outcome"]).to.equal(@"FAILURE");
+}
+
 @end

--- a/XCTest/Tests/Routes/LPBackdoorRouteTest.m
+++ b/XCTest/Tests/Routes/LPBackdoorRouteTest.m
@@ -1,0 +1,52 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import <XCTest/XCTest.h>
+#import "LPBackdoorRoute.h"
+
+@interface LPBackdoorRoute (LPXCTEST)
+
+- (NSDictionary *) failureWithReason:(NSString *) reason
+                             details:(NSString *) details;
+@end
+
+@interface LPBackdoorRouteTest : XCTestCase
+
+@property(nonatomic, strong) LPBackdoorRoute *route;
+
+@end
+
+@implementation LPBackdoorRouteTest
+
+- (void) setUp {
+  [super setUp];
+  self.route = [LPBackdoorRoute new];
+}
+
+- (void) tearDown {
+  self.route = nil;
+  [super tearDown];
+}
+
+- (void) testSupportsMethodPOST {
+  expect([self.route supportsMethod:@"POST" atPath:nil]).to.equal(YES);
+}
+
+- (void) testSupportsMethodAnythingButPOST {
+  expect([self.route supportsMethod:@"GET" atPath:nil]).to.equal(NO);
+}
+
+- (void) testFailureWithReasonDetails {
+  NSString *reason = @"A reason";
+  NSString *details = @"Some details";
+
+  NSDictionary *dictionary = [self.route failureWithReason:reason
+                                                   details:details];
+  expect([dictionary count]).to.equal(3);
+  expect(dictionary[@"reason"]).to.equal(reason);
+  expect(dictionary[@"details"]).to.equal(details);
+  expect(dictionary[@"outcome"]).to.equal(@"FAILURE");
+}
+
+@end

--- a/XCTest/Tests/Routes/LPBackdoorRouteTest.m
+++ b/XCTest/Tests/Routes/LPBackdoorRouteTest.m
@@ -96,4 +96,23 @@
   expect(actual[@"outcome"]).to.equal(@"FAILURE");
 }
 
+- (void) testUnknownSelector {
+
+  NSDictionary *data =
+  @{
+    @"selector" : @"unknownSelector",
+    @"arguments" : @[]
+    };
+
+
+  NSDictionary *actual = [self.route JSONResponseForMethod:nil
+                                                       URI:nil
+                                                      data:data];
+
+  expect([actual count]).to.equal(3);
+  expect(actual[@"reason"]).to.equal(@"The backdoor: 'unknownSelector' is undefined");
+  expect(actual[@"details"]).notTo.equal(nil);
+  expect(actual[@"outcome"]).to.equal(@"FAILURE");
+}
+
 @end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -454,6 +454,7 @@
 		F58C9F8E1B6F802D007D307B /* HTTPFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = F58C9F7B1B6F802D007D307B /* HTTPFileResponse.m */; };
 		F58C9F8F1B6F802D007D307B /* HTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = F58C9F7D1B6F802D007D307B /* HTTPRedirectResponse.m */; };
 		F58C9F901B6F802D007D307B /* WebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = F58C9F7F1B6F802D007D307B /* WebSocket.m */; settings = {COMPILER_FLAGS = "-Wno-unreachable-code -Wno-unused-function"; }; };
+		F58CE49E1BD6757A0025BE67 /* LPBackdoorRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F58CE49D1BD6757A0025BE67 /* LPBackdoorRouteTest.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F59741C11AA565190089DC88 /* OCMockitoIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F59741BD1AA565190089DC88 /* OCMockitoIOS.framework */; };
 		F59741C21AA565190089DC88 /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F59741BE1AA565190089DC88 /* OCHamcrestIOS.framework */; };
 		F59741EE1AA5712F0089DC88 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F59741E31AA5712F0089DC88 /* libOCMock.a */; };
@@ -495,12 +496,12 @@
 		F5A33A5F1AC0172A00224639 /* UIWebView+LPWebViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A33A5E1AC0172A00224639 /* UIWebView+LPWebViewTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A33A711AC01BC400224639 /* WKWebView+LPWebViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A33A701AC01BC400224639 /* WKWebView+LPWebViewTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A33A791AC01EC400224639 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5A33A721AC01E8E00224639 /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		F5A6B9751BD15877009FD08B /* LPProcessInfoRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9741BD15877009FD08B /* LPProcessInfoRouteTest.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A6B96D1BD14E96009FD08B /* LPReflectionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9691BD14E96009FD08B /* LPReflectionRoute.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A6B96E1BD14E96009FD08B /* LPReflectionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9691BD14E96009FD08B /* LPReflectionRoute.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A6B96F1BD14E96009FD08B /* LPReflectionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9691BD14E96009FD08B /* LPReflectionRoute.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A6B9701BD14E96009FD08B /* LPReflectionRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9691BD14E96009FD08B /* LPReflectionRoute.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A6B9721BD14EE2009FD08B /* LPReflectionRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9711BD14EE2009FD08B /* LPReflectionRouteTest.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F5A6B9751BD15877009FD08B /* LPProcessInfoRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A6B9741BD15877009FD08B /* LPProcessInfoRouteTest.m */; settings = {ASSET_TAGS = (); COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A8B4581B39BFEB00F390CA /* LPCLIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A8B43E1B39BFEB00F390CA /* LPCLIColor.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A8B4591B39BFEB00F390CA /* LPCLIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A8B43E1B39BFEB00F390CA /* LPCLIColor.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5A8B45A1B39BFEB00F390CA /* LPCLIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = F5A8B43E1B39BFEB00F390CA /* LPCLIColor.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -916,6 +917,7 @@
 		F58C9F7D1B6F802D007D307B /* HTTPRedirectResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPRedirectResponse.m; sourceTree = "<group>"; };
 		F58C9F7E1B6F802D007D307B /* WebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocket.h; sourceTree = "<group>"; };
 		F58C9F7F1B6F802D007D307B /* WebSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebSocket.m; sourceTree = "<group>"; };
+		F58CE49D1BD6757A0025BE67 /* LPBackdoorRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPBackdoorRouteTest.m; sourceTree = "<group>"; };
 		F591380217C39128007B2BE4 /* LPOrientationOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPOrientationOperation.h; sourceTree = "<group>"; };
 		F591380317C39128007B2BE4 /* LPOrientationOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPOrientationOperation.m; sourceTree = "<group>"; };
 		F59741BD1AA565190089DC88 /* OCMockitoIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OCMockitoIOS.framework; sourceTree = "<group>"; };
@@ -999,10 +1001,10 @@
 		F5A33A601AC01A9F00224639 /* LPWebViewProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPWebViewProtocol.h; sourceTree = "<group>"; };
 		F5A33A701AC01BC400224639 /* WKWebView+LPWebViewTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WKWebView+LPWebViewTest.m"; sourceTree = "<group>"; };
 		F5A33A721AC01E8E00224639 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		F5A6B9741BD15877009FD08B /* LPProcessInfoRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPProcessInfoRouteTest.m; sourceTree = "<group>"; };
 		F5A6B9681BD14E96009FD08B /* LPReflectionRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPReflectionRoute.h; sourceTree = "<group>"; };
 		F5A6B9691BD14E96009FD08B /* LPReflectionRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPReflectionRoute.m; sourceTree = "<group>"; };
 		F5A6B9711BD14EE2009FD08B /* LPReflectionRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPReflectionRouteTest.m; sourceTree = "<group>"; };
+		F5A6B9741BD15877009FD08B /* LPProcessInfoRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPProcessInfoRouteTest.m; sourceTree = "<group>"; };
 		F5A8B43E1B39BFEB00F390CA /* LPCLIColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCLIColor.m; sourceTree = "<group>"; };
 		F5A8B43F1B39BFEB00F390CA /* LPCLIColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCLIColor.h; sourceTree = "<group>"; };
 		F5A8B4411B39BFEB00F390CA /* LPContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPContextFilterLogFormatter.h; sourceTree = "<group>"; };
@@ -2001,6 +2003,7 @@
 				F565B48A1B6A33600039ACFF /* LPKeyboardLanguageRouteTest.m */,
 				F57605181BCE767000E89C97 /* LPSuspendAppRouteTest.m */,
 				F5A6B9711BD14EE2009FD08B /* LPReflectionRouteTest.m */,
+				F58CE49D1BD6757A0025BE67 /* LPBackdoorRouteTest.m */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -2822,6 +2825,7 @@
 				F52A26531BD02D0400AD0E36 /* LPCDataScanner.m in Sources */,
 				F5B6B3E01B5CC9A7006B2CC1 /* LPASLLogFormatter.m in Sources */,
 				F50CBF8B1A04056F004AC9DA /* LPHTTPDynamicFileResponse.m in Sources */,
+				F58CE49E1BD6757A0025BE67 /* LPBackdoorRouteTest.m in Sources */,
 				F5C224E31AD473F0001DB4FA /* LPTouchUtilsTest.m in Sources */,
 				F5A8B4621B39BFEB00F390CA /* LPContextFilterLogFormatter.m in Sources */,
 				B1670E2E1A32411100000A62 /* LPDumpRoute.m in Sources */,
@@ -2832,7 +2836,6 @@
 				F50CBFA41A0405B2004AC9DA /* LPQueryLogRoute.m in Sources */,
 				F50CBFC11A0405CE004AC9DA /* UIScriptASTIndex.m in Sources */,
 				F576058C1BCE77F000E89C97 /* LPSuspendAppRoute.m in Sources */,
-				F50CBFCB1A0405E9004AC9DA /* LPCDataScanner.m in Sources */,
 				F5A33A711AC01BC400224639 /* WKWebView+LPWebViewTest.m in Sources */,
 				F5F2D5E01ACAC3B60027937B /* LPIsWebViewTest.m in Sources */,
 				F5C224EA1AD47403001DB4FA /* LPScreenshotRouteTest.m in Sources */,

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -16,8 +16,8 @@
 #import "LPInvocationResult.h"
 #import "LPInvocationError.h"
 
-const static NSString *ARG_KEY = @"arg";  /* for backwards compatibility */
-const static NSString *ARGUMENTS_KEY = @"arguments";
+static NSString *const ARG_KEY = @"arg";  /* for backwards compatibility */
+static NSString *const ARGUMENTS_KEY = @"arguments";
 
 @implementation LPBackdoorRoute
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -120,7 +120,7 @@ static NSString *const ARGUMENTS_KEY = @"arguments";
 
     NSString *details = [lines componentsJoinedByString:@"\n"];
 
-    NSString *reason = [NSString stringWithFormat:@"The backdoor: '%@' is undefined.",
+    NSString *reason = [NSString stringWithFormat:@"The backdoor: '%@' is undefined",
                         selectorName];
     return  @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
   }

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -22,7 +22,9 @@
   return [method isEqualToString:@"POST"];
 }
 
-- (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data {
   NSString *originalSelStr = [data objectForKey:@"selector"];
   NSString *selectorName = originalSelStr;
   if (![originalSelStr hasSuffix:@":"]) {

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -34,22 +34,37 @@ const static NSString *ARGUMENTS_KEY = @"arguments";
                                     data:(NSDictionary *) data {
   NSString *selectorName = data[@"selector"];
   if (!selectorName) {
-    LPLogError(@"Expected data dictionary to contain a 'selector' key.\nData = %@", data);
+    LPLogError(@"Expected data dictionary to contain a 'selector' key.\nData = %@",
+               data);
+    NSString *details;
+    details = [NSString stringWithFormat:@"No selector key found in route arguments: '%@'",
+               data];
     return [self failureWithReason:@"Missing selector name."
-                           details:[NSString stringWithFormat:@"Expected selector name to be provided for backdoor, but no 'selector' key in data '%@'", data]];
+                           details:details];
   }
 
   if (data[ARG_KEY] && data[ARGUMENTS_KEY]) {
-    LPLogError(@"Expected data dictionary to contain '%@' XOR '%@'.\nData = %@", ARG_KEY, ARGUMENTS_KEY, data);
+    LPLogError(@"Expected data dictionary to contain '%@' XOR '%@'.\nData = %@",
+               ARG_KEY, ARGUMENTS_KEY, data);
+
+    NSString *details;
+    details = [NSString stringWithFormat:@"Expected '%@' OR '%@' key in data, not both. Data: '%@'",
+               ARG_KEY, ARGUMENTS_KEY, data];
     return [self failureWithReason:@"Missing selector name."
-                           details:[NSString stringWithFormat:@"Expected '%@' OR '%@' key in data, not both. Data: '%@'", ARG_KEY, ARGUMENTS_KEY, data]];
+                           details:details];
+
   } else if (!(data[ARG_KEY] || data[ARGUMENTS_KEY])) {
-    LPLogError(@"Expected data dictionary to contain an '%@' or '%@' key.\nData = %@", ARG_KEY, ARGUMENTS_KEY, data);
-    return [self failureWithReason:[NSString stringWithFormat:@"Missing argument(s) for selector: '%@'",
-                                    selectorName]
-                           details:[NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no '%@' or '%@' key in data '%@'", ARG_KEY, ARGUMENTS_KEY, selectorName, data]];
+    LPLogError(@"Expected data dictionary to contain an '%@' or '%@' key.\nData = %@",
+               ARG_KEY, ARGUMENTS_KEY, data);
+    NSString *reason, *details;
+    reason = [NSString stringWithFormat:@"Missing argument(s) for selector: '%@'",
+              selectorName];
+    details = [NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no '%@' or '%@' key in data '%@'",
+               ARG_KEY, ARGUMENTS_KEY, selectorName, data];
+    return [self failureWithReason:reason
+                           details:details];
   }
-  
+
   id arguments = data[ARG_KEY] ? @[data[ARG_KEY]] : data[ARGUMENTS_KEY];
 
   SEL selector = NSSelectorFromString(selectorName);
@@ -60,10 +75,14 @@ const static NSString *ARGUMENTS_KEY = @"arguments";
                                       withTarget:delegate
                                        arguments:arguments];
     if ([invocationResult isError]) {
-      return [self failureWithReason:[NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
-                                      [invocationResult description]]
-                             details:[NSString stringWithFormat:@"Invoking backdoor selector '%@' with arguments '%@' could not be completed because '%@'",
-                                      selectorName, arguments, [invocationResult description]]];
+      NSString *reason, *details;
+      reason = [NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
+                [invocationResult description]];
+      details = [NSString stringWithFormat:@"Invoking backdoor selector '%@' with arguments '%@' could not be completed because '%@'",
+                 selectorName, arguments, [invocationResult description]];
+      return [self failureWithReason:reason
+                             details:details];
+
     } else {
       return
       @{

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -19,9 +19,16 @@
 static NSString *const ARG_KEY = @"arg";  /* for backwards compatibility */
 static NSString *const ARGUMENTS_KEY = @"arguments";
 
+@interface LPBackdoorRoute ()
+
+- (NSDictionary *) failureWithReason:(NSString *) reason
+                             details:(NSString *) details;
+@end
+
 @implementation LPBackdoorRoute
 
-- (NSDictionary *)failureWithReason:(NSString *)reason details:(NSString *)details {
+- (NSDictionary *) failureWithReason:(NSString *) reason
+                             details:(NSString *) details {
   return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
 }
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -16,6 +16,9 @@
 #import "LPInvocationResult.h"
 #import "LPInvocationError.h"
 
+const static NSString *ARG_KEY = @"arg";  /* for backwards compatibility */
+const static NSString *ARGUMENTS_KEY = @"arguments";
+
 @implementation LPBackdoorRoute
 
 - (NSDictionary *)failureWithReason:(NSString *)reason details:(NSString *)details {
@@ -36,18 +39,18 @@
                            details:[NSString stringWithFormat:@"Expected selector name to be provided for backdoor, but no 'selector' key in data '%@'", data]];
   }
 
-  if (data[@"arg"] && data[@"args"]) {
-    LPLogError(@"Expected data dictionary to contain 'arg' XOR 'args'.\nData = %@", data);
+  if (data[ARG_KEY] && data[ARGUMENTS_KEY]) {
+    LPLogError(@"Expected data dictionary to contain '%@' XOR '%@'.\nData = %@", ARG_KEY, ARGUMENTS_KEY, data);
     return [self failureWithReason:@"Missing selector name."
-                           details:[NSString stringWithFormat:@"Expected 'arg' OR 'args' key in data, not both. Data: '%@'", data]];
-  } else if (!(data[@"arg"] || data[@"args"])) {
-    LPLogError(@"Expected data dictionary to contain an 'arg' or 'args' key.\nData = %@", data);
+                           details:[NSString stringWithFormat:@"Expected '%@' OR '%@' key in data, not both. Data: '%@'", ARG_KEY, ARGUMENTS_KEY, data]];
+  } else if (!(data[ARG_KEY] || data[ARGUMENTS_KEY])) {
+    LPLogError(@"Expected data dictionary to contain an '%@' or '%@' key.\nData = %@", ARG_KEY, ARGUMENTS_KEY, data);
     return [self failureWithReason:[NSString stringWithFormat:@"Missing argument(s) for selector: '%@'",
                                     selectorName]
-                           details:[NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no 'arg' or 'args' key in data '%@'", selectorName, data]];
+                           details:[NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no '%@' or '%@' key in data '%@'", ARG_KEY, ARGUMENTS_KEY, selectorName, data]];
   }
   
-  id arguments = data[@"arg"] ? @[data[@"arg"]] : data[@"args"];
+  id arguments = data[ARG_KEY] ? @[data[ARG_KEY]] : data[ARGUMENTS_KEY];
 
   SEL selector = NSSelectorFromString(selectorName);
   id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -46,7 +46,7 @@ static NSString *const ARGUMENTS_KEY = @"arguments";
     NSString *details;
     details = [NSString stringWithFormat:@"No selector key found in route arguments: '%@'",
                data];
-    return [self failureWithReason:@"Missing selector name."
+    return [self failureWithReason:@"Missing selector name"
                            details:details];
   }
 
@@ -57,18 +57,16 @@ static NSString *const ARGUMENTS_KEY = @"arguments";
     NSString *details;
     details = [NSString stringWithFormat:@"Expected '%@' OR '%@' key in data, not both. Data: '%@'",
                ARG_KEY, ARGUMENTS_KEY, data];
-    return [self failureWithReason:@"Missing selector name."
+    return [self failureWithReason:@"Incompatible keys: 'arg' and 'arguments'"
                            details:details];
 
   } else if (!(data[ARG_KEY] || data[ARGUMENTS_KEY])) {
     LPLogError(@"Expected data dictionary to contain an '%@' or '%@' key.\nData = %@",
                ARG_KEY, ARGUMENTS_KEY, data);
-    NSString *reason, *details;
-    reason = [NSString stringWithFormat:@"Missing argument(s) for selector: '%@'",
-              selectorName];
+    NSString *details;
     details = [NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no '%@' or '%@' key in data '%@'",
                ARG_KEY, ARGUMENTS_KEY, selectorName, data];
-    return [self failureWithReason:reason
+    return [self failureWithReason:@"Missing argument(s) for selector"
                            details:details];
   }
 

--- a/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPBackdoorRoute.m
@@ -18,6 +18,10 @@
 
 @implementation LPBackdoorRoute
 
+- (NSDictionary *)failureWithReason:(NSString *)reason details:(NSString *)details {
+  return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+}
+
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
   return [method isEqualToString:@"POST"];
 }
@@ -25,27 +29,25 @@
 - (NSDictionary *) JSONResponseForMethod:(NSString *) method
                                      URI:(NSString *) path
                                     data:(NSDictionary *) data {
-  NSString *originalSelStr = [data objectForKey:@"selector"];
-  NSString *selectorName = originalSelStr;
-  if (![originalSelStr hasSuffix:@":"]) {
-    LPLogWarn(@"Selector name is missing a ':'");
-    LPLogWarn(@"All backdoor methods must take at least one argument.");
-    LPLogWarn(@"Appending a ':' to the selector name.");
-    LPLogWarn(@"This will be an error in the future.");
-    selectorName = [selectorName stringByAppendingString:@":"];
+  NSString *selectorName = data[@"selector"];
+  if (!selectorName) {
+    LPLogError(@"Expected data dictionary to contain a 'selector' key.\nData = %@", data);
+    return [self failureWithReason:@"Missing selector name."
+                           details:[NSString stringWithFormat:@"Expected selector name to be provided for backdoor, but no 'selector' key in data '%@'", data]];
   }
 
-  id argument = [data objectForKey:@"arg"];
-  if (!argument) {
-    LPLogError(@"Expected data dictionary to contain an 'arg' key");
-    LPLogError(@"data = '%@'", data);
-    NSString *details = [NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument, but found no 'arg' key in data '%@'",
-                         selectorName, data];
-
-    NSString *reason = [NSString stringWithFormat:@"Missing argument for selector: '%@'",
-                        selectorName];
-    return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+  if (data[@"arg"] && data[@"args"]) {
+    LPLogError(@"Expected data dictionary to contain 'arg' XOR 'args'.\nData = %@", data);
+    return [self failureWithReason:@"Missing selector name."
+                           details:[NSString stringWithFormat:@"Expected 'arg' OR 'args' key in data, not both. Data: '%@'", data]];
+  } else if (!(data[@"arg"] || data[@"args"])) {
+    LPLogError(@"Expected data dictionary to contain an 'arg' or 'args' key.\nData = %@", data);
+    return [self failureWithReason:[NSString stringWithFormat:@"Missing argument(s) for selector: '%@'",
+                                    selectorName]
+                           details:[NSString stringWithFormat:@"Expected backdoor selector '%@' to have an argument(s), but found no 'arg' or 'args' key in data '%@'", selectorName, data]];
   }
+  
+  id arguments = data[@"arg"] ? @[data[@"arg"]] : data[@"args"];
 
   SEL selector = NSSelectorFromString(selectorName);
   id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
@@ -53,13 +55,12 @@
     LPInvocationResult *invocationResult;
     invocationResult = [LPInvoker invokeSelector:selector
                                       withTarget:delegate
-                                       arguments:@[argument]];
+                                       arguments:arguments];
     if ([invocationResult isError]) {
-      NSString *reason = [NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
-                          [invocationResult description]];
-      NSString *details = [NSString stringWithFormat:@"Invoking backdoor selector '%@' with argument '%@' could not be completed because '%@'",
-                           selectorName, argument, [invocationResult description]];
-      return @{ @"details" : details, @"reason" : reason, @"outcome" : @"FAILURE" };
+      return [self failureWithReason:[NSString stringWithFormat:@"Invoking backdoor resulted in error: %@",
+                                      [invocationResult description]]
+                             details:[NSString stringWithFormat:@"Invoking backdoor selector '%@' with arguments '%@' could not be completed because '%@'",
+                                      selectorName, arguments, [invocationResult description]]];
     } else {
       return
       @{


### PR DESCRIPTION
**FORCE PUSHED** rebased Tue 20 Oct 15:04

- Modified `LPBackdoorRoute` to be able to handle `args` key which should be an array of args. This allows invocation of methods with multiple params. 
- Modified `LPInvoker` to accept `@"__nil__"` as nil, thereby allowing clients to pass `nil` as a param to a backdoor. 
- Since I _believe_ a void return type is already handled, this should allow for backdoor methods of arbitrary sigs. 