### PR TITLE
Fix LPScrollOperation for WebView

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -13,6 +13,7 @@
 #import "LPIsWebView.h"
 #import "LPWebViewProtocol.h"
 #import "LPCocoaLumberjack.h"
+#import "LPJSONUtils.h"
 
 @implementation LPScrollOperation
 
@@ -60,7 +61,7 @@
 
     [sv setContentOffset:point animated:YES];
 
-    return target;
+    return [LPJSONUtils jsonifyObject:target];
   } else if ([LPIsWebView isWebView:target]) {
     NSString *scrollJS = @"window.scrollBy(%@,%@);";
     if ([@"up" isEqualToString:dir]) {
@@ -74,7 +75,8 @@
     }
 
     [target calabashStringByEvaluatingJavaScript:scrollJS];
-    return target;
+
+    return [LPJSONUtils jsonifyObject:target];
   }
   return nil;
 }

--- a/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollOperation.m
@@ -72,6 +72,8 @@
     } else {
       scrollJS = [NSString stringWithFormat:scrollJS, @"100", @"0"];
     }
+
+    [target calabashStringByEvaluatingJavaScript:scrollJS];
     return target;
   }
   return nil;


### PR DESCRIPTION
### Motivation

The CalWebApp has been failing because scrolling stopped working.

I introduced a bug in October 2015 that caused this.

Fixes **Scrolling on UIWebView and WKWebView is not work working in iOS 9** [#980](https://github.com/calabash/calabash-ios/issues/980)

Discovered this by running the static analyzer.

* build scripts should run the static analyzer #320