### PR TITLE
Make: add xctests rule from running XCTest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ webquery_header:
 	bundle exec bin/make/insert-js-into-webquery-header.rb
 
 xct:
+	$(MAKE) xctests
+
+xctests:
 	bundle exec bin/test/xctest.rb
 
 # Makes the LPTestTarget.app without Calabash linked.


### PR DESCRIPTION
### Motivation

More than once I have instructed users to run `make xtc` instead of `make xct`.

The xct remains, but is now an alias for xctests.

FYI/BTW, 'make xctest' was my first choice, but this conflicts with
make's behavior:  if a directory with same name as the rule exists
the rule will exit "xctest is up to date".  The XCTests are in a
directory called 'XCTest'.