### PR TITLE
LPVersionRoute needs to be backward compatible

### DIFF
--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -66,6 +66,10 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
   expect([self.device isPhysicalDevice]).to.equal(NO);
 }
 
+- (void) testLEGACY_iPhoneSimulatorDeviceReturnsSomething {
+  expect([self.device LEGACY_iPhoneSimulatorDevice]).notTo.equal(nil);
+}
+
 #else
 
 - (void) testModelIdentiferReturnsNothing {
@@ -88,6 +92,10 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
   NSString *actual = [self.device physicalDeviceModelIdentifier];
   expect(actual).notTo.equal(nil);
   expect(actual).notTo.equal(@"");
+}
+
+- (void) testLEGACY_iPhoneSimulatorDeviceReturnsNothing {
+  expect([self.device LEGACY_iPhoneSimulatorDevice]).to.equal(nil);
 }
 
 #endif

--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -72,7 +72,7 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
 
 #else
 
-- (void) testModelIdentiferReturnsNothing {
+- (void) testSimulatorModelIdentiferReturnsNothing {
   expect([self.device simulatorModelIdentfier]).to.equal(nil);
 }
 
@@ -104,6 +104,10 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
   NSString *actual = [self.device iOSVersion];
   expect(actual).notTo.equal(nil);
   expect(actual).notTo.equal(@"");
+}
+
+- (void) testLEGACY_systemFromUnameReturnsSomething {
+  expect([self.device LEGACY_systemFromUname]).notTo.equal(nil);
 }
 
 - (void) testProcessEnvironment {

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -138,6 +138,9 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   NSString *iOSVersion = [device iOSVersion];
   if (!iOSVersion) { iOSVersion = @""; }
 
+  NSString *LEGACY_iphoneSimulatorDevice = [device LEGACY_iPhoneSimulatorDevice];
+  if (!LEGACY_iphoneSimulatorDevice) { LEGACY_iphoneSimulatorDevice = @""; }
+
   NSDictionary *git =
   @{
     @"revision" : kLPGitShortRevision,
@@ -174,7 +177,7 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
     @"server_port" : @([infoPlist serverPort]),
     @"short_version_string" : [infoPlist stringForShortVersion],
     @"simulator" : simulatorInfo,
-    @"simulator_device" : formFactor,     // deprecated 0.16.2 replaced with device_family
+    @"simulator_device" : LEGACY_iphoneSimulatorDevice, // deprecate 0.16.2 replaced with device_family
     @"system" : [self LEGACY_deviceSystem], // deprecated 0.16.2, no replacement
     @"version" : calabashVersion
 

--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -64,32 +64,14 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
 
 - (BOOL) isIPhoneAppEmulatedOnIPad;
 
-@property(copy, nonatomic, readonly) NSString *LEGACY_deviceSystem;
-
 @end
 
 @implementation LPVersionRoute
-
-@synthesize LEGACY_deviceSystem = _LEGACY_deviceSystem;
 
 - (BOOL) isIPhoneAppEmulatedOnIPad {
   UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
   NSString *model = [[UIDevice currentDevice] model];
   return idiom == UIUserInterfaceIdiomPhone && [model hasPrefix:@"iPad"];
-}
-
-// Required for backward compatibility for 'system' key.
-// Added 0.16.2.  Replaces [device system].
-- (NSString *) LEGACY_deviceSystem {
-  if (_LEGACY_deviceSystem) { return _LEGACY_deviceSystem; }
-  struct utsname systemInfo;
-  uname(&systemInfo);
-  _LEGACY_deviceSystem = @(systemInfo.machine);
-
-  if (!_LEGACY_deviceSystem) {
-    _LEGACY_deviceSystem = @"";
-  }
-  return _LEGACY_deviceSystem;
 }
 
 - (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
@@ -178,7 +160,7 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
     @"short_version_string" : [infoPlist stringForShortVersion],
     @"simulator" : simulatorInfo,
     @"simulator_device" : LEGACY_iphoneSimulatorDevice, // deprecate 0.16.2 replaced with device_family
-    @"system" : [self LEGACY_deviceSystem], // deprecated 0.16.2, no replacement
+    @"system" : [device LEGACY_systemFromUname],        // deprecated 0.16.2, replaced with model identifer
     @"version" : calabashVersion
 
     };

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -20,6 +20,7 @@ extern NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY;
 @property(copy, nonatomic, readonly) NSString *deviceFamily;
 @property(copy, nonatomic, readonly) NSString *name;
 @property(copy, nonatomic, readonly) NSString *iOSVersion;
+@property(copy, nonatomic, readonly) NSString *physicalDeviceModelIdentifier;
 
 + (LPDevice *) sharedDevice;
 
@@ -27,6 +28,8 @@ extern NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY;
 
 // Required for clients < 0.16.2 - @see LPVersionRoute
 - (NSString *) LEGACY_iPhoneSimulatorDevice;
+- (NSString *) LEGACY_systemFromUname;
+
 
 - (BOOL) isSimulator;
 - (BOOL) isPhysicalDevice;

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -9,6 +9,7 @@
 
 extern NSString *const LPDeviceSimKeyModelIdentifier;
 extern NSString *const LPDeviceSimKeyVersionInfo;
+extern NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY;
 
 @interface LPDevice : NSObject
 
@@ -23,6 +24,9 @@ extern NSString *const LPDeviceSimKeyVersionInfo;
 + (LPDevice *) sharedDevice;
 
 - (NSString *) simulatorVersionInfo;
+
+// Required for clients < 0.16.2 - @see LPVersionRoute
+- (NSString *) LEGACY_iPhoneSimulatorDevice;
 
 - (BOOL) isSimulator;
 - (BOOL) isPhysicalDevice;

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -15,6 +15,7 @@
 
 NSString *const LPDeviceSimKeyModelIdentifier = @"SIMULATOR_MODEL_IDENTIFIER";
 NSString *const LPDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
+NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_DEVICE";
 
 @interface LPDevice ()
 
@@ -250,6 +251,11 @@ NSString *const LPDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
   if (_iOSVersion) { return _iOSVersion; }
   _iOSVersion = [[UIDevice currentDevice] systemVersion];
   return _iOSVersion;
+}
+
+// Required for clients < 0.16.2 - @see LPVersionRoute
+- (NSString *) LEGACY_iPhoneSimulatorDevice {
+  return [self.processEnvironment objectForKey:LPDeviceSimKeyIphoneSimulatorDevice_LEGACY];
 }
 
 // The hardware name of the device.

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -46,6 +46,8 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 @synthesize deviceFamily = _deviceFamily;
 @synthesize name = _name;
 @synthesize iOSVersion = _iOSVersion;
+@synthesize physicalDeviceModelIdentifier = _physicalDeviceModelIdentifier;
+
 
 - (id) init {
   @throw [NSException exceptionWithName:@"Cannot call init"
@@ -230,9 +232,11 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 }
 
 - (NSString *) physicalDeviceModelIdentifier {
+  if (_physicalDeviceModelIdentifier) { return _physicalDeviceModelIdentifier; }
   struct utsname systemInfo;
   uname(&systemInfo);
-  return @(systemInfo.machine);
+  _physicalDeviceModelIdentifier = @(systemInfo.machine);
+  return _physicalDeviceModelIdentifier;
 }
 
 - (NSString *) deviceFamily {
@@ -256,6 +260,11 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 // Required for clients < 0.16.2 - @see LPVersionRoute
 - (NSString *) LEGACY_iPhoneSimulatorDevice {
   return [self.processEnvironment objectForKey:LPDeviceSimKeyIphoneSimulatorDevice_LEGACY];
+}
+
+// Required for clients < 0.16.2 - @see LPVersionRoute
+- (NSString *) LEGACY_systemFromUname {
+  return [self physicalDeviceModelIdentifier];
 }
 
 // The hardware name of the device.


### PR DESCRIPTION
### Motivation

The changes to LPVersionRoute in  #242 were too aggressive.

Caused failures on the client when setting the attributes of Calabash::Device instances.