### PR TITLE
Server logs IP address at launch

### DIFF
--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -392,4 +392,9 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
   OCMVerifyAll(mock);
 }
 
+- (void) testGetIPAddressIPv4 {
+  NSString *ip = [self.device getIPAddress:YES];
+  expect(ip).notTo.equal(nil);
+}
+
 @end

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -39,6 +39,7 @@
 #import "LPTTYLogFormatter.h"
 #import "LPASLLogFormatter.h"
 #import "LPProcessInfoRoute.h"
+#import "LPDevice.h"
 
 @interface CalabashServer ()
 - (void) start;
@@ -238,6 +239,10 @@
   NSError *error = nil;
   if (![_httpServer start:&error]) {
     LPLogError(@"Error starting Calabash HTTP Server: %@", error);
+  } else {
+    LPLogDebug(@"Calabash iOS server is listening on: %@ port %@",
+               [[LPDevice sharedDevice] getIPAddress:YES],
+               @([_httpServer port]));
   }
 }
 

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -40,5 +40,6 @@ extern NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY;
 - (BOOL) isIPhone4Like;
 - (BOOL) isIPhone5Like;
 - (BOOL) isLetterBox;
+- (NSString *) getIPAddress:(BOOL) preferIPv4;
 
 @end

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -12,6 +12,15 @@
 #import "LPDevice.h"
 #import "LPTouchUtils.h"
 #import <sys/utsname.h>
+#include <ifaddrs.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+
+#define IOS_CELLULAR    @"pdp_ip0"
+#define IOS_WIFI        @"en0"
+#define IOS_VPN         @"utun0"
+#define IP_ADDR_IPv4    @"ipv4"
+#define IP_ADDR_IPv6    @"ipv6"
 
 NSString *const LPDeviceSimKeyModelIdentifier = @"SIMULATOR_MODEL_IDENTIFIER";
 NSString *const LPDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
@@ -32,6 +41,7 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 
 - (NSString *) physicalDeviceModelIdentifier;
 - (NSString *) simulatorModelIdentfier;
+- (NSDictionary *) getIPAddresses;
 
 @end
 
@@ -335,6 +345,65 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
   } else {
     return [self heightForMainScreenBounds] * scale == 960;
   }
+}
+
+#pragma mark - IP Address
+
+// http://stackoverflow.com/questions/7072989/iphone-ipad-osx-how-to-get-my-ip-address-programmatically
+
+- (NSString *) getIPAddress:(BOOL) preferIPv4 {
+  NSArray *searchArray = preferIPv4 ?
+  @[ IOS_VPN @"/" IP_ADDR_IPv4, IOS_VPN @"/" IP_ADDR_IPv6, IOS_WIFI @"/" IP_ADDR_IPv4, IOS_WIFI @"/" IP_ADDR_IPv6, IOS_CELLULAR @"/" IP_ADDR_IPv4, IOS_CELLULAR @"/" IP_ADDR_IPv6 ] :
+  @[ IOS_VPN @"/" IP_ADDR_IPv6, IOS_VPN @"/" IP_ADDR_IPv4, IOS_WIFI @"/" IP_ADDR_IPv6, IOS_WIFI @"/" IP_ADDR_IPv4, IOS_CELLULAR @"/" IP_ADDR_IPv6, IOS_CELLULAR @"/" IP_ADDR_IPv4 ] ;
+
+  NSDictionary *addresses = [self getIPAddresses];
+
+  __block NSString *address;
+  [searchArray enumerateObjectsUsingBlock:^(NSString *key, NSUInteger idx, BOOL *stop)
+   {
+     address = addresses[key];
+     if(address) *stop = YES;
+   } ];
+  return address ? address : @"0.0.0.0";
+}
+
+- (NSDictionary *) getIPAddresses {
+  NSMutableDictionary *addresses = [NSMutableDictionary dictionaryWithCapacity:8];
+
+  // retrieve the current interfaces - returns 0 on success
+  struct ifaddrs *interfaces;
+  if(!getifaddrs(&interfaces)) {
+    // Loop through linked list of interfaces
+    struct ifaddrs *interface;
+    for(interface=interfaces; interface; interface=interface->ifa_next) {
+      if(!(interface->ifa_flags & IFF_UP) /* || (interface->ifa_flags & IFF_LOOPBACK) */ ) {
+        continue; // deeply nested code harder to read
+      }
+      const struct sockaddr_in *addr = (const struct sockaddr_in*)interface->ifa_addr;
+      char addrBuf[ MAX(INET_ADDRSTRLEN, INET6_ADDRSTRLEN) ];
+      if(addr && (addr->sin_family==AF_INET || addr->sin_family==AF_INET6)) {
+        NSString *name = [NSString stringWithUTF8String:interface->ifa_name];
+        NSString *type;
+        if(addr->sin_family == AF_INET) {
+          if(inet_ntop(AF_INET, &addr->sin_addr, addrBuf, INET_ADDRSTRLEN)) {
+            type = IP_ADDR_IPv4;
+          }
+        } else {
+          const struct sockaddr_in6 *addr6 = (const struct sockaddr_in6*)interface->ifa_addr;
+          if(inet_ntop(AF_INET6, &addr6->sin6_addr, addrBuf, INET6_ADDRSTRLEN)) {
+            type = IP_ADDR_IPv6;
+          }
+        }
+        if(type) {
+          NSString *key = [NSString stringWithFormat:@"%@/%@", name, type];
+          addresses[key] = [NSString stringWithUTF8String:addrBuf];
+        }
+      }
+    }
+    // Free memory
+    freeifaddrs(interfaces);
+  }
+  return [addresses count] ? addresses : nil;
 }
 
 @end


### PR DESCRIPTION
### Motivation

Last week I was doing a debugging session with Villars and we were having trouble verifying the IP address of a device.

```
CalabashServer:223 | Creating the server: <LPHTTPServer: 0x7fd0c37300d0>
CalabashServer:224 | Calabash iOS server version: CALABASH VERSION: 0.16.4
CalabashServer:227 | App Base SDK: iphonesimulator9.0
CalabashServer:245 | Calabash iOS server is listening on: 192.168.178.31 port 37265
```

This will help debugging especially in cases where users are setting a custom port.