### PR TITLE
LPJSONUtils: set max and min float to avoid JSON parse errors

### DIFF
--- a/XCTest/Tests/Utils/LPJSONUtilsTest.m
+++ b/XCTest/Tests/Utils/LPJSONUtilsTest.m
@@ -776,10 +776,10 @@
   NSDictionary *dict = [LPJSONUtils dictionaryByEncodingView:view];
 
   XCTAssertEqual(((NSDictionary *)[dict objectForKey:@"frame"]).count, 4);
-  XCTAssertEqualObjects(dict[@"frame"][@"x"], @(CGFLOAT_MIN));
-  XCTAssertEqualObjects(dict[@"frame"][@"y"], @(CGFLOAT_MAX));
-  XCTAssertEqualObjects(dict[@"frame"][@"width"], @(CGFLOAT_MAX));
-  XCTAssertEqualObjects(dict[@"frame"][@"height"], @(CGFLOAT_MIN));
+  XCTAssertEqualObjects(dict[@"frame"][@"x"], @(LP_MIN_FLOAT));
+  XCTAssertEqualObjects(dict[@"frame"][@"y"], @(LP_MAX_FLOAT));
+  XCTAssertEqualObjects(dict[@"frame"][@"width"], @(LP_MAX_FLOAT));
+  XCTAssertEqualObjects(dict[@"frame"][@"height"], @(LP_MIN_FLOAT));
 
 
   XCTAssertEqualObjects(dict[@"visible"], @(0));
@@ -891,25 +891,25 @@ describe(@"LPJSONUtils", ^{
     it(@"returns CGFLOAT_MAX if infinite and INFINITY", ^{
       CGFloat value = INFINITY;
       NSNumber *number = [LPJSONUtils normalizeFloat:value];
-      expect(number).to.equal(@(CGFLOAT_MAX));
+      expect(number).to.equal(@(LP_MAX_FLOAT));
     });
 
     it(@"returns CGFLOAT_MIN if infinite and -INFINITY", ^{
       CGFloat value = -INFINITY;
       NSNumber *number = [LPJSONUtils normalizeFloat:value];
-      expect(number).to.equal(@(CGFLOAT_MIN));
+      expect(number).to.equal(@(LP_MIN_FLOAT));
     });
 
     it(@"returns CGFLOAT_MAX if it is float max", ^{
       CGFloat value = CGFLOAT_MAX;
       NSNumber *number = [LPJSONUtils normalizeFloat:value];
-      expect(number).to.equal(@(CGFLOAT_MAX));
+      expect(number).to.equal(@(LP_MAX_FLOAT));
     });
 
     it(@"returns CGFLOAT_MIN if it is float min", ^{
       CGFloat value = CGFLOAT_MIN;
       NSNumber *number = [LPJSONUtils normalizeFloat:value];
-      expect(number).to.equal(@(CGFLOAT_MIN));
+      expect(number).to.equal(@(LP_MIN_FLOAT));
     });
   });
 });

--- a/calabash/Classes/Utils/LPJSONUtils.h
+++ b/calabash/Classes/Utils/LPJSONUtils.h
@@ -4,7 +4,7 @@
 //  Copyright 2011 LessPainful. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 extern CGFloat LP_MAX_FLOAT;
 extern CGFloat LP_MIN_FLOAT;

--- a/calabash/Classes/Utils/LPJSONUtils.h
+++ b/calabash/Classes/Utils/LPJSONUtils.h
@@ -6,6 +6,9 @@
 
 #import <Foundation/Foundation.h>
 
+extern CGFloat LP_MAX_FLOAT;
+extern CGFloat LP_MIN_FLOAT;
+
 @interface LPJSONUtils : NSObject
 
 + (NSString *) serializeDictionary:(NSDictionary *) dictionary;

--- a/calabash/Classes/Utils/LPJSONUtils.m
+++ b/calabash/Classes/Utils/LPJSONUtils.m
@@ -20,6 +20,9 @@
 #import "LPDecimalRounder.h"
 #import "LPCocoaLumberjack.h"
 
+CGFloat LP_MAX_FLOAT = INT32_MAX * 1.0;
+CGFloat LP_MIN_FLOAT = INT32_MIN * 1.0;
+
 @interface LPJSONUtils ()
 
 // If the target responds to the selector, invoke the selector on the target and
@@ -324,11 +327,15 @@
 
 + (NSNumber*)normalizeFloat:(CGFloat) x {
   if (isinf(x)) {
-    return (x == INFINITY ? @(CGFLOAT_MAX) : @(CGFLOAT_MIN));
+    return (x == INFINITY ? @(LP_MAX_FLOAT) : @(LP_MIN_FLOAT));
   } else if (x == CGFLOAT_MIN) {
-    return @(CGFLOAT_MIN);
+    return @(LP_MIN_FLOAT);
   } else if (x == CGFLOAT_MAX) {
-    return @(CGFLOAT_MAX);
+    return @(LP_MAX_FLOAT);
+  } else if (x > LP_MAX_FLOAT) {
+    return @(LP_MAX_FLOAT);
+  } else if (x < LP_MIN_FLOAT) {
+    return @(LP_MIN_FLOAT);
   } else {
     LPDecimalRounder *rounder = [LPDecimalRounder new];
     CGFloat rounded = [rounder round:x];


### PR DESCRIPTION
### Motivation

Users are reporting problems deserializing `CGFLOAT_MIN/MAX` with some JSON clients.

This new implementation forces a min/max float that is equivalent to `INT32_MIN/MAX`.  I thought I might try `INT16`, but if I recall correctly the bounds of MKMapView are way beyond these values.

- [x] @sapieneptus Can you review?  Please don't merge.  I am waiting to test this in the wild against an app that reproduces the problem.
- [ ] Test against a problem app.

ATTN: @GlennWilson @MatisseHack 

Possible fix for **Invalid number error while using the tree command in the REPL** [#742](https://github.com/xamarin/Xamarin.UITest/issues/742)