### PR TITLE
Fix touch coordinates for Zoomed display mode and apps that are not optimized for iPhone 6 screen sizes

### DIFF
--- a/LPTestTarget/Base.lproj/SecondViewController.xib
+++ b/LPTestTarget/Base.lproj/SecondViewController.xib
@@ -12,7 +12,14 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SecondViewController">
             <connections>
-                <outlet property="secretButton" destination="jzm-In-K7d" id="qLj-q7-blG"/>
+                <outlet property="bottomLeftButton" destination="E97-Ev-Naf" id="kpQ-kw-ZxD"/>
+                <outlet property="bottomMiddleButton" destination="kQ7-aQ-y9t" id="gNM-De-Meb"/>
+                <outlet property="bottomRightButton" destination="riB-gt-Sac" id="Q3I-QP-MZs"/>
+                <outlet property="middleLeftButton" destination="IPw-wV-LhW" id="bYc-20-dyp"/>
+                <outlet property="middleRightButton" destination="LN3-eY-EpV" id="17z-a4-5Xm"/>
+                <outlet property="topLeftButton" destination="jzm-In-K7d" id="Aki-GD-tvT"/>
+                <outlet property="topMiddleButton" destination="yta-BF-vuM" id="Ppw-T2-4a6"/>
+                <outlet property="topRightButton" destination="sE7-18-fNc" id="Dwr-Gf-WlT"/>
                 <outlet property="view" destination="iN0-l3-epB" id="x4C-57-ETm"/>
             </connections>
         </placeholder>
@@ -37,7 +44,7 @@
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jzm-In-K7d" userLabel="Secret button">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jzm-In-K7d" userLabel="top left">
                     <rect key="frame" x="88" y="88" width="2" height="2"/>
                     <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
                     <accessibility key="accessibilityConfiguration" label="Secret button"/>
@@ -48,21 +55,154 @@
                     <fontDescription key="fontDescription" type="system" pointSize="2"/>
                     <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="secret button"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="top left"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="IH8-LN-IEt"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sE7-18-fNc" userLabel="top right">
+                    <rect key="frame" x="510" y="88" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="fF0-Lk-854"/>
+                        <constraint firstAttribute="width" constant="2" id="ud6-on-vnK"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="top right"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="o5Y-Y1-9if"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E97-Ev-Naf" userLabel="bottom left">
+                    <rect key="frame" x="88" y="510" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="Jdc-5U-4jp"/>
+                        <constraint firstAttribute="width" constant="2" id="PgP-NF-jg3"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="bottom left"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="vQQ-RN-gv3"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="riB-gt-Sac" userLabel="bottom right">
+                    <rect key="frame" x="510" y="510" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="AOH-Kl-NBW"/>
+                        <constraint firstAttribute="width" constant="2" id="xeY-gz-eXb"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="bottom right"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="maP-AM-hdv"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IPw-wV-LhW" userLabel="middle left">
+                    <rect key="frame" x="10" y="299" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="2" id="kuX-Hm-wLg"/>
+                        <constraint firstAttribute="height" constant="2" id="ppa-cr-KKJ"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="middle left"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="P9y-h5-b1a"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LN3-eY-EpV" userLabel="middle right">
+                    <rect key="frame" x="588" y="299" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="YqU-Za-rYp"/>
+                        <constraint firstAttribute="width" constant="2" id="gdW-6i-mFS"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="middle right"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="Xrk-Gy-uIq"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yta-BF-vuM" userLabel="top middle">
+                    <rect key="frame" x="299" y="88" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="2" id="4Oy-Xw-FaC"/>
+                        <constraint firstAttribute="height" constant="2" id="byE-ML-4VX"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="top middle"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="9V6-Rd-HmJ"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kQ7-aQ-y9t" userLabel="bottom middle">
+                    <rect key="frame" x="299" y="510" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="mra-M2-32k"/>
+                        <constraint firstAttribute="width" constant="2" id="y2O-o4-z84"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="bottom middle"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="su2-CS-LNj"/>
                     </connections>
                 </button>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="jzm-In-K7d" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="88" id="3Es-zi-RDD"/>
+                <constraint firstItem="sE7-18-fNc" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="88" id="4vB-G5-hNe"/>
+                <constraint firstItem="E97-Ev-Naf" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="88" id="60W-Hb-GZd"/>
+                <constraint firstAttribute="bottom" secondItem="E97-Ev-Naf" secondAttribute="bottom" constant="88" id="EK3-wf-c8u"/>
                 <constraint firstItem="iws-4D-UFH" firstAttribute="top" secondItem="CAn-6g-s4q" secondAttribute="bottom" constant="17" id="Ejz-JI-ocY"/>
                 <constraint firstItem="CAn-6g-s4q" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="GY3-Qo-CEm"/>
+                <constraint firstItem="IPw-wV-LhW" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="HpX-Hb-SNP"/>
+                <constraint firstItem="IPw-wV-LhW" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="OjF-Hz-Xaf"/>
+                <constraint firstItem="yta-BF-vuM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RRw-3k-srC"/>
+                <constraint firstAttribute="bottom" secondItem="kQ7-aQ-y9t" secondAttribute="bottom" constant="88" id="UIY-A5-4E7"/>
+                <constraint firstItem="kQ7-aQ-y9t" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="WTG-oA-KgD"/>
+                <constraint firstItem="yta-BF-vuM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="88" id="WUZ-XS-Ia9"/>
                 <constraint firstItem="CAn-6g-s4q" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="XT8-MF-SE0"/>
+                <constraint firstAttribute="trailing" secondItem="sE7-18-fNc" secondAttribute="trailing" constant="88" id="aYO-Lc-orO"/>
+                <constraint firstAttribute="trailing" secondItem="riB-gt-Sac" secondAttribute="trailing" constant="88" id="dZl-Y6-W1a"/>
                 <constraint firstItem="iws-4D-UFH" firstAttribute="centerX" secondItem="CAn-6g-s4q" secondAttribute="centerX" id="gNe-yr-g5W"/>
                 <constraint firstItem="jzm-In-K7d" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="88" id="kwl-Cs-eEF"/>
+                <constraint firstAttribute="bottom" secondItem="riB-gt-Sac" secondAttribute="bottom" constant="88" id="pOm-kE-2pE"/>
+                <constraint firstItem="LN3-eY-EpV" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="wrW-nf-hx1"/>
+                <constraint firstAttribute="trailing" secondItem="LN3-eY-EpV" secondAttribute="trailing" constant="10" id="xKI-YV-edl"/>
             </constraints>
             <point key="canvasLocation" x="437" y="252"/>
         </view>

--- a/LPTestTarget/Base.lproj/SecondViewController.xib
+++ b/LPTestTarget/Base.lproj/SecondViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="Helvetica.ttc">
@@ -12,6 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SecondViewController">
             <connections>
+                <outlet property="secretButton" destination="jzm-In-K7d" id="qLj-q7-blG"/>
                 <outlet property="view" destination="iN0-l3-epB" id="x4C-57-ETm"/>
             </connections>
         </placeholder>
@@ -36,14 +37,34 @@
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jzm-In-K7d" userLabel="Secret button">
+                    <rect key="frame" x="88" y="88" width="2" height="2"/>
+                    <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <accessibility key="accessibilityConfiguration" label="Secret button"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="2" id="WQd-E1-jaj"/>
+                        <constraint firstAttribute="height" constant="2" id="XTX-Tm-pzY"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="2"/>
+                    <color key="tintColor" red="0.0" green="0.50196081400000003" blue="0.25098040700000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="secret button"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="buttonTouchedSecret:" destination="-1" eventType="touchUpInside" id="IH8-LN-IEt"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
+                <constraint firstItem="jzm-In-K7d" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="88" id="3Es-zi-RDD"/>
                 <constraint firstItem="iws-4D-UFH" firstAttribute="top" secondItem="CAn-6g-s4q" secondAttribute="bottom" constant="17" id="Ejz-JI-ocY"/>
                 <constraint firstItem="CAn-6g-s4q" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="GY3-Qo-CEm"/>
                 <constraint firstItem="CAn-6g-s4q" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="XT8-MF-SE0"/>
                 <constraint firstItem="iws-4D-UFH" firstAttribute="centerX" secondItem="CAn-6g-s4q" secondAttribute="centerX" id="gNe-yr-g5W"/>
+                <constraint firstItem="jzm-In-K7d" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="88" id="kwl-Cs-eEF"/>
             </constraints>
+            <point key="canvasLocation" x="437" y="252"/>
         </view>
     </objects>
 </document>

--- a/LPTestTarget/SecondViewController.m
+++ b/LPTestTarget/SecondViewController.m
@@ -2,8 +2,15 @@
 
 @interface SecondViewController ()
 
-@property (weak, nonatomic) IBOutlet UIButton *secretButton;
-- (IBAction)buttonTouchedSecret:(id)sender;
+@property (weak, nonatomic) IBOutlet UIButton *topLeftButton;
+@property (weak, nonatomic) IBOutlet UIButton *topRightButton;
+@property (weak, nonatomic) IBOutlet UIButton *bottomLeftButton;
+@property (weak, nonatomic) IBOutlet UIButton *bottomRightButton;
+@property (weak, nonatomic) IBOutlet UIButton *middleLeftButton;
+@property (weak, nonatomic) IBOutlet UIButton *middleRightButton;
+@property (weak, nonatomic) IBOutlet UIButton *topMiddleButton;
+@property (weak, nonatomic) IBOutlet UIButton *bottomMiddleButton;
+- (IBAction)buttonTouchedSecret:(UIButton *)sender;
 
 @end
 
@@ -29,16 +36,21 @@
 
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
-  [self.secretButton setTitle:@"Hidden" forState:UIControlStateNormal];
+  NSArray *subviews = [self.view subviews];
+  for (UIView *subView in subviews) {
+    if ([subView isKindOfClass:[UIButton class]]) {
+      UIButton *button = (UIButton *)subView;
+      [button setTitle:@"Hidden" forState:UIControlStateNormal];
+    }
+  }
 }
 
 - (void)didReceiveMemoryWarning {
   [super didReceiveMemoryWarning];
 }
 
-- (IBAction)buttonTouchedSecret:(id)sender {
-  NSLog(@"Secret button touched");
-  [self.secretButton setTitle:@"Found me!" forState:UIControlStateNormal];
+- (IBAction)buttonTouchedSecret:(UIButton *)sender {
+  [sender setTitle:@"Found me!" forState:UIControlStateNormal];
 }
 
 @end

--- a/LPTestTarget/SecondViewController.m
+++ b/LPTestTarget/SecondViewController.m
@@ -2,6 +2,9 @@
 
 @interface SecondViewController ()
 
+@property (weak, nonatomic) IBOutlet UIButton *secretButton;
+- (IBAction)buttonTouchedSecret:(id)sender;
+
 @end
 
 @implementation SecondViewController
@@ -24,8 +27,18 @@
   [super viewDidLoad];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+  [super viewDidAppear:animated];
+  [self.secretButton setTitle:@"Hidden" forState:UIControlStateNormal];
+}
+
 - (void)didReceiveMemoryWarning {
   [super didReceiveMemoryWarning];
+}
+
+- (IBAction)buttonTouchedSecret:(id)sender {
+  NSLog(@"Secret button touched");
+  [self.secretButton setTitle:@"Found me!" forState:UIControlStateNormal];
 }
 
 @end

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -113,7 +113,7 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 - (CGFloat) sampleFactor {
   if (_sampleFactor != CGFLOAT_MAX) { return _sampleFactor; }
 
-  _sampleFactor = 1.0f;
+  _sampleFactor = 1.0;
 
   UIScreen *screen = [UIScreen mainScreen];
   CGSize screenSize = screen.bounds.size;
@@ -125,8 +125,8 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
     nativeScale = screen.nativeScale;
   }
 
-  CGFloat iphone6_zoom_sample = 1.171875f;
-  CGFloat iphone6p_zoom_sample = 0.96f;
+  CGFloat iphone6_zoom_sample = 1.171875;
+  CGFloat iphone6p_zoom_sample = 0.96;
 
   UIScreenMode *screenMode = [screen currentMode];
   CGSize screenSizeForMode = screenMode.size;
@@ -141,11 +141,13 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
   LPLogDebug(@"Pixel Aspect Ratio: %@", @(pixelAspectRatio));
 
   if ([self isIPhone6PlusLike]) {
-    if (screenHeight == 568.0 && nativeScale > scale) {
-      LPLogDebug(@"iPhone 6 Plus: application is not optimized for screen size - adjusting sampleFactor");
+    if (screenHeight == 568.0 && nativeScale > scale) { // native => 2.88
+      LPLogDebug(@"iPhone 6 Plus: Zoom display mode and app is not optimized for screen size - adjusting sampleFactor");
       _sampleFactor = iphone6p_zoom_sample;
-    } else if (screenHeight == 667.0 && nativeScale <= scale) {
+    } else if (screenHeight == 667.0 && nativeScale <= scale) { // native => ???
       LPLogDebug(@"iPhone 6 Plus: Zoomed display mode - sampleFactor remains the same");
+    } else if (screenHeight == 736 && nativeScale < scale) { // native => 2.61
+      LPLogDebug(@"iPhone 6 Plus: Standard Display and app is not optimized for screen size - sampleFactor remains the same");
     }
   } else if ([self isIPhone6Like]) {
     if (screenHeight == 568.0 && nativeScale <= scale) {

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -125,10 +125,6 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
     nativeScale = screen.nativeScale;
   }
 
-
-  //CGSize iphone6_size = CGSizeMake(375.0 * scale, 667.0 * scale);
-  //CGSize iphone6p_size = CGSizeMake(414.0 * scale, 736.0 * scale);
-
   CGFloat iphone6_zoom_sample = 1.171875f;
   CGFloat iphone6p_zoom_sample = 0.96f;
 

--- a/cucumber/features/sample_factor.feature
+++ b/cucumber/features/sample_factor.feature
@@ -1,0 +1,9 @@
+@sample_factor
+Feature: sample_factor for non-optimized apps and zoomed mode
+
+@wip
+Scenario: Touch a small button
+Given the app has launched
+And I go to the second tab
+And I touch the secret button
+Then the secret button title changes to Found me

--- a/cucumber/features/sample_factor.feature
+++ b/cucumber/features/sample_factor.feature
@@ -1,9 +1,38 @@
 @sample_factor
 Feature: sample_factor for non-optimized apps and zoomed mode
 
-@wip
+The server must be able to detect two Scenarios:
+
+1. When the device is in Zoomed vs. Standard mode
+2. When the application is not optimized for the iPhone 6* screen sizes.
+
+In the first case, the sample factor does not change.  In the second case, the
+sample factor must change.
+
+The LPTestTarget is _optimized_ for the larger screen sizes; it has the correct
+launch images, the correct app icons, and image assets in @3x sizes.  This
+Scenario tests that the scale factor is correct in Zoomed and Standard view
+modes.  There is a 2x2 point button that, when touched, changes its title from
+"Hidden" to "Found me!".
+
+There are six tests to run:
+
+1. Target an iPhone 6 simulator
+2. Target an iPhone 6 Plus simulator
+3. Target an iPhone 6 in Zoomed mode
+4. Target an iPhone 6 in Standard mode
+5. Target an iPhone 6 Plus in Zoomed mode
+6. Target an iPhone 6 Plus in Standard mode
+
+To change the display mode, use Settings.app:
+
+Display & Brightness > Display Zoom > Standard | Zoomed > Set
+
+On iOS Simulators, there is no Zoomed or Standard mode.
+
 Scenario: Touch a small button
 Given the app has launched
 And I go to the second tab
 And I touch the secret button
 Then the secret button title changes to Found me
+

--- a/cucumber/features/sample_factor.feature
+++ b/cucumber/features/sample_factor.feature
@@ -11,9 +11,9 @@ sample factor must change.
 
 The LPTestTarget is _optimized_ for the larger screen sizes; it has the correct
 launch images, the correct app icons, and image assets in @3x sizes.  This
-Scenario tests that the scale factor is correct in Zoomed and Standard view
-modes.  There is a 2x2 point button that, when touched, changes its title from
-"Hidden" to "Found me!".
+Scenario tests that the sample factor is correct in Zoomed and Standard display
+modes.  There are a series of 2x2 point buttons that, when touched, change title
+from "Hidden" to "Found me!".
 
 There are six tests to run:
 
@@ -30,9 +30,15 @@ Display & Brightness > Display Zoom > Standard | Zoomed > Set
 
 On iOS Simulators, there is no Zoomed or Standard mode.
 
-Scenario: Touch a small button
+Scenario: Touch small buttons
 Given the app has launched
 And I go to the second tab
-And I touch the secret button
-Then the secret button title changes to Found me
+Then touching the top left button changes the title
+Then touching the top middle button changes the title
+Then touching the top right button changes the title
+Then touching the middle left button changes the title
+Then touching the middle right button changes the title
+Then touching the bottom left button changes the title
+Then touching the bottom middle button changes the title
+Then touching the bottom right button changes the title
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -50,18 +50,31 @@ And(/^I go to the first tab$/) do
   wait_for_none_animating
 end
 
-And(/^I touch the secret button$/) do
-  qstr = "view marked:'secret button'"
-  wait_for do
+Then(/^touching the (top|middle|bottom) (left|middle|right) button changes the title$/) do |y_id, x_id|
+  mark = "#{y_id} #{x_id}"
+  qstr = "view marked:'#{mark}'"
+  timeout = 8
+  message = "Timed out waiting after #{timeout} seconds for #{qstr}"
+  options = {
+    :timeout => timeout,
+    :timeout_message => message
+  }
+
+  wait_for(options) do
     !query(qstr).empty?
   end
 
-  touch(qstr)
-end
-
-Then(/^the secret button title changes to Found me$/) do
-  qstr = "view marked:'secret button'"
   title = query(qstr, {:titleForState => 0}).first
-  expect(title).to be == "Found me!"
+  expect(title).to be == "Hidden"
+
+  touch(qstr)
+
+  expected = "Found me!"
+  message = "Timed out waiting after #{timeout} seconds for title to change to '#{expected}'"
+  options[:timeout_message] = message
+
+  wait_for(options) do
+    query(qstr, {:titleForState => 0}).first == expected
+  end
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -50,3 +50,18 @@ And(/^I go to the first tab$/) do
   wait_for_none_animating
 end
 
+And(/^I touch the secret button$/) do
+  qstr = "view marked:'secret button'"
+  wait_for do
+    !query(qstr).empty?
+  end
+
+  touch(qstr)
+end
+
+Then(/^the secret button title changes to Found me$/) do
+  qstr = "view marked:'secret button'"
+  title = query(qstr, {:titleForState => 0}).first
+  expect(title).to be == "Found me!"
+end
+


### PR DESCRIPTION
### Motivation

Resolves **Screen coordinates are incorrect when running in Zoomed mode** [#998](https://github.com/calabash/calabash-ios/issues/998)

On iPhone 6* physical devices, there are two display modes: Zoomed and Standard.  You change the display mode in Settings.app > Display & Brightness > Standard | Zoomed > Set.   Zoomed and Standard display modes have different coordinate spaces.  There is no Zoomed mode for iOS Simulators.

Apps that are not optimized for the iPhone 6* screen size also have different coordinate spaces. In order to be optimized for the iPhone 6* screen sizes, apps must have the correct app icons, launch images, and image assets in 3x sizes.  To complicate matters further, physical devices and simulators have different coordinate space for non-optimized apps.  

This PR fixes the touch coordinates for all these cases except one:  Non-optimized apps in Zoomed display mode on iPhone 6 Plus physical devices.

There are two workarounds:

* Update your app to be optimized for the iPhone 6* screen sizes
* Test in Standard display mode

### Testing

* [Non-optimized apps](https://github.com/calabash/ios-iphone-only-app/pull/3)
* Optimized apps in Zoomed/Standard display - cucumber/features/sample_factor.feature
* [Non optimized in XTC](https://testcloud.xamarin.com/app/d75b541d-01f9-4665-bc9a-db782568103b/master)
* [LPTestTarget in XTC](https://testcloud.xamarin.com/test/sh-calaba-lptesttarget_9f3a9890-e9b1-4bd0-827b-4cad16045034/)
