### PR TITLE
LPVersionRoute: remove reference to calabash_version

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPVersionRoute.m
@@ -78,15 +78,17 @@ static NSString *const kLPGitRemoteOrigin = @"Unknown";
   return [method isEqualToString:@"GET"];
 }
 
+// Frank support
 - (BOOL)canHandlePostForPath:(NSArray *)path {
-  return [@"calabash_version" isEqualToString:[path lastObject]];
+  return [@"version" isEqualToString:[path lastObject]];
 }
 
+// Frank support
 - (id)handleRequestForPath:(NSArray *)path withConnection:(id)connection {
   if (![self canHandlePostForPath:path]) {  return nil;  }
 
   NSDictionary *version = [self JSONResponseForMethod:@"GET"
-                                                  URI:@"calabash_version"
+                                                  URI:@"version"
                                                  data:nil];
   NSData *jsonData = [[LPJSONUtils serializeDictionary:version]
                       dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
### Motivation

I believe this is for Frank support, but there is no reason why there needs to be a separate `version` route for Frank (it was `calabash_version`).

The goal here is to remove the CALABASH_VERSION_PATH from the client.

It is referenced twice in the client:

* https://github.com/calabash/calabash-ios/blob/develop/calabash-cucumber/bin/frank-calabash#L70
* https://github.com/calabash/calabash-ios/blob/develop/calabash-cucumber/lib/calabash-cucumber/launcher.rb#L601

The ultimate goal is to reduce the number of lines of code in client so I can implement an XCUITest action model.