### PR TITLE
Jenkins: force Xcode 7 CoreSimulatorService to load

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,24 +12,24 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.3)
+    CFPropertyList (2.3.5)
     awesome_print (1.7.0)
-    command_runner_ng (0.1.0)
-    httpclient (2.8.2.4)
-    i18n (0.7.0)
-    json (1.8.3)
+    command_runner_ng (0.1.2)
+    httpclient (2.8.3)
+    i18n (0.8.1)
+    json (1.8.6)
     retriable (2.0.2)
     rouge (1.11.1)
-    run_loop (2.2.0)
+    run_loop (2.4.1)
       CFPropertyList (~> 2.2)
       awesome_print (~> 1.2)
       command_runner_ng (>= 0.0.2)
-      httpclient (~> 2.6)
+      httpclient (>= 2.7.1, < 3.0)
       i18n (>= 0.7.0, < 1.0)
       json (~> 1.8)
       thor (>= 0.18.1, < 1.0)
-    thor (0.19.1)
-    xcpretty (0.2.2)
+    thor (0.19.4)
+    xcpretty (0.2.6)
       rouge (~> 1.8)
 
 PLATFORMS
@@ -42,4 +42,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.13.1
+   1.14.3

--- a/bin/ci/jenkins/make-ipa.sh
+++ b/bin/ci/jenkins/make-ipa.sh
@@ -7,7 +7,7 @@ if [ -z "${JENKINS_HOME}" ]; then
   exit 1
 fi
 
-bin/ci/travis/install-keychain.sh
+bin/ci/jenkins/install-keychain.sh
 
 CODE_SIGN_DIR="${HOME}/.calabash/calabash-codesign"
 KEYCHAIN="${CODE_SIGN_DIR}/ios/Calabash.keychain"

--- a/bin/ci/jenkins/run.sh
+++ b/bin/ci/jenkins/run.sh
@@ -42,8 +42,7 @@ bin/ci/jenkins/make-ipa.sh
 bundle exec bin/test/test-cloud.rb
 
 # Restart CoreSimulator processes
-bundle update
-bundle exec run-loop simctl manage-processes
+bundle install
 
 banner "Run Tests"
 bundle exec bin/test/xctest.rb

--- a/bin/ci/jenkins/run.sh
+++ b/bin/ci/jenkins/run.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+set +e
+
+# Force Xcode 7 CoreSimulator env to be loaded so xcodebuild does not fail.
+export DEVELOPER_DIR=/Xcode/7.3.1/Xcode.app/Contents/Developer
+
+for try in {1..4}; do
+  xcrun simctl help &>/dev/null
+  sleep 1.0
+done
+
+set -e
+
 function info {
   echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
 }

--- a/bin/test/xctest.rb
+++ b/bin/test/xctest.rb
@@ -29,7 +29,7 @@ end
 args =
       [
             'test',
-            '-SYMROOT=build',
+            '-SYMROOT=build/xctest',
             '-derivedDataPath build/xctest',
             '-project calabash.xcodeproj',
             '-scheme XCTest',
@@ -41,6 +41,8 @@ args =
       ]
 
 Dir.chdir(working_dir) do
+
+  FileUtils.rm_rf(File.join(working_dir, "build/xctest"))
 
   cmd = "xcrun xcodebuild #{args.join(' ')}"
 

--- a/bin/test/xctest.rb
+++ b/bin/test/xctest.rb
@@ -13,6 +13,7 @@ xcode = RunLoop::Xcode.new
 default_sim_name = RunLoop::Core.default_simulator
 default_sim = RunLoop::Device.device_with_identifier(default_sim_name)
 
+RunLoop::CoreSimulator.terminate_core_simulator_processes
 core_sim = RunLoop::CoreSimulator.new(default_sim, nil, {:xcode => xcode})
 core_sim.launch_simulator
 

--- a/bin/test/xctest.rb
+++ b/bin/test/xctest.rb
@@ -73,13 +73,9 @@ Dir.chdir(working_dir) do
                                     :fail_msg => 'XCTests failed',
                                     :env_vars => env,
                                     :exit_on_nonzero_status => false})
-    if Luffa::Environment.travis_ci?
-      if exit_code != 0
-        Luffa.log_fail "XCTest exited '#{exit_code}' - did a test fail or did the tests not start?"
-        raise XCTestFailedError, 'XCTest failed.'
-      end
-    else
-      exit(exit_code)
+    if exit_code != 0
+      Luffa.log_fail "XCTest exited '#{exit_code}' - did a test fail or did the tests not start?"
+      raise XCTestFailedError, 'XCTest failed.'
     end
   end
 end

--- a/bin/test/xctest.rb
+++ b/bin/test/xctest.rb
@@ -13,7 +13,6 @@ xcode = RunLoop::Xcode.new
 default_sim_name = RunLoop::Core.default_simulator
 default_sim = RunLoop::Device.device_with_identifier(default_sim_name)
 
-RunLoop::CoreSimulator.terminate_core_simulator_processes
 core_sim = RunLoop::CoreSimulator.new(default_sim, nil, {:xcode => xcode})
 core_sim.launch_simulator
 


### PR DESCRIPTION
### Motivation

Most jobs on Jenkins have migrated to Xcode 8.   This job is not ready to be migrated - there are failing Xcode 8 unit tests. The Xcode 8-based jobs load the Xcode 8 CoreSimulatorService to keep xcodebuild from failing. This job needs to load the Xcode 7 CoreSimulatorService.

The run_loop version in the Gemfile.lock was 2.2.4 which is ancient.  Updated the Gemfile.lock to get the latest run-loop (2.4.1).

I watched CI and saw that XCTests were failing because the Simulator did not boot properly, so I reworked how we manage the CoreSim processes.

I also revived the XCTest retry algorithm.

Related:

* Fixes finding subview in subviewWithMark #379