### PR TITLE
Increment LPTestTarget CFBundleVersion for every build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ calabash-dylibs
 *.ipa
 tmp
 
+# Versioning info
+LPTestTarget/InfoPlist.h
+
 # Code coverage and profiling.
 *.gcda
 *.gcno

--- a/LPTestTarget/Info.plist
+++ b/LPTestTarget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>PRODUCT_BUILD_NUMBER</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/bin/xcode-build-phase/increment-build-number.sh
+++ b/bin/xcode-build-phase/increment-build-number.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+HEADER="${PROJECT_DIR}/${INFOPLIST_PREFIX_HEADER}"
+PLIST="${PROJECT_DIR}/${INFOPLIST_FILE}"
+touch "${PLIST}"
+
+if [ -f "${HEADER}" ]; then
+  set +e
+  LINE=`cat "${HEADER}" | grep "define PRODUCT_BUILD_NUMBER"`
+  OLD_BUILD_NUMBER=`echo "${LINE}" | awk -F' ' '{printf $3}'`
+
+  if [ "$?" != "0" ]; then
+    NEW_BUILD_NUMBER="1"
+  else
+    NEW_BUILD_NUMBER=$(($OLD_BUILD_NUMBER + 1))
+  fi
+  set -e
+else
+  NEW_BUILD_NUMBER="1"
+fi
+
+cat > "${HEADER}" <<EOF
+/*
+DO NOT MANUALLY CHANGE THE CONTENTS OF THIS FILE
+
+The PRODUCT_BUILD_NUMBER is advanced for every
+build of ${PRODUCT_NAME}.
+
+This file should not be added to version control.
+*/
+
+#define PRODUCT_BUILD_NUMBER ${NEW_BUILD_NUMBER}
+EOF
+

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		F5DDE54D1CDE4AB000E0E187 /* LPTestTargetBuildNumber */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = F5DDE54E1CDE4AB000E0E187 /* Build configuration list for PBXAggregateTarget "LPTestTargetBuildNumber" */;
+			buildPhases = (
+				F5DDE5521CDE4AB600E0E187 /* Run Script Increment Build Number */,
+			);
+			dependencies = (
+			);
+			name = LPTestTargetBuildNumber;
+			productName = BuildNumber;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		89043AC21C289A5D0067E22F /* LPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 89043ABE1C289A5D0067E22F /* LPConstants.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		89043AC31C289A5D0067E22F /* LPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 89043ABE1C289A5D0067E22F /* LPConstants.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -623,6 +637,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = F59CA46C1A82EF40007A2F38;
 			remoteInfo = LPTestTarget;
+		};
+		F5DDE5531CDE4B0700E0E187 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B121E78814B6D9FB0034C6A9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F5DDE54D1CDE4AB000E0E187;
+			remoteInfo = BuildNumber;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -2275,6 +2296,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				F5DDE5541CDE4B0700E0E187 /* PBXTargetDependency */,
 			);
 			name = LPTestTarget;
 			productName = LPTestTarget;
@@ -2298,6 +2320,9 @@
 					F59CA46C1A82EF40007A2F38 = {
 						CreatedOnToolsVersion = 6.2;
 					};
+					F5DDE54D1CDE4AB000E0E187 = {
+						CreatedOnToolsVersion = 7.3;
+					};
 				};
 			};
 			buildConfigurationList = B121E78B14B6D9FB0034C6A9 /* Build configuration list for PBXProject "calabash" */;
@@ -2320,6 +2345,7 @@
 				B15BF97019ABAFD200B38577 /* calabash-dylib */,
 				F59CA46C1A82EF40007A2F38 /* LPTestTarget */,
 				F537398B18E5253B004133FA /* version */,
+				F5DDE54D1CDE4AB000E0E187 /* LPTestTargetBuildNumber */,
 			);
 		};
 /* End PBXProject section */
@@ -2544,6 +2570,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh calabash/gitversioning-after.sh \"calabash/LPGitVersionDefines.h\"";
+			showEnvVarsInLog = 0;
+		};
+		F5DDE5521CDE4AB600E0E187 /* Run Script Increment Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script Increment Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bin/xcode-build-phase/increment-build-number.sh";
 			showEnvVarsInLog = 0;
 		};
 		F5E2A5EF1BFF090F0068DFAD /* Run Script  Checkout LPTestTarget/change-sha.plist */ = {
@@ -3150,6 +3191,11 @@
 			isa = PBXTargetDependency;
 			target = F59CA46C1A82EF40007A2F38 /* LPTestTarget */;
 			targetProxy = F59CA4961A82F2BF007A2F38 /* PBXContainerItemProxy */;
+		};
+		F5DDE5541CDE4B0700E0E187 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F5DDE54D1CDE4AB000E0E187 /* LPTestTargetBuildNumber */;
+			targetProxy = F5DDE5531CDE4B0700E0E187 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -4152,7 +4198,9 @@
 					"$(inherited)",
 					/Xcode/6.4/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
-				INFOPLIST_FILE = LPTestTarget/Info.plist;
+				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
+				INFOPLIST_PREFIX_HEADER = "${PRODUCT_NAME}/InfoPlist.h";
+				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
@@ -4232,7 +4280,9 @@
 					"$(inherited)",
 					/Xcode/6.4/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
-				INFOPLIST_FILE = LPTestTarget/Info.plist;
+				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
+				INFOPLIST_PREFIX_HEADER = "${PRODUCT_NAME}/InfoPlist.h";
+				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
@@ -4278,7 +4328,9 @@
 					"$(inherited)",
 					/Xcode/6.4/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
-				INFOPLIST_FILE = LPTestTarget/Info.plist;
+				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
+				INFOPLIST_PREFIX_HEADER = "";
+				INFOPLIST_PREPROCESS = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
@@ -4294,6 +4346,36 @@
 					"-Warc-retain-cycles",
 					"-Wno-objc-designated-initializers",
 				);
+			};
+			name = Release;
+		};
+		F5DDE54F1CDE4AB000E0E187 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "";
+				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
+				INFOPLIST_PREFIX_HEADER = "${PRODUCT_NAME}/InfoPlist.h";
+				PRODUCT_NAME = LPTestTarget;
+			};
+			name = Debug;
+		};
+		F5DDE5501CDE4AB000E0E187 /* CalabashApp */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "";
+				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
+				INFOPLIST_PREFIX_HEADER = "${PRODUCT_NAME}/InfoPlist.h";
+				PRODUCT_NAME = LPTestTarget;
+			};
+			name = CalabashApp;
+		};
+		F5DDE5511CDE4AB000E0E187 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "";
+				INFOPLIST_FILE = "${PRODUCT_NAME}/Info.plist";
+				INFOPLIST_PREFIX_HEADER = "${PRODUCT_NAME}/InfoPlist.h";
+				PRODUCT_NAME = LPTestTarget;
 			};
 			name = Release;
 		};
@@ -4369,6 +4451,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
+		};
+		F5DDE54E1CDE4AB000E0E187 /* Build configuration list for PBXAggregateTarget "LPTestTargetBuildNumber" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F5DDE54F1CDE4AB000E0E187 /* Debug */,
+				F5DDE5501CDE4AB000E0E187 /* CalabashApp */,
+				F5DDE5511CDE4AB000E0E187 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 


### PR DESCRIPTION
### Motivation

I want to be able to support this use case:

```
Given I testing against a physical device
And the app I am testing is already installed
When the installed app version is different than the .ipa I have on disk
Then I want Calabash to install the .ipa from disk
```

On iOS Simulators, we do a checksum to determine if an installed .app is stale.  This is not possible on physical devices; the only information about an app we can get is from the Info.plist.  The idea is to ask "Are the versions of the installed app and the app on disk the same?" and reinstall if the answer is, "No.".