### PR TITLE
LPConstants: prefer NSString *const pattern

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPConstants.h
+++ b/calabash/Classes/FranklyServer/Operations/LPConstants.h
@@ -8,11 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *NODE_NAME_KEY;
-extern NSString *IFRAME_KEY;
-extern NSString *WEBVIEW_KEY;
-extern NSString *QUERY_KEY;
-extern NSString *QUERY_TYPE_KEY;
-extern NSString *IFRAME_INFO_KEY;
+extern NSString *const NODE_NAME_KEY;
+extern NSString *const IFRAME_KEY;
+extern NSString *const WEBVIEW_KEY;
+extern NSString *const QUERY_KEY;
+extern NSString *const QUERY_TYPE_KEY;
+extern NSString *const IFRAME_INFO_KEY;
 
-extern NSString *WEBVIEW_DOCUMENT_FRAME_SELECTOR;
+extern NSString *const WEBVIEW_DOCUMENT_FRAME_SELECTOR;

--- a/calabash/Classes/FranklyServer/Operations/LPConstants.m
+++ b/calabash/Classes/FranklyServer/Operations/LPConstants.m
@@ -8,11 +8,11 @@
 
 #import "LPConstants.h"
 
-const NSString *NODE_NAME_KEY = @"nodeName";
-const NSString *IFRAME_KEY = @"IFRAME";
-const NSString *WEBVIEW_KEY = @"webView";
-const NSString *QUERY_KEY = @"iframe_query";
-const NSString *QUERY_TYPE_KEY = @"iframe_query_type";
-const NSString *IFRAME_INFO_KEY = @"iframe_info";
+NSString *const NODE_NAME_KEY = @"nodeName";
+NSString *const IFRAME_KEY = @"IFRAME";
+NSString *const WEBVIEW_KEY = @"webView";
+NSString *const QUERY_KEY = @"iframe_query";
+NSString *const QUERY_TYPE_KEY = @"iframe_query_type";
+NSString *const IFRAME_INFO_KEY = @"iframe_info";
 
-const NSString *WEBVIEW_DOCUMENT_FRAME_SELECTOR = nil;
+NSString *const WEBVIEW_DOCUMENT_FRAME_SELECTOR = nil;


### PR DESCRIPTION
### Motivation

I am hazy on the details, but I believe this is the correct way to declare extern'd constants.

This is non-blocking.  Feel free to close if you are not convinced or can argue against.