### PR TITLE
Bonjour: create a unique service instance name

### DIFF
--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -204,7 +204,11 @@
 
     _httpServer = [[[LPHTTPServer alloc] init] retain];
 
-    [_httpServer setName:@"Calabash Server"];
+    NSString *uuid = [[NSProcessInfo processInfo] globallyUniqueString];
+    NSString *token = [uuid componentsSeparatedByString:@"-"][0];
+    NSString *serverName = [NSString stringWithFormat:@"CalabashServer-%@", token];
+    [_httpServer setName:serverName];
+
     [_httpServer setType:@"_http._tcp."];
     [_httpServer setConnectionClass:[LPRouter class]];
 


### PR DESCRIPTION
### Motivation

Having a unique instance name  makes automatic Bonjour service discovery possible.