### PR TITLE
Log POST requests w/ body

### DIFF
--- a/calabash/Classes/FranklyServer/LPRouter.m
+++ b/calabash/Classes/FranklyServer/LPRouter.m
@@ -157,7 +157,7 @@
                                                     length:[postData length]
                                                   encoding:NSUTF8StringEncoding];
         params = [LPJSONUtils deserializeDictionary:postDataAsString];
-
+        LPLogInfo(@"POST: [%@] %@", NSStringFromClass([route class]), params);
         // UNEXPECTED
         // After the POST data is parsed we need to unset it.
         _mutablePostData = nil;


### PR DESCRIPTION
# Motivation

Log POST request raw bodies (as `NSDictionary *`) to increase helpful output in tests. 

CC: @jmoody 