### PR TITLE
Cucumber: add @shake feature to quarantine

### DIFF
--- a/cucumber/features/shake.feature
+++ b/cucumber/features/shake.feature
@@ -1,3 +1,4 @@
+@quarantine
 @shake
 Feature: Shake
 


### PR DESCRIPTION
### Motivation

`shake` is causing app crashes on certain Xcode and iOS combinations [#968](https://github.com/calabash/calabash-ios/issues/968)

This should not block a 0.17.1 release.