### PR TITLE
Wrong base branch: Release/0.16.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.16.0
+
+This release contains no code-level changes.  It is being made
+so we can tag and distribute libraries that have been compiled
+with Xcode 7.  This is necessary because of the new bit code
+settings in Xcode 7.
+
 ### 0.15.0
 
 * LPQueryAllOperation needs some TLC #204

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
@@ -21,7 +21,7 @@
  Do not change the 'CALABASH VERSION' portion of the following constant without
  updating the ruby API.
  ******************/
-#define kLPCALABASHVERSION @"CALABASH VERSION: 0.15.0"
+#define kLPCALABASHVERSION @"CALABASH VERSION: 0.16.0"
 
 @interface LPVersionRoute : NSObject <LPRoute>
 


### PR DESCRIPTION
### 0.16.0

This release contains no code-level changes.  It is being made
so we can tag and distribute libraries that have been compiled
with Xcode 7.  This is necessary because of the new bit code
settings in Xcode 7.