### PR TITLE
ARM builds are forced to emit bitcode

### DIFF
--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -128,6 +128,9 @@ xcrun xcodebuild install \
   ARCHS="armv7 armv7s arm64" \
   VALID_ARCHS="armv7 armv7s arm64" \
   ONLY_ACTIVE_ARCH=NO \
+  OTHER_CFLAGS="-fembed-bitcode" \
+  DEPLOYMENT_POSTPROCESSING=YES \
+  ENABLE_BITCODE=YES \
   -sdk iphoneos \
   IPHONE_DEPLOYMENT_TARGET=6.0 \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \

--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -32,6 +32,17 @@ function ditto_or_exit {
   fi
 }
 
+function xcode_gte_7 {
+ XC_MAJOR=`xcrun xcodebuild -version | awk 'NR==1{print $2}' | awk -v FS="." '{ print $1 }'`
+ if [ "${XC_MAJOR}" \> "7" -o "${XC_MAJOR}" = "7" ]; then
+   echo "true"
+ else
+   echo "false"
+ fi
+}
+
+XC_GTE_7=$(xcode_gte_7)
+
 XC_TARGET=calabash-dylib
 XC_PROJECT=calabash.xcodeproj
 XC_SCHEME=calabash-dylib
@@ -119,6 +130,10 @@ rm -rf "${ARM_LIBRARY_XC7}"
 ARM_LIBRARY_XC6="${ARM_BUILD_DIR}/Build/Products/${XC_BUILD_CONFIG}-iphoneos/${LIBRARY_NAME}"
 rm -rf "${ARM_LIBRARY_XC6}"
 
+if [ "${XC_GTE_7}" = "true" ]; then
+  XC7_FLAGS="OTHER_CFLAGS=\"-fembed-bitcode\" DEPLOYMENT_POSTPROCESSING=YES ENABLE_BITCODE=YES"
+fi
+
 xcrun xcodebuild install \
   -project "${XC_PROJECT}" \
   -scheme "${XC_SCHEME}" \
@@ -127,11 +142,7 @@ xcrun xcodebuild install \
   -configuration "${XC_BUILD_CONFIG}" \
   ARCHS="armv7 armv7s arm64" \
   VALID_ARCHS="armv7 armv7s arm64" \
-  ONLY_ACTIVE_ARCH=NO \
-  OTHER_CFLAGS="-fembed-bitcode" \
-  DEPLOYMENT_POSTPROCESSING=YES \
-  ENABLE_BITCODE=YES \
-  -sdk iphoneos \
+  ${XC7_FLAGS} -sdk iphoneos \
   IPHONE_DEPLOYMENT_TARGET=6.0 \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \
   GCC_GENERATE_TEST_COVERAGE_FILES=NO \
@@ -229,7 +240,34 @@ banner "Dylib Info"
 VERSION=`xcrun strings "${INSTALL_DIR}/libCalabashDynSim.dylib" | grep -E 'CALABASH VERSION' | head -1 | grep -oEe '\d+\.\d+\.\d+' | tr -d '\n'`
 echo "Built version:  $VERSION"
 
-lipo -info "${INSTALL_DIR}/libCalabashDynSim.dylib"
+lipo -info "${INSTALL_DIR}/libCalabashDyn.dylib"
 lipo -info "${INSTALL_DIR}/libCalabashDynSim.dylib"
 lipo -info "${INSTALL_DIR}/libCalabashDynFAT.dylib"
+
+if [ "${XC_GTE_7}"  = "true" ]; then
+
+  xcrun otool -arch arm64 -l "${INSTALL_DIR}/libCalabashDyn.dylib" | grep -q LLVM
+  if [ $? -eq 0 ]; then
+    echo "libCalabashDyn.dylib contains bitcode for arm64"
+  else
+    echo "libCalabashDyn.dylib does not contain bitcode for arm64"
+    exit 1
+  fi
+
+  xcrun otool -arch armv7s -l "${INSTALL_DIR}/libCalabashDyn.dylib" | grep -q LLVM
+  if [ $? -eq 0 ]; then
+    echo "libCalabashDyn.dylib contains bitcode for armv7s"
+  else
+    echo "libCalabashDyn.dylib does not contain bitcode for armv7s"
+    exit 1
+  fi
+
+  xcrun otool -arch armv7 -l "${INSTALL_DIR}/libCalabashDyn.dylib" | grep -q LLVM
+  if [ $? -eq 0 ]; then
+    echo "libCalabashDyn.dylib contains bitcode for armv7"
+  else
+    echo "libCalabashDyn.dylib does not contain bitcode for armv7"
+    exit 1
+  fi
+fi
 

--- a/bin/make/framework.sh
+++ b/bin/make/framework.sh
@@ -129,6 +129,9 @@ xcrun xcodebuild install \
   ARCHS="armv7 armv7s arm64" \
   VALID_ARCHS="armv7 armv7s arm64" \
   ONLY_ACTIVE_ARCH=NO \
+  OTHER_CFLAGS="-fembed-bitcode" \
+  DEPLOYMENT_POSTPROCESSING=YES \
+  ENABLE_BITCODE=YES \
   -sdk iphoneos \
   IPHONE_DEPLOYMENT_TARGET=6.0 \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \

--- a/bin/make/framework.sh
+++ b/bin/make/framework.sh
@@ -29,6 +29,17 @@ function ditto_or_exit {
   fi
 }
 
+function xcode_gte_7 {
+ XC_MAJOR=`xcrun xcodebuild -version | awk 'NR==1{print $2}' | awk -v FS="." '{ print $1 }'`
+ if [ "${XC_MAJOR}" \> "7" -o "${XC_MAJOR}" = "7" ]; then
+   echo "true"
+ else
+   echo "false"
+ fi
+}
+
+XC_GTE_7=$(xcode_gte_7)
+
 XC_TARGET=calabash
 XC_PROJECT=calabash.xcodeproj
 XC_SCHEME=calabash
@@ -120,6 +131,10 @@ rm -rf "${ARM_LIBRARY_XC7}"
 ARM_LIBRARY_XC6="${ARM_BUILD_DIR}/Build/Intermediates/UninstalledProducts/${LIBRARY_NAME}"
 rm -rf "${ARM_LIBRARY_XC6}"
 
+if [ "${XC_GTE_7}" = "true" ]; then
+  XC7_FLAGS="OTHER_CFLAGS=\"-fembed-bitcode\" DEPLOYMENT_POSTPROCESSING=YES ENABLE_BITCODE=YES"
+fi
+
 xcrun xcodebuild install \
   -project "${XC_PROJECT}" \
   -scheme "${XC_SCHEME}" \
@@ -128,11 +143,7 @@ xcrun xcodebuild install \
   -configuration "${XC_BUILD_CONFIG}" \
   ARCHS="armv7 armv7s arm64" \
   VALID_ARCHS="armv7 armv7s arm64" \
-  ONLY_ACTIVE_ARCH=NO \
-  OTHER_CFLAGS="-fembed-bitcode" \
-  DEPLOYMENT_POSTPROCESSING=YES \
-  ENABLE_BITCODE=YES \
-  -sdk iphoneos \
+  ${XC7_FLAGS} -sdk iphoneos \
   IPHONE_DEPLOYMENT_TARGET=6.0 \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \
   GCC_GENERATE_TEST_COVERAGE_FILES=NO \
@@ -234,4 +245,31 @@ fi
 
 echo "Built version: `./${INSTALLED_FRAMEWORK}/Resources/version | tr -d '\n'`"
 lipo -info "${INSTALLED_FRAMEWORK}/calabash"
+
+if [ "${XC_GTE_7}"  = "true" ]; then
+
+  xcrun otool -arch arm64 -l calabash.framework/calabash | grep -q bitcode
+  if [ $? -eq 0 ]; then
+    echo "calabash.framework/calabash contains bitcode for arm64"
+  else
+    echo "calabash.framework/calabash does not contain bitcode for arm64"
+    exit 1
+  fi
+
+  xcrun otool -arch armv7s -l calabash.framework/calabash | grep -q bitcode
+  if [ $? -eq 0 ]; then
+    echo "calabash.framework/calabash contains bitcode for armv7s"
+  else
+    echo "calabash.framework/calabash does not contain bitcode for armv7s"
+    exit 1
+  fi
+
+  xcrun otool -arch armv7 -l calabash.framework/calabash | grep -q bitcode
+  if [ $? -eq 0 ]; then
+    echo "calabash.framework/calabash contains bitcode for armv7"
+  else
+    echo "calabash.framework/calabash does not contain bitcode for armv7"
+    exit 1
+  fi
+fi
 

--- a/bin/make/frank-plugin.sh
+++ b/bin/make/frank-plugin.sh
@@ -29,6 +29,17 @@ function ditto_or_exit {
   fi
 }
 
+function xcode_gte_7 {
+ XC_MAJOR=`xcrun xcodebuild -version | awk 'NR==1{print $2}' | awk -v FS="." '{ print $1 }'`
+ if [ "${XC_MAJOR}" \> "7" -o "${XC_MAJOR}" = "7" ]; then
+   echo "true"
+ else
+   echo "false"
+ fi
+}
+
+XC_GTE_7=$(xcode_gte_7)
+
 XC_TARGET=calabash-plugin-for-frank
 XC_PROJECT=calabash.xcodeproj
 XC_SCHEME=calabash-plugin-for-frank
@@ -93,10 +104,10 @@ xcrun xcodebuild build \
 EXIT_CODE=${PIPESTATUS[0]}
 
 if [ $EXIT_CODE != 0 ]; then
-  error "Building simulator library for framework failed."
+  error "Building simulator library for frank plug-in failed."
   exit $RETVAL
 else
-  info "Building simulator library for framework succeeded."
+  info "Building simulator library for frank plug-in succeeded."
 fi
 
 ditto_or_exit "${SIM_LIBRARY}" "${SIM_PRODUCTS_DIR}/${LIBRARY_NAME}"
@@ -112,6 +123,10 @@ rm -rf "${ARM_LIBRARY_XC7}"
 ARM_LIBRARY_XC6="${ARM_BUILD_DIR}/Build/Intermediates/UninstalledProducts/${LIBRARY_NAME}"
 rm -rf "${ARM_LIBRARY_XC6}"
 
+if [ "${XC_GTE_7}" = "true" ]; then
+  XC7_FLAGS="OTHER_CFLAGS=\"-fembed-bitcode\" DEPLOYMENT_POSTPROCESSING=YES ENABLE_BITCODE=YES"
+fi
+
 xcrun xcodebuild install \
   -project "${XC_PROJECT}" \
   -scheme "${XC_SCHEME}" \
@@ -121,10 +136,7 @@ xcrun xcodebuild install \
   ARCHS="armv7 armv7s arm64" \
   VALID_ARCHS="armv7 armv7s arm64" \
   ONLY_ACTIVE_ARCH=NO \
-  OTHER_CFLAGS="-fembed-bitcode" \
-  DEPLOYMENT_POSTPROCESSING=YES \
-  ENABLE_BITCODE=YES \
-  -sdk iphoneos \
+  ${XC7_FLAGS} -sdk iphoneos \
   IPHONE_DEPLOYMENT_TARGET=6.0 \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \
   GCC_GENERATE_TEST_COVERAGE_FILES=NO \
@@ -168,3 +180,29 @@ VERSION=`xcrun strings "${INSTALLED_LIBRARY}" | grep -E 'CALABASH VERSION' | hea
 echo "Built version:  $VERSION"
 lipo -info "${INSTALLED_LIBRARY}"
 
+if [ "${XC_GTE_7}"  = "true" ]; then
+
+  xcrun otool -arch arm64 -l "${INSTALLED_LIBRARY}" | grep -q bitcode
+  if [ $? -eq 0 ]; then
+    echo "${LIBRARY_NAME} contains bitcode for arm64"
+  else
+    echo "${LIBRARY_NAME} does not contain bitcode for arm64"
+    exit 1
+  fi
+
+  xcrun otool -arch armv7s -l "${INSTALLED_LIBRARY}" | grep -q bitcode
+  if [ $? -eq 0 ]; then
+    echo "${LIBRARY_NAME} contains bitcode for armv7s"
+  else
+    echo "calabash.framework/calabash does not contain bitcode for armv7s"
+    exit 1
+  fi
+
+  xcrun otool -arch armv7s -l "${INSTALLED_LIBRARY}" | grep -q bitcode
+  if [ $? -eq 0 ]; then
+    echo "${LIBRARY_NAME} contains bitcode for armv7"
+  else
+    echo "${LIBRARY_NAME} does not contain bitcode for armv7"
+    exit 1
+  fi
+fi

--- a/bin/make/frank-plugin.sh
+++ b/bin/make/frank-plugin.sh
@@ -121,6 +121,9 @@ xcrun xcodebuild install \
   ARCHS="armv7 armv7s arm64" \
   VALID_ARCHS="armv7 armv7s arm64" \
   ONLY_ACTIVE_ARCH=NO \
+  OTHER_CFLAGS="-fembed-bitcode" \
+  DEPLOYMENT_POSTPROCESSING=YES \
+  ENABLE_BITCODE=YES \
   -sdk iphoneos \
   IPHONE_DEPLOYMENT_TARGET=6.0 \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -3256,7 +3256,6 @@
 				MACOSX_DEPLOYMENT_TARGET = "";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
-				"OTHER_CFLAGS[sdk=iphoneos9.0]" = "-fembed-bitcode";
 				PRODUCT_NAME = "calabash-dylib";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
@@ -3366,7 +3365,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = "";
 				OTHER_CFLAGS = "";
-				"OTHER_CFLAGS[sdk=iphoneos9.0]" = "-fembed-bitcode";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "calabash-plugin-for-frank";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)Headers";
@@ -3489,7 +3487,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = "";
 				OTHER_CFLAGS = "";
-				"OTHER_CFLAGS[sdk=iphoneos9.0]" = "-fembed-bitcode";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = calabash;
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)Headers";
@@ -3905,7 +3902,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = "";
 				OTHER_CFLAGS = "";
-				"OTHER_CFLAGS[sdk=iphoneos9.0]" = "-fembed-bitcode";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = calabash;
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)Headers";
@@ -3967,7 +3963,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = "";
 				OTHER_CFLAGS = "";
-				"OTHER_CFLAGS[sdk=iphoneos9.0]" = "-fembed-bitcode";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "calabash-plugin-for-frank";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)Headers";
@@ -4020,7 +4015,6 @@
 				MACOSX_DEPLOYMENT_TARGET = "";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
-				"OTHER_CFLAGS[sdk=iphoneos9.0]" = "-fembed-bitcode";
 				PRODUCT_NAME = "calabash-dylib";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
### Motivation

By default xcodebuild only generates bitcode during an Archive action.  This PR adds additional build settings to coerce Xcode into generating bitcode for Debug builds.

There previous build settings inside Xcode where inadequate - the only SDK with the `-fembed-bitcode` option was iphoneos 9.0; no other iOS version had the correct flag.

The make rules check for bitcode in the built libraries.  Detecting bitcode in the dylibs is a little strange.  The string "bitcode" does not appear in the dylib load commands, but LLVM does - but only for the arm* libraries.

@sapieneptus I generated the FAT dylib yesterday from this branch.

Many thanks to @hilli for his help simplifying the bash scripts.