### PR TITLE
LPTestTarget: reesign embedded dylibs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ If you are running the XCTests from Xcode, you might see failures in
 `LPJSONUtilsTest`.  If you do, clean (Shift + Option + Command + K)
 and rerun.
 
+If you want to test the LPTestTarget on device and are having problems
+in Xcode or the command line with messages like this:
+
+```
+iPhone Developer: ambiguous matches
+```
+
+then you must either:
+
+1. `$ CODE_SIGN_IDENTITY="< cert name >" make ipa-cal` (preferred)
+2. Update the Xcode project with a specific Code Signing entity.  **DO
+   NOT CHECK THESE CHANGES INTO GIT.**
+
+Maintainers should be using the Calabash.keychain
+(calabash/calabash-codesign).
+
 ### Contributing
 
 * The Calabash iOS Toolchain uses git-flow.

--- a/bin/xcode-build-phase/lptesttarget-sign-dylibs.sh
+++ b/bin/xcode-build-phase/lptesttarget-sign-dylibs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# If you see an error like this:
+#
+# iPhone Developer: ambiguous (matches "iPhone Developer: Person A (2<snip>Q)"
+#                                  and "iPhone Developer: Person B (8<snip>F)"
+# in /Users/<snip>/Library/Keychains/login.keychain)
+#
+# Uncomment this line and update it with the correct credentials.
+# CODE_SIGN_IDENTITY="iPhone Developer: Person B (8<snip>F)"
+
+set -e
+
+BUNDLE_PATH="${BUILT_PRODUCTS_DIR}/${FULL_PRODUCT_NAME}"
+
+BAD="${BUNDLE_PATH}/badPlugin.dylib"
+EXAMPLE="${BUNDLE_PATH}/examplePlugin.dylib"
+EXAMPLE_CAL="${BUNDLE_PATH}/examplePluginCalabash.dylib"
+MEMORY="${BUNDLE_PATH}/memoryPlugin.dylib"
+MEMORY_CAL="${BUNDLE_PATH}/memoryPluginCalabash.dylib"
+
+if [ -n "${CODE_SIGN_IDENTITY}" ]; then
+  xcrun codesign -fs "${CODE_SIGN_IDENTITY}" "${BAD}"
+  xcrun codesign -fs "${CODE_SIGN_IDENTITY}" "${EXAMPLE}"
+  xcrun codesign -fs "${CODE_SIGN_IDENTITY}" "${EXAMPLE_CAL}"
+  xcrun codesign -fs "${CODE_SIGN_IDENTITY}" "${MEMORY}"
+  xcrun codesign -fs "${CODE_SIGN_IDENTITY}" "${MEMORY_CAL}"
+fi
+

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -2253,6 +2253,7 @@
 				F59CA4691A82EF40007A2F38 /* Sources */,
 				F59CA46A1A82EF40007A2F38 /* Frameworks */,
 				F59CA46B1A82EF40007A2F38 /* Resources */,
+				F563A5461C57BF60005EE33F /* Run Script Sign Embedded Dylibs */,
 				F596A20B1BE3930B00E4E35B /* Run Script stage binaries to ./Products */,
 				F5E2A5EF1BFF090F0068DFAD /* Run Script  Checkout LPTestTarget/change-sha.plist */,
 			);
@@ -2438,6 +2439,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh calabash/gitversioning-after.sh \"calabash/LPGitVersionDefines.h\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F563A5461C57BF60005EE33F /* Run Script Sign Embedded Dylibs */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script Sign Embedded Dylibs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bin/xcode-build-phase/lptesttarget-sign-dylibs.sh";
 			showEnvVarsInLog = 0;
 		};
 		F596A20B1BE3930B00E4E35B /* Run Script stage binaries to ./Products */ = {


### PR DESCRIPTION
### Motivation

* calabash-ios-server: 0.18.0 release [#94](https://github.com/xamarinhq/test-cloud-frameworks/issues/94)
* LPTestTarget: embedded plug-ins are not signed correctly #323