### PR TITLE
LPInvoker handles __self__ and __nil__ tokens in arguments

### DIFF
--- a/XCTest/Tests/Invoker/InvokerFactory.h
+++ b/XCTest/Tests/Invoker/InvokerFactory.h
@@ -92,6 +92,7 @@ struct InvokerFactoryStruct {
 - (BOOL) selectorClass:(Class) arg;
 - (BOOL) selectorObjectPointer:(id) arg;
 - (BOOL) selectorArgumentIsSelf:(id) arg;
+- (BOOL) selectorArgumentIsNil:(id) arg;
 
 // Not Handled
 

--- a/XCTest/Tests/Invoker/InvokerFactory.m
+++ b/XCTest/Tests/Invoker/InvokerFactory.m
@@ -126,6 +126,7 @@
     @"Class" : NSStringFromSelector(@selector(selectorClass:)),
     @"object pointer" : NSStringFromSelector(@selector(selectorObjectPointer:)),
     @"self" : NSStringFromSelector(@selector(selectorArgumentIsSelf:)),
+    @"self" : NSStringFromSelector(@selector(selectorArgumentIsNil:)),
 
     // Not handled
     @"void *" : NSStringFromSelector(@selector(selectorVoidStar:)),
@@ -384,6 +385,10 @@
 
 - (BOOL) selectorArgumentIsSelf:(id) arg {
   return arg == self;
+}
+
+- (BOOL) selectorArgumentIsNil:(id) arg {
+  return arg == nil;
 }
 
 #pragma mark - Unhandled Argument Types

--- a/XCTest/Tests/Invoker/LPInvokerSelectorWithArgumentsTest.m
+++ b/XCTest/Tests/Invoker/LPInvokerSelectorWithArgumentsTest.m
@@ -342,6 +342,7 @@
   LPInvocationResult *actual =  [LPInvoker invokeSelector:selector
                                                withTarget:self.target
                                                 arguments:@[[InvokerFactory shared]]];
+
   expect(actual.value).to.equal(YES);
 }
 
@@ -350,6 +351,14 @@
   LPInvocationResult *actual =  [LPInvoker invokeSelector:selector
                                                withTarget:self.target
                                                 arguments:@[@"__self__"]];
+  expect(actual.value).to.equal(YES);
+}
+
+- (void) selfNilArg {
+  SEL selector = [InvokerFactory selectorForArgumentType:@"nil"];
+  LPInvocationResult *actual =  [LPInvoker invokeSelector:selector
+                                               withTarget:self.target
+                                                arguments:@[@"__nil__"]];
   expect(actual.value).to.equal(YES);
 }
 

--- a/calabash/Classes/Invoker/LPInvoker.m
+++ b/calabash/Classes/Invoker/LPInvoker.m
@@ -651,8 +651,12 @@ static NSString *const LPInvokerNilReference = @"__nil__";
     switch (char_encoding) {
 
       case '@': {
-        if ([argument isEqual:@"__self__"]) {
-          argument = self.target;
+        if ([argument isKindOfClass:[NSString class]]) {
+          if ([argument isEqualToString:LPInvokerSelfReference]) {
+            argument = self.target;
+          } else if ([argument isEqualToString:LPInvokerNilReference]) {
+            argument = nil;
+          }
         }
         [invocation setArgument:&argument atIndex:invocationArgIndex];
         break;

--- a/calabash/Classes/Invoker/LPInvoker.m
+++ b/calabash/Classes/Invoker/LPInvoker.m
@@ -8,6 +8,9 @@
 #import <objc/runtime.h>
 #import "LPCocoaLumberjack.h"
 
+static NSString *const LPInvokerSelfReference = @"__self__";
+static NSString *const LPInvokerNilReference = @"__nil__";
+
 @interface LPInvoker ()
 
 @property(strong, nonatomic, readonly) NSString *encodingForSelectorReturnType;


### PR DESCRIPTION
### Motivation

Support for **Expand backdoor route to handle arbitrary method signatures** #220

That PR (among other things) allows LPInvoker to handle the "\_\_nil\_\_" token as nil when passed as an argument.   The problem is that the `argument` may or may not be an instance of NSString.  In cases where the `argument` is not an NSString `isEqualToString:` raises an exception.

This PR does a check for NSString and _then_ calls `isEqualToString:` to check for the special "\_\_self\_\_" and "\_\_nil\_\_" tokens.

