### PR TITLE
Server: add set device orientation route

### DIFF
--- a/XCTest/Tests/Routes/LPSetDeviceOrientationRouteTest.m
+++ b/XCTest/Tests/Routes/LPSetDeviceOrientationRouteTest.m
@@ -1,0 +1,178 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import <XCTest/XCTest.h>
+#import "LPSetDeviceOrientationRoute.h"
+#import "LPOrientationOperation.h"
+
+@interface UIDevice (LP_DEVICE_ORIENTATION_CATEGORY)
+
+-(void)setOrientation:(NSInteger)orientation animated:(BOOL)animated;
+@end
+
+@interface LPSetDeviceOrientationRoute (LPTEST)
+
+- (NSInteger)orientationWithDictionary:(NSDictionary *)arguments;
+- (NSInteger)orientationForString:(NSString *)string;
+- (BOOL)isValidUIDeviceOrientation:(NSInteger)orientation;
+
+@end
+
+@interface LPSetDeviceOrientationRouteTest : XCTestCase
+
+@property(atomic, strong) LPSetDeviceOrientationRoute *route;
+
+@end
+
+@implementation LPSetDeviceOrientationRouteTest
+
+- (void)setUp {
+  [super setUp];
+  self.route = [LPSetDeviceOrientationRoute new];
+}
+
+- (void)tearDown {
+  self.route = nil;
+  [super tearDown];
+}
+
+- (void)testRespondsToPOST {
+  BOOL actual = [self.route supportsMethod:@"POST" atPath:nil];
+  expect(actual).to.equal(YES);
+}
+
+- (void)testDoesNotRespondToGET {
+  BOOL actual = [self.route supportsMethod:@"GET" atPath:nil];
+  expect(actual).to.equal(NO);
+}
+
+- (void)testOrientationForStringUpsideDown {
+  NSInteger expected = (NSInteger)UIDeviceOrientationPortraitUpsideDown;
+
+  expect([self.route orientationForString:@"up"]).to.equal(expected);
+  expect([self.route orientationForString:@"top"]).to.equal(expected);
+  expect([self.route orientationForString:@"upside down"]).to.equal(expected);
+}
+
+- (void)testOrientationForStringPortrait {
+  NSInteger expected = (NSInteger)UIDeviceOrientationPortrait;
+
+  expect([self.route orientationForString:@"bottom"]).to.equal(expected);
+  expect([self.route orientationForString:@"down"]).to.equal(expected);
+  expect([self.route orientationForString:@"portrait"]).to.equal(expected);
+}
+
+- (void)testOrientationForStringLandscapeRight {
+  NSInteger expected = (NSInteger)UIDeviceOrientationLandscapeRight;
+
+  expect([self.route orientationForString:@"left"]).to.equal(expected);
+  expect([self.route orientationForString:@"landscape right"]).to.equal(expected);
+}
+
+- (void)testOrientationForStringLandscapeLeft {
+  NSInteger expected = (NSInteger)UIDeviceOrientationLandscapeLeft;
+
+  expect([self.route orientationForString:@"right"]).to.equal(expected);
+  expect([self.route orientationForString:@"landscape left"]).to.equal(expected);
+}
+
+- (void)testOrientationForStringUnexpectedInput {
+  NSInteger expected = (NSInteger)UIDeviceOrientationPortrait;
+
+  expect([self.route orientationForString:@"face down"]).to.equal(expected);
+  expect([self.route orientationForString:@"face up"]).to.equal(expected);
+  expect([self.route orientationForString:@"unknown"]).to.equal(expected);
+  expect([self.route orientationForString:nil]).to.equal(expected);
+}
+
+- (void)testIsValidDeviceOrientationYES {
+  expect([self.route isValidUIDeviceOrientation:UIDeviceOrientationPortrait]).to.equal(YES);
+  expect([self.route isValidUIDeviceOrientation:UIDeviceOrientationPortraitUpsideDown]).to.equal(YES);
+  expect([self.route isValidUIDeviceOrientation:UIDeviceOrientationLandscapeLeft]).to.equal(YES);
+  expect([self.route isValidUIDeviceOrientation:UIDeviceOrientationLandscapeRight]).to.equal(YES);
+}
+
+- (void)testIsValidDeviceOrientationNO {
+  expect([self.route isValidUIDeviceOrientation:UIDeviceOrientationPortrait - 1]).to.equal(NO);
+  expect([self.route isValidUIDeviceOrientation:UIDeviceOrientationLandscapeRight + 1]).to.equal(NO);
+}
+
+- (void)testOrientationWithDictionaryNoValueForKey {
+  NSDictionary *args = @{};
+
+  expect([self.route orientationWithDictionary:args]).to.equal(1);
+}
+
+- (void)testOrientationWithDictionaryStringValue {
+  NSDictionary *args = @{
+                         @"orientation" : @"string"
+                         };
+  NSInteger expected = 10;
+  id mock = OCMPartialMock(self.route);
+  OCMExpect([mock orientationForString:@"string"]).andReturn(expected);
+  OCMExpect([mock isValidUIDeviceOrientation:expected]).andReturn(YES);
+
+  NSInteger actual = [self.route orientationWithDictionary:args];
+  expect(actual).to.equal(expected);
+
+  OCMVerifyAll(mock);
+}
+
+- (void)testOrientationWithDictionaryNumberValue {
+  NSInteger expected = 10;
+  NSDictionary *args = @{
+                         @"orientation" : @(expected)
+                         };
+
+  id mock = OCMPartialMock(self.route);
+  OCMExpect([mock isValidUIDeviceOrientation:expected]).andReturn(YES);
+
+  NSInteger actual = [self.route orientationWithDictionary:args];
+  expect(actual).to.equal(expected);
+
+  OCMVerifyAll(mock);
+}
+
+- (void)testOrientationWithDictionaryInvalidObjectType {
+  NSInteger expected = (NSInteger)UIDeviceOrientationPortrait;
+  NSDictionary *args = @{
+                         @"orientation" : @[]
+                         };
+
+  id mock = OCMPartialMock(self.route);
+  OCMExpect([mock isValidUIDeviceOrientation:expected]).andReturn(YES);
+
+  NSInteger actual = [self.route orientationWithDictionary:args];
+  expect(actual).to.equal(expected);
+}
+
+- (void)testJSONResponsForMethod {
+  id klassMock = OCMClassMock([LPOrientationOperation class]);
+  OCMExpect([klassMock statusBarOrientation]).andReturn(@"status bar orientation");
+  OCMExpect([klassMock deviceOrientation]).andReturn(@"device orientation");
+
+  id routeMock = OCMPartialMock(self.route);
+  NSDictionary *args = @{
+                         @"orientation" : @(4)
+                         };
+  OCMExpect([routeMock orientationWithDictionary:args]).andReturn(4);
+
+  id deviceMock = OCMPartialMock([UIDevice currentDevice]);
+  OCMExpect([deviceMock setOrientation:4 animated:YES]).andForwardToRealObject();
+
+  NSDictionary *actual = [routeMock JSONResponseForMethod:nil URI:nil data:args];
+  expect(actual[@"outcome"]).to.equal(@"SUCCESS");
+  expect(actual[@"results"]).notTo.equal(nil);
+
+  NSDictionary *results = actual[@"results"];
+
+  expect(results[@"device_orientation"]).to.equal(@"device orientation");
+  expect(results[@"status_bar_orientation"]).to.equal(@"status bar orientation");
+
+  OCMVerifyAll(klassMock);
+  OCMVerifyAll(deviceMock);
+  OCMVerifyAll(routeMock);
+}
+
+@end

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -407,6 +407,11 @@
 		F52427E71BA8457D00B7678F /* LPProcessInfoRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52427E21BA8457D00B7678F /* LPProcessInfoRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F52427E81BA8457D00B7678F /* LPProcessInfoRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52427E21BA8457D00B7678F /* LPProcessInfoRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F52427E91BA8457D00B7678F /* LPProcessInfoRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52427E21BA8457D00B7678F /* LPProcessInfoRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F52975C51D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52975C11D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F52975C61D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52975C11D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F52975C71D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52975C11D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F52975C81D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = F52975C11D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F52975CA1D4FC5DB009094D5 /* LPSetDeviceOrientationRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F52975C91D4FC5DB009094D5 /* LPSetDeviceOrientationRouteTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F52A26531BD02D0400AD0E36 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = F52A26511BD02D0400AD0E36 /* LPCDataScanner.m */; };
 		F52A26541BD02D0400AD0E36 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = F52A26511BD02D0400AD0E36 /* LPCDataScanner.m */; };
 		F52A26551BD02D0400AD0E36 /* LPCDataScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = F52A26511BD02D0400AD0E36 /* LPCDataScanner.m */; };
@@ -893,6 +898,9 @@
 		F514ACCB1B341557004ACFEE /* LPiOSVersionInlinesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPiOSVersionInlinesTest.m; sourceTree = "<group>"; };
 		F52427E11BA8457D00B7678F /* LPProcessInfoRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPProcessInfoRoute.h; sourceTree = "<group>"; };
 		F52427E21BA8457D00B7678F /* LPProcessInfoRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPProcessInfoRoute.m; sourceTree = "<group>"; };
+		F52975C01D4FBA29009094D5 /* LPSetDeviceOrientationRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPSetDeviceOrientationRoute.h; sourceTree = "<group>"; };
+		F52975C11D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPSetDeviceOrientationRoute.m; sourceTree = "<group>"; };
+		F52975C91D4FC5DB009094D5 /* LPSetDeviceOrientationRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPSetDeviceOrientationRouteTest.m; sourceTree = "<group>"; };
 		F52A264D1BD02B7B00AD0E36 /* LPiOSVersionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPiOSVersionInlines.h; sourceTree = "<group>"; };
 		F52A26511BD02D0400AD0E36 /* LPCDataScanner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCDataScanner.m; sourceTree = "<group>"; };
 		F52A26521BD02D0400AD0E36 /* LPCDataScanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCDataScanner.h; sourceTree = "<group>"; };
@@ -1438,6 +1446,8 @@
 		B184FDD014B6DB2B002A744C /* Routes */ = {
 			isa = PBXGroup;
 			children = (
+				F52975C01D4FBA29009094D5 /* LPSetDeviceOrientationRoute.h */,
+				F52975C11D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m */,
 				E2F802591BE207570000A0E4 /* LPShakeRoute.h */,
 				E2F8025A1BE207670000A0E4 /* LPShakeRoute.m */,
 				F57605871BCE77F000E89C97 /* LPSuspendAppRoute.h */,
@@ -2100,6 +2110,7 @@
 				E2F8025F1BE21C690000A0E4 /* LPShakeRouteTest.m */,
 				F5A6B9711BD14EE2009FD08B /* LPReflectionRouteTest.m */,
 				F58CE49D1BD6757A0025BE67 /* LPBackdoorRouteTest.m */,
+				F52975C91D4FC5DB009094D5 /* LPSetDeviceOrientationRouteTest.m */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -2616,6 +2627,7 @@
 				B15BF99C19ABB1DD00B38577 /* LPGCDAsyncSocket.m in Sources */,
 				B15BF99D19ABB1DD00B38577 /* LPHTTPAuthenticationRequest.m in Sources */,
 				B15BF99E19ABB1DD00B38577 /* LPHTTPConnection.m in Sources */,
+				F52975C81D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */,
 				B1F772321A22A398009A2336 /* LPUIASharedElementChannel.m in Sources */,
 				B15BF99F19ABB1DD00B38577 /* LPHTTPMessage.m in Sources */,
 				B15BF9A019ABB1DD00B38577 /* LPHTTPServer.m in Sources */,
@@ -2753,6 +2765,7 @@
 				B1D5BD8719A23BCE0070E8CE /* LPHTTPRedirectResponse.m in Sources */,
 				B1D5BD8819A23BCE0070E8CE /* LPScrollToMarkOperation.m in Sources */,
 				B1D5BD8919A23BCE0070E8CE /* LPRouter.m in Sources */,
+				F52975C71D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */,
 				F5A6B96F1BD14E96009FD08B /* LPReflectionRoute.m in Sources */,
 				B1D5BD8A19A23BCE0070E8CE /* LPQueryAllOperation.m in Sources */,
 				B1D5BD8B19A23BCE0070E8CE /* LPOperation.m in Sources */,
@@ -2859,6 +2872,7 @@
 				F5091BE018C4E1D700C85307 /* LPHTTPMessage.m in Sources */,
 				F5091BE118C4E1D700C85307 /* LPHTTPServer.m in Sources */,
 				F5091BE218C4E1D700C85307 /* NSData+LPCHSExtensions.m in Sources */,
+				F52975C61D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */,
 				B1F7722E1A22A398009A2336 /* LPUIASharedElementChannel.m in Sources */,
 				F5091BE318C4E1D700C85307 /* NSNumber+LPCHSExtensions.m in Sources */,
 				F5091BE418C4E1D700C85307 /* LPDDRange.m in Sources */,
@@ -2978,6 +2992,7 @@
 				F50CBF9B1A04058C004AC9DA /* LPSetTextOperation.m in Sources */,
 				F50CBFA91A0405B2004AC9DA /* LPGenericAsyncRoute.m in Sources */,
 				F514ACCC1B341557004ACFEE /* LPiOSVersionInlinesTest.m in Sources */,
+				F52975CA1D4FC5DB009094D5 /* LPSetDeviceOrientationRouteTest.m in Sources */,
 				F5A6B96D1BD14E96009FD08B /* LPReflectionRoute.m in Sources */,
 				F50CBF8D1A04056F004AC9DA /* LPHTTPRedirectResponse.m in Sources */,
 				F52427E61BA8457D00B7678F /* LPProcessInfoRoute.m in Sources */,
@@ -3071,6 +3086,7 @@
 				F5A8B4701B39BFEB00F390CA /* LPMultiFormatter.m in Sources */,
 				F5986B301B5A327500CCB142 /* LPOperationTest.m in Sources */,
 				F50CBFA31A0405B2004AC9DA /* LPAppPropertyRoute.m in Sources */,
+				F52975C51D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */,
 				F50CBFB41A0405CE004AC9DA /* LPISO8601DateFormatter.m in Sources */,
 				F50CBF871A040564004AC9DA /* NSNumber+LPCHSExtensions.m in Sources */,
 				B1670E341A3248CC00000A62 /* LPSharedUIATextField.m in Sources */,
@@ -4460,6 +4476,7 @@
 				F5DDE5511CDE4AB000E0E187 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -43,6 +43,7 @@
 #import "LPShakeRoute.h"
 #import "LPSuspendAppRoute.h"
 #import "LPReflectionRoute.h"
+#import "LPSetDeviceOrientationRoute.h"
 
 @interface CalabashServer ()
 - (void) start;
@@ -201,6 +202,10 @@
     LPReflectionRoute *reflectionRoute = [LPReflectionRoute new];
     [LPRouter addRoute:reflectionRoute forPath:@"reflection"];
     [reflectionRoute release];
+
+    LPSetDeviceOrientationRoute *orientationRoute = [LPSetDeviceOrientationRoute new];
+    [LPRouter addRoute:orientationRoute forPath:@"setDeviceOrientation"];
+    [orientationRoute release];
 
     _httpServer = [[[LPHTTPServer alloc] init] retain];
 

--- a/calabash/Classes/FranklyServer/Routes/LPSetDeviceOrientationRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPSetDeviceOrientationRoute.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "LPRoute.h"
+
+@interface LPSetDeviceOrientationRoute : NSObject <LPRoute>
+
+@end

--- a/calabash/Classes/FranklyServer/Routes/LPSetDeviceOrientationRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPSetDeviceOrientationRoute.m
@@ -1,0 +1,118 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import <UIKit/UIKit.h>
+#import "LPSetDeviceOrientationRoute.h"
+#import "LPOrientationOperation.h"
+#import "LPCocoaLumberjack.h"
+
+@interface UIDevice (LP_DEVICE_ORIENTATION_CATEGORY)
+
+-(void)setOrientation:(NSInteger)orientation animated:(BOOL)animated;
+-(void)setOrientation:(NSInteger)orientation;
+
+@end
+
+@interface LPSetDeviceOrientationRoute ()
+
+- (NSInteger)orientationWithDictionary:(NSDictionary *)arguments;
+- (NSInteger)orientationForString:(NSString *)string;
+- (BOOL)isValidUIDeviceOrientation:(NSInteger)orientation;
+
+@end
+
+@implementation LPSetDeviceOrientationRoute
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"POST"];
+}
+
+- (NSInteger)orientationForString:(NSString *)string {
+  NSInteger value;
+
+  if ([string isEqualToString:@"up"] ||
+      [string isEqualToString:@"top"] ||
+      [string isEqualToString:@"upside down"]) {
+    value = (NSInteger)UIDeviceOrientationPortraitUpsideDown;
+  } else if ([string isEqualToString:@"bottom"] ||
+             [string isEqualToString:@"down"] ||
+             [string isEqualToString:@"portrait"]) {
+    value = (NSInteger)UIDeviceOrientationPortrait;
+  } else if ([string isEqualToString:@"left"] ||
+             [string isEqualToString:@"landscape right"]) {
+      value = (NSInteger)UIDeviceOrientationLandscapeRight;
+  } else if ([string isEqualToString:@"right"] ||
+             [string isEqualToString:@"landscape left"]) {
+    value = (NSInteger)UIDeviceOrientationLandscapeLeft;
+  } else {
+    LPLogDebug(@"Cannot map orientation '%@' to a portrait, landscape right, \
+               landscape left, or upside down.", string);
+    LPLogDebug(@"Defaulting to portrait");
+    value = (NSInteger)UIDeviceOrientationPortrait;
+
+  }
+  return value;
+}
+
+- (BOOL)isValidUIDeviceOrientation:(NSInteger)orientation {
+  return (orientation >= UIDeviceOrientationPortrait &&
+          orientation <= UIDeviceOrientationLandscapeRight);
+}
+
+- (NSInteger)orientationWithDictionary:(NSDictionary *)arguments {
+  id value = arguments[@"orientation"];
+
+  NSInteger orientation;
+
+  if (!value) {
+    LPLogDebug(@"Expected key 'orientation' to have a value in arguments: %@",
+               arguments);
+    LPLogDebug(@"Setting orientation to portrait");
+    orientation = (NSInteger)UIDeviceOrientationPortrait;
+  } else if ([value isKindOfClass:[NSString class]]) {
+    NSString *string = (NSString *)value;
+    orientation = [self orientationForString:string];
+  } else if ([value isKindOfClass:[NSNumber class]]) {
+    NSNumber *number = (NSNumber *)value;
+    orientation = [number integerValue];
+  } else {
+    LPLogDebug(@"Expected an NSNumber or NSString for key 'orienation' in arguments:\
+               %@, but found %@", arguments, [value class]);
+    LPLogDebug(@"Setting orientation to portrait");
+    orientation = (NSInteger)UIDeviceOrientationPortrait;
+  }
+
+  if (![self isValidUIDeviceOrientation:orientation]) {
+    LPLogDebug(@"Normalized orientation %@ to UIDeviceOrientation '%@' which is\
+               an invalid orientation.", value, @(orientation));
+    LPLogDebug(@"Setting orientation to portrait");
+    orientation = (NSInteger)UIDeviceOrientationPortrait;
+  }
+
+  return orientation;
+}
+
+- (NSDictionary *) JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data {
+
+  NSInteger targetOrientation = [self orientationWithDictionary:data];
+
+  [[UIDevice currentDevice] setOrientation:targetOrientation
+                                  animated:YES];
+
+  NSString *statusBarOrientation = [LPOrientationOperation statusBarOrientation];
+  NSString *deviceOrientation = [LPOrientationOperation deviceOrientation];
+  NSDictionary *result =
+  @{
+    @"outcome" : @"SUCCESS",
+    @"results" : @{
+        @"status_bar_orientation" : statusBarOrientation,
+        @"device_orientation" : deviceOrientation
+        }
+    };
+  return result;
+}
+
+@end


### PR DESCRIPTION
### Motivation

Xcode 8.0 beta 3 had a problem setting the device orientation on iOS Simulators.

This appears to be corrected in Xcode 8.0 beta 4.

This PR adds `setOrientation` route to the LPServer which can be used to set the UIDeviceOrientation of iOS Simulators.  It's behavior on physical devices is well understood - it appears to work, but the animation not great (on some devices).

I believe this is worth committing to give us another orientation option.  I don't think we should make a client implementation at this time.

```
# Valid orientations:
#
# up, top, upside down => PortraitUpsideDown
# bottom, down, portrait => Portrait
# left, landscape right => LandscapeRight
# right, landscape left => LandscapeLeft
#
# The orientation can also be an integer corresponding to UIDeviceOrientation enum values.
#
# Invalid orientations are treated as portrait.
#
# Unknown, FaceUp, FaceDown orientations are are treated as portrait.
http({:method => :post, :path => 'setOrientation', {:orientation => < orientation > })
```

Filed a radar and forum post.

* 27638336 REGRESSION: Cannot change the orientation of a simulator with XCUITest in Xcode 8.0 beta 3
* [Developer Forum](https://forums.developer.apple.com/message/158993)
* https://github.com/calabash/DeviceAgent.iOS/pull/132
