### PR TITLE
LPDevice: fix sampleFactor for legacy apps in zoomed mode on iphone 6+

### DIFF
--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -196,8 +196,11 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
     nativeScale = screen.nativeScale;
   }
 
+  // Never used, but we should keep this magic number around because at one
+  // point we thought it was useful (see the Paint Code URL above).
+  // CGFloat iphone6p_zoom_sample = 0.96;
+
   CGFloat iphone6_zoom_sample = 1.171875;
-  CGFloat iphone6p_zoom_sample = 0.96;
   // This was derived by trial and error.
   // This is sufficient for touching a 2x2 pixel button.
   CGFloat iphone6p_legacy_app_sample = 1.3;
@@ -219,7 +222,8 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
       if (nativeScale > scale) {
         LPLogDebug(@"iPhone 6 Plus: Zoom display and app is not optimized for screen size - adjusting sampleFactor");
         // native => 2.88
-        _sampleFactor = iphone6p_zoom_sample;
+        // Displayed with iPhone _6_ zoom sample
+        _sampleFactor = iphone6_zoom_sample;
       } else {
         LPLogDebug(@"iPhone 6 Plus: Standard display and app is not optimized for screen size - adjusting sampleFactor");
         // native == scale == 3.0
@@ -245,6 +249,7 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
     }
   }
 
+  LPLogDebug(@"sampleFactor = %@", @(_sampleFactor));
   return _sampleFactor;
 }
 


### PR DESCRIPTION
### Motivation

Related to:

* Fix touch coordinates for Zoomed display mode and apps that are not optimized for iPhone 6 screen sizes #339

Resolves:

> This PR fixes the touch coordinates for all these cases except one: Non-optimized apps in Zoomed display mode on iPhone 6 Plus physical devices.

Tested against the [iPhoneOnlyApp](https://github.com/calabash/ios-iphone-only-app) in these 6 configurations:

1. Target an iPhone 6 simulator
2. Target an iPhone 6 Plus simulator
3. Target an iPhone 6 in Zoomed mode
4. Target an iPhone 6 in Standard mode
5. Target an iPhone 6 Plus in Zoomed mode
6. Target an iPhone 6 Plus in Standard mode

### Background

The server must be able to detect two Scenarios:

1. When the device is in Zoomed vs. Standard mode
2. When the application is not optimized for the iPhone 6* screen sizes.

In the first case, the sample factor does not change.  In the second case, the
sample factor must change.

The iPhoneOnly app is _not_ optimized for the larger screen sizes; it is
missing the required launch images, the correct app icons, and the image assets
in @3x sizes.  This Scenario tests that sample factor is correct in Zoomed and
Standard display modes.  There a several 2x2 point buttons that, when touched,
change the action label (in the middle of the view).