### PR TITLE
LPScreenshot: handle exceptions when calling snapshot API

### DIFF
--- a/XCTest/Tests/Routes/LPScreenshotRouteTest.m
+++ b/XCTest/Tests/Routes/LPScreenshotRouteTest.m
@@ -10,6 +10,8 @@
 - (NSObject <LPHTTPResponse> *) httpResponseForMethod:(NSString *) method
                                                   URI:(NSString *) path;
 - (NSData *) takeScreenshot;
+- (NSData *) takeScreenshotUsingSnapshotAPI;
+- (NSData *) takeScreenshotUsingRenderInContext;
 
 @end
 
@@ -44,6 +46,29 @@ describe(@"LPScreenshotRoute", ^{
       XCTAssertNotNil(result);
       expect(result).to.conformTo(@protocol(LPHTTPResponse));
       OCMVerify([mock takeScreenshot]);
+    });
+  });
+
+  describe(@"#takeScreenshot", ^{
+    it(@"uses snapshot api", ^{
+      NSData *expected = [NSData data];
+      id mock = OCMPartialMock(route);
+      OCMExpect([mock takeScreenshotUsingSnapshotAPI]).andReturn(expected);
+
+      NSData *actual = [mock takeScreenshot];
+      expect(actual).to.equal(expected);
+      OCMVerifyAll(mock);
+    });
+
+    it(@"falls back to render in context on exception", ^{
+      NSData *expected = [NSData data];
+      id mock = OCMPartialMock(route);
+      OCMStub([mock takeScreenshotUsingSnapshotAPI]).andThrow([NSException new]);
+      OCMExpect([mock takeScreenshotUsingRenderInContext]).andReturn(expected);
+
+      NSData *actual = [mock takeScreenshot];
+      expect(actual).to.equal(expected);
+      OCMVerifyAll(mock);
     });
   });
 });

--- a/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPScreenshotRoute.m
@@ -11,10 +11,13 @@
 #import "LPScreenshotRoute.h"
 #import "LPHTTPDataResponse.h"
 #import "LPTouchUtils.h"
+#import "LPCocoaLumberjack.h"
 
 @interface LPScreenshotRoute ()
 
 - (NSData *) takeScreenshot;
+- (NSData *) takeScreenshotUsingSnapshotAPI;
+- (NSData *) takeScreenshotUsingRenderInContext;
 
 @end
 
@@ -31,7 +34,24 @@
 }
 
 - (NSData *) takeScreenshot {
+  NSData *imageData = [NSData data];
 
+  @try {
+    imageData = [self takeScreenshotUsingSnapshotAPI];
+  } @catch (NSException *exception) {
+    LPLogError(@"Caught an exception using the snapshot API");
+    LPLogError(@"%@", exception);
+    LPLogError(@"Will try taking a screenshot using render in context");
+    imageData = [self takeScreenshotUsingRenderInContext];
+  }
+
+  return imageData;
+}
+
+// Take a screenshot using the the snapshot API.  This is preferred because it
+// captures OpenGL and UIKit views.  Unfortunately, it can cause app crashes
+// if called during an animation.
+- (NSData *) takeScreenshotUsingSnapshotAPI {
 
   // Available on iOS >= 7
   SEL selector = @selector(drawViewHierarchyInRect:afterScreenUpdates:);
@@ -65,6 +85,47 @@
         // Render the layer hierarchy to the current context
         [[window layer] renderInContext:context];
       }
+
+      // Restore the context
+      CGContextRestoreGState(context);
+    }
+  }
+
+  // Retrieve the screenshot image
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+
+  UIGraphicsEndImageContext();
+
+  return UIImagePNGRepresentation(image);
+}
+
+// Takes a screenshot using renderInContext.  This method is not preferred
+// because it does not capture OpenGL views.  Its advantage is that it does not
+// throw exceptions.
+- (NSData *) takeScreenshotUsingRenderInContext {
+
+  CGSize imageSize = [[UIScreen mainScreen] bounds].size;
+  UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
+
+  CGContextRef context = UIGraphicsGetCurrentContext();
+
+  // Iterate over every window from back to front
+  for (UIWindow *window in [LPTouchUtils applicationWindows]) {
+    if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen]) {
+      // -renderInContext: renders in the coordinate space of the layer,
+      // so we must first apply the layer's geometry to the graphics context
+      CGContextSaveGState(context);
+      // Center the context around the window's anchor point
+      CGContextTranslateCTM(context, [window center].x, [window center].y);
+      // Apply the window's transform about the anchor point
+      CGContextConcatCTM(context, [window transform]);
+      // Offset by the portion of the bounds left of and above the anchor point
+      CGContextTranslateCTM(context,
+                            -[window bounds].size.width * [[window layer] anchorPoint].x,
+                            -[window bounds].size.height * [[window layer] anchorPoint].y);
+
+      // Render the layer hierarchy to the current context
+      [[window layer] renderInContext:context];
 
       // Restore the context
       CGContextRestoreGState(context);


### PR DESCRIPTION
### Motivation

Some users are reporting crashes using the Snapshot API for screenshots.

We don't want to stop using the Snapshot API because it supports UIKit _and_ OpenGL views.

