### PR TITLE
LPUIAUserPrefsChannel: use NSUserDefaults

### DIFF
--- a/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
+++ b/calabash/Classes/Utils/LPUIAUserPrefsChannel.m
@@ -153,23 +153,11 @@ const static NSInteger LPUIAChannelMaximumLoopCount = 1200;
     NSLog(@"iOS >= 8.1 detected; assuming Xcode >= 6.1");
     NSInteger i = 0;
     while (i < LPUIAChannelMaximumLoopCount) {
-      [[NSUserDefaults standardUserDefaults] synchronize];
-      preferences  = [NSMutableDictionary dictionaryWithContentsOfFile:preferencesPlist];
-      if (!preferences) {
-        preferences = [NSMutableDictionary dictionary];
-        NSLog(@"Empty preferences... resetting");
-      }
-
       NSDictionary *uiaRequest   = [self requestForCommand:command];
-      [preferences setObject:uiaRequest forKey:LPUIAChannelUIAPrefsRequestKey];
-      BOOL writeSuccess = [preferences writeToFile:preferencesPlist
-                                        atomically:YES];
-
-      if (!writeSuccess) {
-        NSLog(@"Preparing for retry of simulatorRequestExecutionOf:");
-      }
-
-      if ([self validateRequestWritten:uiaRequest]) {
+      [[NSUserDefaults standardUserDefaults] setObject:uiaRequest forKey:(NSString *)LPUIAChannelUIAPrefsRequestKey];
+      [[NSUserDefaults standardUserDefaults] synchronize];
+      
+      if ([self validateRequestWritten:uiaRequest] ) {
         return;
       } else {
         i++;


### PR DESCRIPTION
I don't have any facts here, but what I found was that if the `.plist` was in binary form, it seemed to work. If it was in plain text, it did not. `[[NSUserDefaults standardDefaults] setObject:forKey]` seems to write to that file synchronously as far as I can tell, but will do more testing to confirm (as well as backwards compat w/ 8.x sims).

Note: appears to work on 8.3 simulator, didn't notice any issues with the `index` being out of sync or anything. It _appears_ to be a little faster in 8.3 than 9.0. 