### PR TITLE
Add 'shake' route to mimic shake of device on iOS9+ devices

### DIFF
--- a/LPTestTarget/FirstViewController.m
+++ b/LPTestTarget/FirstViewController.m
@@ -21,4 +21,26 @@
   [self.webView loadRequest:[NSURLRequest requestWithURL:url]];
 }
 
+- (void)motionBegan:(UIEventSubtype)motion withEvent:(UIEvent *)event
+{
+
+  if (motion == UIEventSubtypeMotionShake) {
+    [self showAlertWithMessage:@"shake detected!"];
+  }
+  [super motionBegan:motion withEvent:event];
+}
+
+
+#pragma mark - Alert messages
+
+- (void)showAlertWithMessage:(NSString *)message {
+  UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@""
+                                                      message:message
+                                                     delegate:nil
+                                            cancelButtonTitle:nil
+                                            otherButtonTitles:@"OK", nil];
+
+  [alertView show];
+}
+
 @end

--- a/XCTest/Tests/Routes/LPShakeAppRouteTest.m
+++ b/XCTest/Tests/Routes/LPShakeAppRouteTest.m
@@ -1,0 +1,64 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import <XCTest/XCTest.h>
+#import "LPShakeAppRoute.h"
+
+@interface LPShakeAppRoute (LPXCTEST)
+
+- (CGFloat) durationWithDictionary:(NSDictionary *) arguments;
+
+@end
+
+@interface LPShakeAppRouteTest : XCTestCase
+
+@property (nonatomic, strong) LPShakeAppRoute *route;
+
+@end
+
+@implementation LPShakeAppRouteTest
+
+- (void)setUp {
+  [super setUp];
+  self.route = [LPShakeAppRoute new];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  self.route = nil;
+}
+
+- (void) testSupportsMethodGET {
+  BOOL actual = [self.route supportsMethod:@"GET" atPath:nil];
+  expect(actual).to.equal(YES);
+}
+
+- (void) testSupportsNoOtherMethod {
+  BOOL actual = [self.route supportsMethod:@"POST" atPath:nil];
+  expect(actual).to.equal(NO);
+
+  actual = [self.route supportsMethod:@"FOO" atPath:nil];
+  expect(actual).to.equal(NO);
+}
+
+- (void) testDurationWithDictionaryNoDurationKey {
+  NSDictionary *dictionary = @{};
+
+  CGFloat expected = 0.1;
+  CGFloat actual = [self.route durationWithDictionary:dictionary];
+
+  expect(actual).to.equal(expected);
+}
+
+- (void) testDurationWithDictionaryDurationKey {
+  NSDictionary *dictionary = @{@"duration" : @(3.0)};
+
+  CGFloat expected = 3.0;
+  CGFloat actual = [self.route durationWithDictionary:dictionary];
+
+  expect(actual).to.equal(expected);
+}
+
+
+@end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -207,6 +207,11 @@
 		B1FBBC5B19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1FBBC5E19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1FBBC5F19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		E2F8025B1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; };
+		E2F8025C1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		E2F8025D1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		E2F8025E1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		E2F802601BE21C690000A0E4 /* LPShakeAppRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025F1BE21C690000A0E4 /* LPShakeAppRouteTest.m */; };
 		F50292971ACAD4FE00D07D31 /* LPIsWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5F2D5E11ACACF2F0027937B /* LPIsWebView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F5091BDD18C4E1D700C85307 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDE18C4E1D700C85307 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -803,6 +808,9 @@
 		B1F7721B1A22A398009A2336 /* LPUIASharedElementChannel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPUIASharedElementChannel.m; sourceTree = "<group>"; };
 		B1FBBC5919D0070000EE03CE /* LPDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPDevice.m; sourceTree = "<group>"; };
 		B1FBBC5A19D0070000EE03CE /* LPDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPDevice.h; sourceTree = "<group>"; };
+		E2F802591BE207570000A0E4 /* LPShakeAppRoute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPShakeAppRoute.h; sourceTree = "<group>"; };
+		E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPShakeAppRoute.m; sourceTree = "<group>"; };
+		E2F8025F1BE21C690000A0E4 /* LPShakeAppRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPShakeAppRouteTest.m; sourceTree = "<group>"; };
 		F500459D17D249D000B72386 /* LPGitVersionDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPGitVersionDefines.h; sourceTree = "<group>"; };
 		F5091C4618C4E1D700C85307 /* libcalabash.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcalabash.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F5097CF51B6A377E00326D6A /* LPKeyboardLanguageRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPKeyboardLanguageRoute.h; sourceTree = "<group>"; };
@@ -1373,6 +1381,8 @@
 		B184FDD014B6DB2B002A744C /* Routes */ = {
 			isa = PBXGroup;
 			children = (
+				E2F802591BE207570000A0E4 /* LPShakeAppRoute.h */,
+				E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */,
 				F57605871BCE77F000E89C97 /* LPSuspendAppRoute.h */,
 				F57605881BCE77F000E89C97 /* LPSuspendAppRoute.m */,
 				B13B7FBD1A31FE560054FFB1 /* LPDumpRoute.h */,
@@ -2002,6 +2012,7 @@
 				F54EFE8C1B5B88D500F8D665 /* LPRouterTest.m */,
 				F565B48A1B6A33600039ACFF /* LPKeyboardLanguageRouteTest.m */,
 				F57605181BCE767000E89C97 /* LPSuspendAppRouteTest.m */,
+				E2F8025F1BE21C690000A0E4 /* LPShakeAppRouteTest.m */,
 				F5A6B9711BD14EE2009FD08B /* LPReflectionRouteTest.m */,
 				F58CE49D1BD6757A0025BE67 /* LPBackdoorRouteTest.m */,
 			);
@@ -2458,6 +2469,7 @@
 				F52A26561BD02D0400AD0E36 /* LPCDataScanner.m in Sources */,
 				B15BF9A319ABB1DD00B38577 /* LPDDRange.m in Sources */,
 				F5A8B4AC1B39BFEB00F390CA /* LPTTYLogger.m in Sources */,
+				E2F8025E1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */,
 				B15BF9A419ABB1DD00B38577 /* LPHTTPAsyncFileResponse.m in Sources */,
 				B15BF9A519ABB1DD00B38577 /* LPHTTPDataResponse.m in Sources */,
 				B15BF9A619ABB1DD00B38577 /* LPHTTPDynamicFileResponse.m in Sources */,
@@ -2616,6 +2628,7 @@
 				B1D5BD9D19A23BCE0070E8CE /* LPScreenshotRoute.m in Sources */,
 				F5C04E321B33110B00F23526 /* LPDecimalRounder.m in Sources */,
 				F56592681B47E76C00C044C8 /* LPWebSocket.m in Sources */,
+				E2F8025D1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */,
 				F5F2D5EC1ACACF2F0027937B /* LPIsWebView.m in Sources */,
 				F5BA6F0C1B4E4B8200DB898F /* LPInvoker.m in Sources */,
 				B1D5BD9E19A23BCE0070E8CE /* LPAsyncPlaybackRoute.m in Sources */,
@@ -2697,6 +2710,7 @@
 				F52A26541BD02D0400AD0E36 /* LPCDataScanner.m in Sources */,
 				F5091BE718C4E1D700C85307 /* LPHTTPDynamicFileResponse.m in Sources */,
 				F5A8B4AA1B39BFEB00F390CA /* LPTTYLogger.m in Sources */,
+				E2F8025C1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */,
 				F5E2D1E418C9120E00A0D9B6 /* LPSSKeychainQuery.m in Sources */,
 				F5091BE818C4E1D700C85307 /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */,
 				F5091BE918C4E1D700C85307 /* LPHTTPFileResponse.m in Sources */,
@@ -2933,6 +2947,7 @@
 				F5419F0D1AF3D37000EAAA66 /* LPJSONUtils_AccessibilityElementTest.m in Sources */,
 				F50CBF7A1A040511004AC9DA /* LPTouchUtils.m in Sources */,
 				F50CBFAC1A0405B2004AC9DA /* LPMapRoute.m in Sources */,
+				E2F802601BE21C690000A0E4 /* LPShakeAppRouteTest.m in Sources */,
 				F50CBFC01A0405CE004AC9DA /* UIScriptASTFirst.m in Sources */,
 				F50CBFBD1A0405CE004AC9DA /* UIScriptASTALL.m in Sources */,
 				F50CBF811A040564004AC9DA /* LPGCDAsyncSocket.m in Sources */,
@@ -2942,6 +2957,7 @@
 				B15369FD1A327A400093923F /* LPUIATapRouteOverSharedElement.m in Sources */,
 				F5C224E01AD473F0001DB4FA /* LPDeviceTest.m in Sources */,
 				F54EFE8D1B5B88D500F8D665 /* LPRouterTest.m in Sources */,
+				E2F8025B1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */,
 				F50CBF7D1A040564004AC9DA /* LPSSKeychainQuery.m in Sources */,
 				F50CBF9C1A04058C004AC9DA /* LPRecorder.m in Sources */,
 				F50CBF7C1A040564004AC9DA /* LPSSKeychain.m in Sources */,

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -207,7 +207,7 @@
 		B1FBBC5B19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1FBBC5E19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B1FBBC5F19D0070000EE03CE /* LPDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = B1FBBC5919D0070000EE03CE /* LPDevice.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		E2F8025B1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; };
+		E2F8025B1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		E2F8025C1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		E2F8025D1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		E2F8025E1BE207670000A0E4 /* LPShakeAppRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeAppRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -40,6 +40,7 @@
 #import "LPASLLogFormatter.h"
 #import "LPProcessInfoRoute.h"
 #import "LPDevice.h"
+#import "LPShakeAppRoute.h"
 #import "LPSuspendAppRoute.h"
 #import "LPReflectionRoute.h"
 
@@ -188,6 +189,10 @@
     LPProcessInfoRoute *processInfoRoute = [LPProcessInfoRoute new];
     [LPRouter addRoute:processInfoRoute forPath:@"process-info"];
     [processInfoRoute release];
+
+    LPShakeAppRoute *shakeAppRoute = [LPShakeAppRoute new];
+    [LPRouter addRoute:shakeAppRoute forPath:@"shake"];
+    [shakeAppRoute release];
 
     LPSuspendAppRoute *suspendAppRoute = [LPSuspendAppRoute new];
     [LPRouter addRoute:suspendAppRoute forPath:@"suspend"];

--- a/calabash/Classes/FranklyServer/Routes/LPShakeAppRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPShakeAppRoute.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "LPRoute.h"
+
+@interface LPShakeAppRoute : NSObject <LPRoute>
+
+@end

--- a/calabash/Classes/FranklyServer/Routes/LPShakeAppRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPShakeAppRoute.m
@@ -1,0 +1,61 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import <UIKit/UIKit.h>
+#import "LPShakeAppRoute.h"
+#import "LPCocoaLumberjack.h"
+
+@interface UIApplication (LP_SUSPEND_APP_CATEGORY)
+
+- (void) shake;
+
+@end
+
+@interface LPShakeAppRoute ()
+
+- (CGFloat) durationWithDictionary:(NSDictionary *) arguments;
+
+@end
+
+@implementation LPShakeAppRoute
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"GET"];
+}
+
+- (CGFloat) durationWithDictionary:(NSDictionary *) arguments {
+  NSNumber *durationNumber = [arguments objectForKey:@"duration"];
+  if (durationNumber) {
+    return [durationNumber doubleValue];
+  } else {
+    return 0.1;
+  }
+}
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                     data:(NSDictionary *) data {
+
+  CGFloat duration = [self durationWithDictionary:data];
+
+  LPLogDebug(@"Shaking device for %d seconds.", duration);
+
+  UIEvent *m = [[NSClassFromString(@"UIMotionEvent") alloc] init];
+  [m setValue:[NSNumber numberWithInt:UIEventSubtypeMotionShake] forKey:@"_subtype"];
+
+  [[UIApplication sharedApplication] sendEvent:m];
+  [[UIApplication sharedApplication].keyWindow motionBegan:UIEventSubtypeMotionShake withEvent:m];
+
+  dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW,
+                                       (int64_t)(duration * NSEC_PER_SEC));
+  dispatch_queue_t queue = dispatch_get_main_queue();
+
+  dispatch_after(when, queue, ^{
+    [[UIApplication sharedApplication].keyWindow motionEnded:UIEventSubtypeMotionShake withEvent:m];
+  });
+
+  return @{@"outcome" : @"SUCCESS", @"duration": @(duration)};
+}
+
+@end

--- a/calabash/Classes/FranklyServer/Routes/LPShakeAppRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPShakeAppRoute.m
@@ -6,7 +6,7 @@
 #import "LPShakeAppRoute.h"
 #import "LPCocoaLumberjack.h"
 
-@interface UIApplication (LP_SUSPEND_APP_CATEGORY)
+@interface UIApplication (LP_SHAKE_APP_CATEGORY)
 
 - (void) shake;
 
@@ -39,7 +39,7 @@
 
   CGFloat duration = [self durationWithDictionary:data];
 
-  LPLogDebug(@"Shaking device for %d seconds.", duration);
+  LPLogDebug(@"Shaking device for %f seconds.", duration);
 
   UIEvent *m = [[NSClassFromString(@"UIMotionEvent") alloc] init];
   [m setValue:[NSNumber numberWithInt:UIEventSubtypeMotionShake] forKey:@"_subtype"];

--- a/cucumber/features/shake.feature
+++ b/cucumber/features/shake.feature
@@ -1,0 +1,6 @@
+Feature: Shake
+
+Scenario: Mimic shake on device
+  Given the app has launched
+  When I shake the device
+  Then I should see the "shake detected!" alert

--- a/cucumber/features/steps/alert_steps.rb
+++ b/cucumber/features/steps/alert_steps.rb
@@ -1,0 +1,83 @@
+
+def alert_exists?(alert_title=nil)
+  if alert_title.nil?
+    res = uia('uia.alert() != null')
+  else
+    if ios6?
+      res = uia("uia.alert().staticTexts()['#{alert_title}'].label()")
+    else
+      res = uia("uia.alert().name() == '#{alert_title}'")
+    end
+  end
+
+  if res['status'] == 'success'
+    res['value']
+  else
+    false
+  end
+end
+
+def wait_for_alert
+  timeout = 4
+  message = "Waited #{timeout} seconds for an alert to appear"
+  options = {timeout: timeout, timeout_message: message}
+
+  wait_for(options) do
+    alert_exists?
+  end
+end
+
+def alert_view_query_str
+  if ios8? || ios9?
+    "view:'_UIAlertControllerView'"
+  elsif ios7?
+    "view:'_UIModalItemAlertContentView'"
+  else
+    'UIAlertView'
+  end
+end
+
+def alert_button_views
+  wait_for_alert
+
+  if ios8? || ios9?
+    query = "view:'_UIAlertControllerActionView'"
+  elsif ios7?
+    query = "view:'_UIModalItemAlertContentView' descendant UITableView descendant label"
+  else
+    query = 'UIAlertView descendant button'
+  end
+  query(query)
+end
+
+def alert_button_titles
+  alert_button_views.map { |res| res['label'] }.compact
+end
+
+def all_alert_labels
+  wait_for_alert
+  query = "#{alert_view_query_str} descendant label"
+  query(query)
+end
+
+def non_alert_button_views
+  button_titles = alert_button_titles()
+  all_labels = all_alert_labels()
+  all_labels.select do |res|
+    !button_titles.include?(res['label']) &&
+          res['label'] != nil
+  end
+end
+
+def alert_message
+  with_max_y = non_alert_button_views.max_by do |res|
+    res['rect']['y']
+  end
+
+  with_max_y['label']
+end
+
+Then(/^I (should )?see the "([^"]*)" alert$/) do |_should, message|
+  wait_for_alert
+  expect(alert_message).to be == message
+end

--- a/cucumber/features/steps/shake_steps.rb
+++ b/cucumber/features/steps/shake_steps.rb
@@ -1,0 +1,4 @@
+
+When(/^I shake the device$/) do
+  http({:method => :get, :path => 'shake'})
+end


### PR DESCRIPTION
As discussed in https://github.com/calabash/calabash-ios/issues/873

iOS9+ devices have no ability to mimic shake via UIAutomation, I've filed radar://22796974 but no response.

In the meantime here is an implementation to mimic the shake. I've tested on simulator, but not on device yet. I haven't been able to get the tests running on this suite, I assume I'm missing a dependency or something?

<img width="697" alt="screen shot 2015-10-29 at 8 34 02 pm" src="https://cloud.githubusercontent.com/assets/19973/10814864/98d1e104-7e7c-11e5-8da0-ff8dd62d90cd.png">

This should only be used for iOS9+ devices as `target.shake()` continues to work for iOS 8.4 and below (even in XCode 7.1).