### PR TITLE
Feature/update form factor table with latest iphone7 info

### DIFF
--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -314,7 +314,9 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 
     // iPhone 7/7+
     @"iPhone9,1" : @"iphone 6",
+    @"iPhone9,3" : @"iphone 6",
     @"iPhone9,2" : @"iphone 6+",
+    @"iPhone9,4" : @"iphone 6+",
 
     // iPad Pro 13in
     @"iPad6,7" : @"ipad pro",


### PR DESCRIPTION
### Motivation

Touch coordinates are wrong because the iPhone 7 physical devices are not reporting as iPhone 6 and 6+ form factors.

### Testing

* [Before](https://testcloud.xamarin.com/test/sh-calaba-iphoneonly_1417836e-c8f0-4026-9481-fdaa492159e7/?step=0_0_1)
* [After](https://testcloud.xamarin.com/test/sh.calaba.iphoneonly_44cdcb79-d402-49e3-a4ba-e50cfbbc7c63/)

Anyone can review and merge.  This should be merged ASAP!!!