### PR TITLE
Screenshot: use drawViewHierarchy when possible

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -32,7 +32,14 @@
 
 - (NSData *) takeScreenshot {
 
-  CGSize imageSize = [[UIScreen mainScreen] bounds].size;
+
+  // Available on iOS >= 7
+  SEL selector = @selector(drawViewHierarchyInRect:afterScreenUpdates:);
+  UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
+  BOOL drawViewHierarchy = [view respondsToSelector:selector];
+
+  CGRect bounds = [[UIScreen mainScreen] bounds];
+  CGSize imageSize = bounds.size;
   UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
 
   CGContextRef context = UIGraphicsGetCurrentContext();
@@ -52,8 +59,12 @@
                             -[window bounds].size.width * [[window layer] anchorPoint].x,
                             -[window bounds].size.height * [[window layer] anchorPoint].y);
 
-      // Render the layer hierarchy to the current context
-      [[window layer] renderInContext:context];
+      if (drawViewHierarchy) {
+        [window drawViewHierarchyInRect:bounds afterScreenUpdates:YES];
+      } else {
+        // Render the layer hierarchy to the current context
+        [[window layer] renderInContext:context];
+      }
 
       // Restore the context
       CGContextRestoreGState(context);


### PR DESCRIPTION
### Motivation

Resolves:

* screenshot does not capture all views; e.g. custom keyboards and OpenGL views [#789](https://github.com/calabash/calabash-ios/issues/789)
* screenshot route should use drawViewHierarchyInRect:afterScreenUpdates: for iOS 7 [#347](https://github.com/calabash/calabash-ios/issues/347)
* iOS - OpenGL views don't show up in screenshots taken locally (device or simulator), but they do in screenshots taken in the cloud [#134](https://github.com/xamarinhq/test-cloud-frameworks/issues/134)

We've known for a while that the screenshot route does not capture OpenGL - @Clancey demonstrated this at the last Xummit (back in April 2014).  We've been reluctant to change the behavior because of the quality of screenshots when UIAlertView and UIActionSheet are showing.  It seems that this problem has been resolved - at least on iOS 9 simulators and devices.

Can you review Chris? 