### PR TITLE
Scroll to marked operations should descend to depth N

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPCollectionViewScrollToItemOperation.m
@@ -11,17 +11,14 @@
 // _arguments ==> [item_num, section_num, scroll postion, animated]
 - (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
 
-  // UICollectionView appears in iOS 6
-  Class clz = NSClassFromString(@"UICollectionView");
-  if (clz == nil) {
-    LPLogWarn(@"UICollectionView is not supported on this version of iOS:  '%@'",
-            [[UIDevice currentDevice] systemVersion]);
+  if (!target) {
+    LPLogWarn(@"Cannot perform operation on nil target");
     return nil;
   }
 
-  if ([target isKindOfClass:[UICollectionView class]] == NO) {
+  if (![[target class] isSubclassOfClass:[UICollectionView class]]) {
     LPLogWarn(@"View: %@ should be an instance of UICollectionView but found '%@'",
-            target, target == nil ? nil : [target class]);
+              target, NSStringFromClass([target class]));
     return nil;
   }
 

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.h
@@ -11,6 +11,7 @@
 @interface LPScrollToMarkOperation : LPOperation
 
 - (BOOL) view:(UIView *) aView hasMark:(NSString *) aMark;
+- (BOOL) view:(UIView *) aView hasSubviewWithMark:(NSString *) aMark;
 - (BOOL) cell:(UIView *) aCell contentViewHasSubviewMarked:(NSString *) aMark;
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.h
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.h
@@ -12,6 +12,5 @@
 
 - (BOOL) view:(UIView *) aView hasMark:(NSString *) aMark;
 - (BOOL) view:(UIView *) aView hasSubviewWithMark:(NSString *) aMark;
-- (BOOL) cell:(UIView *) aCell contentViewHasSubviewMarked:(NSString *) aMark;
 
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.m
@@ -66,14 +66,4 @@
   return result;
 }
 
-- (BOOL) cell:(UIView *) aCell contentViewHasSubviewMarked:(NSString *) aMark {
-  if ([aCell respondsToSelector: @selector(contentView)]){
-    UIView *contentView = [aCell valueForKey:@"contentView"];
-    for (UIView *subview in [contentView subviews]) {
-      if ([self view:subview hasMark:aMark]) { return YES; }
-    }
-  }
-  return NO;
-}
-
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.m
@@ -11,35 +11,59 @@
 #endif
 
 #import "LPScrollToMarkOperation.h"
+#import "LPInvoker.h"
+#import "LPInvocationResult.h"
+
+@interface LPScrollToMarkOperation ()
+
+- (BOOL) view:(UIView *) aView hasTextMatchingMark:(NSString *) aMark;
+
+@end
 
 @implementation LPScrollToMarkOperation
 
+- (BOOL) view:(UIView *) aView hasTextMatchingMark:(NSString *) aMark {
+  if (![aView respondsToSelector:@selector(text)]) { return NO; }
+
+  LPInvocationResult *result = [LPInvoker invokeOnMainThreadZeroArgumentSelector:@selector(text)
+                                                                      withTarget:aView];
+  if (result.isError || result.isNSNull) { return NO; }
+  
+  if (![[result.value class] isSubclassOfClass:[NSString class]]) { return NO; }
+
+  return [aMark isEqualToString:result.value];
+}
+
 - (BOOL) view:(UIView *) aView hasMark:(NSString *) aMark {
-  // iOS 5+
-  NSString *identifier = nil;
-  if ([aView respondsToSelector:@selector(accessibilityIdentifier)]) {
-    identifier = aView.accessibilityIdentifier;
-  }
+
+  if ([aView.accessibilityIdentifier isEqualToString:aMark]) { return YES; }
   
-  if (identifier != nil && [identifier isEqualToString:aMark]) {
-    return YES;
-  }
-  
-  if ([aView.accessibilityLabel isEqualToString:aMark]) {
-    return YES;
-  }
-  
-  if ([aView isKindOfClass:[UILabel class]]) {
-    UILabel *label = (UILabel *) aView;
-    if ([label.text isEqualToString:aMark]) { return YES; }
-  }
-  
-  if ([aView isKindOfClass:[UITextView class]]) {
-    UITextView *textView = (UITextView *) aView;
-    if ([textView.text isEqualToString:aMark]) { return YES; }
+  if ([aView.accessibilityLabel isEqualToString:aMark]) { return YES; }
+
+  if ([self view:aView hasTextMatchingMark:aMark]) { return YES; }
+
+  if ([aView isKindOfClass:[UIButton class]]) {
+    UIButton *button = (UIButton *) aView;
+    if ([[button currentTitle] isEqualToString:aMark]) { return YES; }
   }
   
   return NO;
+}
+
+- (BOOL) view:(UIView *)aView hasSubviewWithMark:(NSString *)aMark {
+  BOOL result = NO;
+
+  if ([self view:aView hasMark:aMark]) {
+    result = YES;
+  } else if ([aView.subviews count] == 0) {
+    result = NO;
+  } else {
+    for (UIView *subView in [aView subviews]) {
+      result = [self view:subView hasSubviewWithMark:aMark];
+      if (result) { break; }
+    }
+  }
+  return result;
 }
 
 - (BOOL) cell:(UIView *) aCell contentViewHasSubviewMarked:(NSString *) aMark {

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowOperation.m
@@ -29,59 +29,64 @@
   return nil;
 }
 
-
 - (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
   NSArray *arguments = self.arguments;
 
-  if ([target isKindOfClass:[UITableView class]]) {
-    UITableView *table = (UITableView *) target;
-    NSNumber *rowNum = [arguments objectAtIndex:0];
-    if ([arguments count] >= 2) {
-      NSInteger row = [rowNum integerValue];
-      NSInteger sec = [[arguments objectAtIndex:1] integerValue];
-      NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:sec];
-
-      if ((sec >= 0 && sec < [table numberOfSections]) && (row >= 0 && row < [table numberOfRowsInSection:sec])) {
-        UITableViewScrollPosition sp = UITableViewScrollPositionTop;
-        BOOL animate = YES;
-        if ([arguments count] >= 3) {
-          NSString *pos = [arguments objectAtIndex:2];
-          if ([@"middle" isEqualToString:pos]) {
-            sp = UITableViewScrollPositionMiddle;
-          } else if ([@"bottom" isEqualToString:pos]) {
-            sp = UITableViewScrollPositionBottom;
-          } else if ([@"none" isEqualToString:pos]) {
-            sp = UITableViewScrollPositionNone;
-          }
-        }
-        if ([arguments count] >= 4) {
-          NSNumber *ani = [arguments objectAtIndex:3];
-          animate = [ani boolValue];
-        }
-
-        [table scrollToRowAtIndexPath:path
-                     atScrollPosition:sp
-                             animated:animate];
-
-        return target;
-      } else {
-        LPLogWarn(@"Table doesn't contain indexPath: %@", path);
-        return nil;
-      }
-    } else {
-      NSIndexPath *indexPathForRow = [self indexPathForRow:[rowNum unsignedIntegerValue]
-                                                   inTable:table];
-      if (!indexPathForRow) { return nil;  }
-
-      [table scrollToRowAtIndexPath:indexPathForRow
-                   atScrollPosition:UITableViewScrollPositionTop
-                           animated:YES];
-      return target;
-    }
+  if (!target) {
+    LPLogWarn(@"Cannot perform operation on nil target");
+    return nil;
   }
 
- LPLogWarn(@"View %@ should be a table view for scrolling to row/cell to make sense",
-          target);
-  return nil;
+  if (![[target class] isSubclassOfClass:[UITableView class]]) {
+    LPLogWarn(@"View: %@ should be an instance of UITableView but found '%@'",
+              target, NSStringFromClass([target class]));
+    return nil;
+  }
+
+  UITableView *table = (UITableView *) target;
+  NSNumber *rowNum = [arguments objectAtIndex:0];
+  if ([arguments count] >= 2) {
+    NSInteger row = [rowNum integerValue];
+    NSInteger sec = [[arguments objectAtIndex:1] integerValue];
+    NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:sec];
+
+    if ((sec >= 0 && sec < [table numberOfSections]) && (row >= 0 && row < [table numberOfRowsInSection:sec])) {
+      UITableViewScrollPosition sp = UITableViewScrollPositionTop;
+      BOOL animate = YES;
+      if ([arguments count] >= 3) {
+        NSString *pos = [arguments objectAtIndex:2];
+        if ([@"middle" isEqualToString:pos]) {
+          sp = UITableViewScrollPositionMiddle;
+        } else if ([@"bottom" isEqualToString:pos]) {
+          sp = UITableViewScrollPositionBottom;
+        } else if ([@"none" isEqualToString:pos]) {
+          sp = UITableViewScrollPositionNone;
+        }
+      }
+      if ([arguments count] >= 4) {
+        NSNumber *ani = [arguments objectAtIndex:3];
+        animate = [ani boolValue];
+      }
+
+      [table scrollToRowAtIndexPath:path
+                   atScrollPosition:sp
+                           animated:animate];
+
+      return target;
+    } else {
+      LPLogWarn(@"Table doesn't contain indexPath: %@", path);
+      return nil;
+    }
+  } else {
+    NSIndexPath *indexPathForRow = [self indexPathForRow:[rowNum unsignedIntegerValue]
+                                                 inTable:table];
+    if (!indexPathForRow) { return nil;  }
+
+    [table scrollToRowAtIndexPath:indexPathForRow
+                 atScrollPosition:UITableViewScrollPositionTop
+                         animated:YES];
+    return target;
+  }
 }
+
 @end

--- a/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToRowWithMarkOperation.m
@@ -7,46 +7,43 @@
 
 @implementation LPScrollToRowWithMarkOperation
 
-- (BOOL) cell:(UITableViewCell *) aCell contentViewHasSubviewMarked:(NSString *) aMark {
-  // check the textLabel first
-  if ([self view:aCell.textLabel hasMark:aMark]) {return YES;}
-
-  return [super cell:aCell contentViewHasSubviewMarked:aMark];
-}
-
-
 - (NSIndexPath *) indexPathForRowWithMark:(NSString *) aMark inTable:(UITableView *) aTable {
   NSUInteger numberOfSections = [aTable numberOfSections];
 
   id<UITableViewDataSource> dataSource = aTable.dataSource;
 
+  NSIndexPath *path = nil;
+  UITableViewCell *cell = nil;
+
   for (NSUInteger section = 0; section < numberOfSections; section++) {
     NSUInteger numberOfRows = [aTable numberOfRowsInSection:section];
     for (NSUInteger row = 0; row < numberOfRows; row++) {
-      NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:section];
-      // only returns visible cells
-      UITableViewCell *cell = [aTable cellForRowAtIndexPath:path];
-      if (cell == nil) {
-        // ask the dataSource for the cell
-        cell = [dataSource tableView:aTable cellForRowAtIndexPath:path];
-      }
+      path = [NSIndexPath indexPathForRow:row inSection:section];
 
-      // is the cell itself marked?
-      if ([self view:cell hasMark:aMark]) {return path;}
-      // are any of it's subviews marked?
-      if ([self cell:cell contentViewHasSubviewMarked:aMark]) {return path;}
+      cell = [dataSource tableView:aTable cellForRowAtIndexPath:path];
+
+      if ([self view:cell hasMark:aMark]) { return path; }
+      if ([self view:cell.textLabel hasMark:aMark]) { return path; }
+      if ([self view:cell.detailTextLabel hasMark:aMark]) { return path; }
+      if ([self view:cell hasSubviewWithMark:aMark]) { return path; }
+      if ([self view:cell.contentView hasSubviewWithMark:aMark]) { return path; }
     }
   }
   return nil;
 }
 
-
 //                 required      optional     optional
 // _arguments ==> [row mark, scroll position, animated]
 - (id) performWithTarget:(id) target error:(NSError *__autoreleasing*) error {
-  if ([target isKindOfClass:[UITableView class]] == NO) {
-    LPLogWarn(@"View %@ should be a table view for scrolling to row/cell to make sense",
-            target);
+
+  if (!target) {
+    LPLogWarn(@"Cannot perform operation on nil target");
+    return nil;
+  }
+
+  if (![[target class] isSubclassOfClass:[UITableView class]]) {
+    LPLogWarn(@"View: %@ should be an instance of UITableView but found '%@'",
+              target, NSStringFromClass([target class]));
     return nil;
   }
 
@@ -89,4 +86,5 @@
 
   return target;
 }
+
 @end


### PR DESCRIPTION
### Motivation

Resolves:

* scroll_to_collection_view_item_with_mark doesn't work for complex collection view [#1162](https://github.com/calabash/calabash-ios/issues/1162)
* LPServer needs to descend to depth N when searching for marks [JIRA](https://jira.xamarin.com/browse/TCFW-605)

Progress on:

* UITest/XDB ScrollTo [JIRA](https://jira.xamarin.com/browse/TCFW-146)

@jonstoneman This is one piece of the puzzle.  A subsequent PR will add the `map scrollToMark` behavior.

### Testing

The testing story is not great.

The following Scenarios are running locally on the CalSmokeApp but require some synchronization between the LPServer, run-loop, and Calabash iOS gem to work elsewhere.

I shared the calabash.framework with the user who reported the problem and they verified that it fixed their problem.

```
Scenario: Collection views
When I touch the collection views row
Then I see the collection views page
Then I scroll the logos collection to the steam icon by mark
Then I scroll the logos collection to the github icon by index
Then I scroll the logos collection to the wordpress icon using a subview mark  *NEW*
Then I scroll up on the logos collection to the android icon
Then I scroll the colors collection to the middle of the purple boxes
Then I scroll the colors collection to the Wedge Antilles box using a subview mark *NEW*

Scenario: Table views
When I touch the table views row
Then I see the table views page
Then I scroll the logos table to the steam row by mark
Then I scroll the logos table to the apple row using a subview mark *NEW*
Then I scroll the logos table to the github row by index
Then I scroll up on the logos table to the android row
```

ATTN: @JoeSSS 