### PR TITLE
Fixes finding subview in subviewWithMark

### DIFF
--- a/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.m
+++ b/calabash/Classes/FranklyServer/Operations/LPScrollToMarkOperation.m
@@ -80,6 +80,7 @@
     if ([self view:aView hasMark:aMark]) {
       result = aView;
     }
+    if (result) { return result; }
     for (UIView* subView in [aView subviews]) {
       result = [self view:subView subviewWithMark:aMark];
       if (result) { break; }


### PR DESCRIPTION
**Motivation**

I noticed failures in using `ScrollTo(Mark)` because `subviewWithMark` would return a `null` value even though a view with the matching mark was found (it just wasn't the _last_ subview so result would be set to null after having a non-null value) resulting in no scrolling being performed. 