### PR TITLE
Release/0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-### 0.16.0
+### 0.16.0 and 0.16.1
 
-This release contains no code-level changes.  It is being made
-so we can tag and distribute libraries that have been compiled
+These releases contains no code-level changes.  They have been
+made so we can tag and distribute libraries that have been compiled
 with Xcode 7.  This is necessary because of the new bit code
 settings in Xcode 7.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ The Calabash iOS Toolchain uses git-flow.
 
 See these links for information about git-flow and git best practices.
 
+Please see this [post](http://chris.beams.io/posts/git-commit/) for tips
+on how to make a good commit messages.
+
 ##### Git Flow Step-by-Step guide
 
 * https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.h
@@ -21,7 +21,7 @@
  Do not change the 'CALABASH VERSION' portion of the following constant without
  updating the ruby API.
  ******************/
-#define kLPCALABASHVERSION @"CALABASH VERSION: 0.16.0"
+#define kLPCALABASHVERSION @"CALABASH VERSION: 0.16.1"
 
 @interface LPVersionRoute : NSObject <LPRoute>
 


### PR DESCRIPTION
### 0.16.0 and 0.16.1

These releases contains no code-level changes.  They have been
made so we can tag and distribute libraries that have been compiled
with Xcode 7.  This is necessary because of the new bit code
settings in Xcode 7.