### PR TITLE
Scenarios for testing Cucumber embed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GIT
 
 GIT
   remote: git://github.com/calabash/run_loop.git
-  revision: 68b5953e88a272ef143c4d20b919a14d6759bd64
+  revision: 8ad697025a2dd40fdf35c4238f232299cd426541
   branch: develop
   specs:
-    run_loop (2.1.0.pre1)
+    run_loop (2.1.1)
       CFPropertyList (~> 2.2)
       awesome_print (~> 1.2)
       command_runner_ng (>= 0.0.2)
@@ -45,11 +45,11 @@ GEM
       net-http-persistent (>= 2.7)
       net-http-pipeline
     highline (1.7.8)
-    httpclient (2.7.1)
+    httpclient (2.8.0)
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    multi_json (1.11.2)
+    multi_json (1.11.3)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
@@ -70,7 +70,7 @@ GEM
       typhoeus (~> 0.6, >= 0.6.8)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    websocket (1.2.2)
+    websocket (1.2.3)
     xcpretty (0.2.2)
       rouge (~> 1.8)
 

--- a/cucumber/config/cucumber.yml
+++ b/cucumber/config/cucumber.yml
@@ -32,6 +32,8 @@ end
 
 default_report = "./reports/calabash-#{date}.html"
 ss_path = "./screenshots/"
+FileUtils.rm_rf(ss_path)
+FileUtils.mkdir(ss_path)
 
 if ENV["USER"] == "jenkins"
   formatter = "pretty"

--- a/cucumber/config/cucumber.yml
+++ b/cucumber/config/cucumber.yml
@@ -84,7 +84,7 @@ default:       -p simulator
 # required only for devices
 bundle_id:    BUNDLE_ID=sh.calaba.LPTestTarget
 
-device_common:  -p common -p bundle_id --tags ~@simulator --tags ~@simulator_only
+device_common:  -p common -p bundle_id -p ss_path --tags ~@simulator --tags ~@simulator_only
 
 neptune_common: DEVICE_TARGET=<%= devices[:neptune][:udid] %> DEVICE_ENDPOINT=<%= devices[:neptune][:ip] %> -p device_common  -p neptune_html -p neptune_ss
 

--- a/cucumber/features/issue_246_screenshot_embed.feature
+++ b/cucumber/features/issue_246_screenshot_embed.feature
@@ -1,0 +1,21 @@
+@screenshot
+@issue_246
+Feature:  Screenshot embed in and out of cucumber world
+
+# undefined method `embed` (NoMethodError) when calling screenshot_and_raise
+# https://github.com/calabash/calabash-ios/issues/246
+
+Scenario: screenshots outside of a page
+When I use screenshot_and_raise in the context of cucumber
+Then I should get a runtime error
+
+Scenario: screenshots in a page that does not extend IBase
+When I screenshot_and_raise in a page that does not inherit from IBase
+Then I should get a runtime error
+But it should not be a NoMethod error for embed
+
+Scenario: screenshots in a page that does extend IBase
+When I screenshot_and_raise in a page that does inherit from IBase
+Then I should get a runtime error
+But it should not be a NoMethod error for embed
+

--- a/cucumber/features/pages/not_pom.rb
+++ b/cucumber/features/pages/not_pom.rb
@@ -1,0 +1,11 @@
+module NotPOM
+  class HomePage
+    include Calabash::Cucumber::Operations
+
+    def my_buggy_method
+      screenshot_and_raise 'Hey!'
+    end
+
+  end
+end
+

--- a/cucumber/features/pages/pom.rb
+++ b/cucumber/features/pages/pom.rb
@@ -1,0 +1,12 @@
+module POM
+  require "calabash-cucumber/ibase"
+
+  class HomePage < Calabash::IBase
+
+    def my_buggy_method
+      screenshot_and_raise 'Hey!'
+    end
+
+  end
+end
+

--- a/cucumber/features/steps/issue_246_screenshot_steps.rb
+++ b/cucumber/features/steps/issue_246_screenshot_steps.rb
@@ -2,7 +2,16 @@ module CalSmokeApp
   module ScreenshotEmbed
 
     def screenshot_count
-      Dir.glob("./screenshots/*.png").count
+      screenshot_dir = ENV["SCREENSHOT_PATH"]
+      if !screenshot_dir
+        screenshot_dir = "./screenshots"
+      end
+
+      unless File.exist?(screenshot_dir)
+        FileUtils.mkdir_p(screenshot_dir)
+      end
+
+      Dir.glob("#{screenshot_dir}/*.png").count
     end
 
     def log_screenshot_context(kontext, e)
@@ -10,6 +19,13 @@ module CalSmokeApp
       $stdout.flush
     end
 
+    def expect_screenshot_count(expected)
+      if Calabash::Cucumber::Environment.xtc?
+        # Skip this test on the XTC.
+      else
+        expect(screenshot_count).to be == expected
+      end
+    end
   end
 end
 
@@ -23,7 +39,7 @@ When(/^I use screenshot_and_raise in the context of cucumber$/) do
   rescue => e
     @screenshot_and_raise_error = e
     log_screenshot_context("Cucumber", e)
-    expect(screenshot_count).to be == last_count + 1
+    expect_screenshot_count(last_count + 1)
   end
 end
 
@@ -35,7 +51,7 @@ When(/I screenshot_and_raise in a page that does not inherit from IBase$/) do
   rescue => e
     log_screenshot_context("NotPOM", e)
     @screenshot_and_raise_error = e
-    expect(screenshot_count).to be == last_count + 1
+    expect_screenshot_count(last_count + 1)
   end
 end
 
@@ -47,7 +63,7 @@ When(/I screenshot_and_raise in a page that does inherit from IBase$/) do
   rescue => e
     log_screenshot_context("POM", e)
     @screenshot_and_raise_error = e
-    expect(screenshot_count).to be == last_count + 1
+    expect_screenshot_count(last_count + 1)
   end
 end
 

--- a/cucumber/features/steps/issue_246_screenshot_steps.rb
+++ b/cucumber/features/steps/issue_246_screenshot_steps.rb
@@ -1,0 +1,66 @@
+module CalSmokeApp
+  module ScreenshotEmbed
+
+    def screenshot_count
+      Dir.glob("./screenshots/*.png").count
+    end
+
+    def log_screenshot_context(kontext, e)
+      $stdout.puts "  #{kontext} #{e.class} #{e.message}"
+      $stdout.flush
+    end
+
+  end
+end
+
+World(CalSmokeApp::ScreenshotEmbed)
+
+When(/^I use screenshot_and_raise in the context of cucumber$/) do
+  last_count = screenshot_count
+
+  begin
+    screenshot_and_raise 'Hey!'
+  rescue => e
+    @screenshot_and_raise_error = e
+    log_screenshot_context("Cucumber", e)
+    expect(screenshot_count).to be == last_count + 1
+  end
+end
+
+When(/I screenshot_and_raise in a page that does not inherit from IBase$/) do
+  last_count = screenshot_count
+
+  begin
+    NotPOM::HomePage.new.my_buggy_method
+  rescue => e
+    log_screenshot_context("NotPOM", e)
+    @screenshot_and_raise_error = e
+    expect(screenshot_count).to be == last_count + 1
+  end
+end
+
+When(/I screenshot_and_raise in a page that does inherit from IBase$/) do
+  last_count = screenshot_count
+
+  begin
+    POM::HomePage.new(self).my_buggy_method
+  rescue => e
+    log_screenshot_context("POM", e)
+    @screenshot_and_raise_error = e
+    expect(screenshot_count).to be == last_count + 1
+  end
+end
+
+Then(/^I should get a runtime error$/) do
+  if @screenshot_and_raise_error.nil?
+    raise 'Expected the previous step to raise an error'
+  end
+
+  expect(@screenshot_and_raise_error).to be_a_kind_of(RuntimeError)
+end
+
+But(/^it should not be a NoMethod error for embed$/) do
+  expect(@screenshot_and_raise_error.message[/embed/, 0]).to be_falsey
+  expect(@screenshot_and_raise_error).not_to be_a_kind_of(NoMethodError)
+end
+


### PR DESCRIPTION
### Motivation

Somewhere along the way we lost the Cucumbers for testing screenshots.

Tests fix for **0.19.0: undefined method `embed` in Calabash::Cucumber.map** [#1083](https://github.com/calabash/calabash-ios/issues/1083)