### PR TITLE
Route for clearing text that calls delegate methods and posts text changed notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ cucumber/xtc-submit-acquaint
 !cucumber/acquaint/AcquaintNativeiOS.app
 !cucumber/acquaint/AcquaintNativeiOS.app.dSYM
 !cucumber/acquaint/AcquaintNativeiOS.ipa
+cucumber/xtc-submit-device-agent-test-app
+!cucumber/device-agent-test-app/TestApp.app
+!cucumber/device-agent-test-app/TestApp.app.dSYM
+!cucumber/device-agent-test-app/TestApp.app
 
 # The version tool which is staged to bin as part
 # of the build process.

--- a/bin/test/cucumber.rb
+++ b/bin/test/cucumber.rb
@@ -68,7 +68,7 @@ Dir.chdir working_dir do
     passed_sims = []
     failed_sims = []
     devices.each do |key, name|
-      cucumber_cmd = "bundle exec cucumber -p simulator --tags ~@acquaint --format json -o reports/#{key}.json #{cucumber_args}"
+      cucumber_cmd = "bundle exec cucumber -p simulator --tags ~@device_agent_test_app --tags ~@acquaint --format json -o reports/#{key}.json #{cucumber_args}"
 
       match = simulators.find do |sim|
         sim.name == name && sim.version == sim_version

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		42069AFD1EB1035B00C1F0A5 /* LPMachClock.m in Sources */ = {isa = PBXBuildFile; fileRef = 42069AFC1EB1035B00C1F0A5 /* LPMachClock.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		42069AFE1EB103C100C1F0A5 /* LPMachClock.m in Sources */ = {isa = PBXBuildFile; fileRef = 42069AFC1EB1035B00C1F0A5 /* LPMachClock.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		42069AFF1EB103C200C1F0A5 /* LPMachClock.m in Sources */ = {isa = PBXBuildFile; fileRef = 42069AFC1EB1035B00C1F0A5 /* LPMachClock.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		42069B001EB103C200C1F0A5 /* LPMachClock.m in Sources */ = {isa = PBXBuildFile; fileRef = 42069AFC1EB1035B00C1F0A5 /* LPMachClock.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		429CD6921EAFBC2800E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		429CD6931EAFBD2800E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		429CD6941EAFBD2900E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -683,6 +687,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		42069AFB1EB1034600C1F0A5 /* LPMachClock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPMachClock.h; sourceTree = "<group>"; };
+		42069AFC1EB1035B00C1F0A5 /* LPMachClock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPMachClock.m; sourceTree = "<group>"; };
 		429CD6901EAFBC1800E7CA85 /* LPClearTextRoute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPClearTextRoute.h; sourceTree = "<group>"; };
 		429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPClearTextRoute.m; sourceTree = "<group>"; };
 		5BFF97A218B391810094E71E /* LPCollectionViewScrollToItemWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCollectionViewScrollToItemWithMarkOperation.h; sourceTree = "<group>"; };
@@ -1617,6 +1623,8 @@
 				F5C04E261B33110B00F23526 /* LPDecimalRounder.h */,
 				F5C04E271B33110B00F23526 /* LPDecimalRounder.m */,
 				F56592601B4713FE00C044C8 /* LPRepeatingTimerProtocol.h */,
+				42069AFB1EB1034600C1F0A5 /* LPMachClock.h */,
+				42069AFC1EB1035B00C1F0A5 /* LPMachClock.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2672,6 +2680,7 @@
 				B15BF9A919ABB1DD00B38577 /* LPCORSResponse.m in Sources */,
 				B15BF9AA19ABB1DD00B38577 /* LPRouter.m in Sources */,
 				B15BF9AB19ABB1DD00B38577 /* LPScrollToMarkOperation.m in Sources */,
+				42069B001EB103C200C1F0A5 /* LPMachClock.m in Sources */,
 				F5A8B4651B39BFEB00F390CA /* LPContextFilterLogFormatter.m in Sources */,
 				B15BF9AC19ABB1DD00B38577 /* LPScrollToRowWithMarkOperation.m in Sources */,
 				B15BF9AD19ABB1DD00B38577 /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */,
@@ -2786,6 +2795,7 @@
 				B1D5BD8319A23BCE0070E8CE /* LPHTTPDynamicFileResponse.m in Sources */,
 				F5A8B4AB1B39BFEB00F390CA /* LPTTYLogger.m in Sources */,
 				B1D5BD8419A23BCE0070E8CE /* LPSSKeychainQuery.m in Sources */,
+				42069AFF1EB103C200C1F0A5 /* LPMachClock.m in Sources */,
 				B1D5BD8519A23BCE0070E8CE /* LPCollectionViewScrollToItemWithMarkOperation.m in Sources */,
 				B1D5BD8619A23BCE0070E8CE /* LPHTTPFileResponse.m in Sources */,
 				B1D5BD8719A23BCE0070E8CE /* LPHTTPRedirectResponse.m in Sources */,
@@ -2921,6 +2931,7 @@
 				F5091BEC18C4E1D700C85307 /* LPRouter.m in Sources */,
 				F5091BED18C4E1D700C85307 /* LPQueryAllOperation.m in Sources */,
 				F5091BEE18C4E1D700C85307 /* LPOperation.m in Sources */,
+				42069AFD1EB1035B00C1F0A5 /* LPMachClock.m in Sources */,
 				F5A8B4631B39BFEB00F390CA /* LPContextFilterLogFormatter.m in Sources */,
 				F5091BEF18C4E1D700C85307 /* LPQueryOperation.m in Sources */,
 				F5091BF018C4E1D700C85307 /* LPScrollOperation.m in Sources */,
@@ -3165,6 +3176,7 @@
 				B15369FD1A327A400093923F /* LPUIATapRouteOverSharedElement.m in Sources */,
 				F5C224E01AD473F0001DB4FA /* LPDeviceTest.m in Sources */,
 				F54EFE8D1B5B88D500F8D665 /* LPRouterTest.m in Sources */,
+				42069AFE1EB103C100C1F0A5 /* LPMachClock.m in Sources */,
 				89043AC21C289A5D0067E22F /* LPConstants.m in Sources */,
 				E2F8025B1BE207670000A0E4 /* LPShakeRoute.m in Sources */,
 				F50CBF7D1A040564004AC9DA /* LPSSKeychainQuery.m in Sources */,

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		429CD6921EAFBC2800E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		429CD6931EAFBD2800E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		429CD6941EAFBD2900E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		429CD6951EAFBD2900E7CA85 /* LPClearTextRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		89043AC21C289A5D0067E22F /* LPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 89043ABE1C289A5D0067E22F /* LPConstants.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		89043AC31C289A5D0067E22F /* LPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 89043ABE1C289A5D0067E22F /* LPConstants.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		89043AC41C289A5D0067E22F /* LPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 89043ABE1C289A5D0067E22F /* LPConstants.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -679,6 +683,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		429CD6901EAFBC1800E7CA85 /* LPClearTextRoute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPClearTextRoute.h; sourceTree = "<group>"; };
+		429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPClearTextRoute.m; sourceTree = "<group>"; };
 		5BFF97A218B391810094E71E /* LPCollectionViewScrollToItemWithMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPCollectionViewScrollToItemWithMarkOperation.h; sourceTree = "<group>"; };
 		5BFF97A318B391810094E71E /* LPCollectionViewScrollToItemWithMarkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCollectionViewScrollToItemWithMarkOperation.m; sourceTree = "<group>"; };
 		5BFF97A618B392370094E71E /* LPScrollToMarkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPScrollToMarkOperation.h; sourceTree = "<group>"; };
@@ -1516,6 +1522,8 @@
 				F5A6B9691BD14E96009FD08B /* LPReflectionRoute.m */,
 				F5963ECD1D626368002F9304 /* LPStatusBarRoute.h */,
 				F5963ECE1D626368002F9304 /* LPStatusBarRoute.m */,
+				429CD6901EAFBC1800E7CA85 /* LPClearTextRoute.h */,
+				429CD6911EAFBC2800E7CA85 /* LPClearTextRoute.m */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -2716,6 +2724,7 @@
 				B15BF9CE19ABB1DE00B38577 /* LPISO8601DateFormatter.m in Sources */,
 				B15BF9CF19ABB1DE00B38577 /* LPCDataScanner_Extensions.m in Sources */,
 				B1670E2C1A32410F00000A62 /* LPDumpRoute.m in Sources */,
+				429CD6951EAFBD2900E7CA85 /* LPClearTextRoute.m in Sources */,
 				B15BF9D019ABB1DE00B38577 /* LPCJSONDeserializer.m in Sources */,
 				F576058F1BCE77F000E89C97 /* LPSuspendAppRoute.m in Sources */,
 				B15BF9D119ABB1DE00B38577 /* LPCJSONScanner.m in Sources */,
@@ -2788,6 +2797,7 @@
 				B1D5BD8B19A23BCE0070E8CE /* LPOperation.m in Sources */,
 				F5A8B4641B39BFEB00F390CA /* LPContextFilterLogFormatter.m in Sources */,
 				B1D5BD8C19A23BCE0070E8CE /* LPQueryOperation.m in Sources */,
+				429CD6941EAFBD2900E7CA85 /* LPClearTextRoute.m in Sources */,
 				B1D5BDDA19A23BE00070E8CE /* LPCalabashFrankRegistrar.m in Sources */,
 				B1D5BD8D19A23BCE0070E8CE /* LPScrollOperation.m in Sources */,
 				B1D5BD8E19A23BCE0070E8CE /* LPUIATapRoute.m in Sources */,
@@ -2963,6 +2973,7 @@
 				F5091C0F18C4E1D700C85307 /* UIScriptASTLast.m in Sources */,
 				F5091C1018C4E1D700C85307 /* LPEnv.m in Sources */,
 				B13B7FC01A31FE560054FFB1 /* LPDumpRoute.m in Sources */,
+				429CD6921EAFBC2800E7CA85 /* LPClearTextRoute.m in Sources */,
 				F5091C1118C4E1D700C85307 /* UIScriptASTWith.m in Sources */,
 				F576058D1BCE77F000E89C97 /* LPSuspendAppRoute.m in Sources */,
 				F5E2D1E018C9120E00A0D9B6 /* LPSSKeychain.m in Sources */,
@@ -3104,6 +3115,7 @@
 				F5A6B9721BD14EE2009FD08B /* LPReflectionRouteTest.m in Sources */,
 				F50CBFB21A0405B2004AC9DA /* LPExitRoute.m in Sources */,
 				F5A8B4701B39BFEB00F390CA /* LPMultiFormatter.m in Sources */,
+				429CD6931EAFBD2800E7CA85 /* LPClearTextRoute.m in Sources */,
 				F5986B301B5A327500CCB142 /* LPOperationTest.m in Sources */,
 				F50CBFA31A0405B2004AC9DA /* LPAppPropertyRoute.m in Sources */,
 				F52975C51D4FBA29009094D5 /* LPSetDeviceOrientationRoute.m in Sources */,

--- a/calabash/Classes/CalabashServer.m
+++ b/calabash/Classes/CalabashServer.m
@@ -45,6 +45,7 @@
 #import "LPReflectionRoute.h"
 #import "LPSetDeviceOrientationRoute.h"
 #import "LPStatusBarRoute.h"
+#import "LPClearTextRoute.h"
 
 @interface CalabashServer ()
 - (void) start;
@@ -211,6 +212,10 @@
     LPStatusBarRoute *statusBarRoute = [LPStatusBarRoute new];
     [LPRouter addRoute:statusBarRoute forPath:@"statusBar"];
     [statusBarRoute release];
+
+    LPClearTextRoute *clearTextRoute = [LPClearTextRoute new];
+    [LPRouter addRoute:clearTextRoute forPath:@"clearText"];
+    [clearTextRoute release];
 
     _httpServer = [[[LPHTTPServer alloc] init] retain];
 

--- a/calabash/Classes/FranklyServer/Routes/LPClearTextRoute.h
+++ b/calabash/Classes/FranklyServer/Routes/LPClearTextRoute.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "LPRoute.h"
+
+@interface LPClearTextRoute : NSObject <LPRoute>
+
+@end

--- a/calabash/Classes/FranklyServer/Routes/LPClearTextRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPClearTextRoute.m
@@ -1,0 +1,140 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import "LPClearTextRoute.h"
+#import "UIScriptParser.h"
+#import "LPTouchUtils.h"
+#import "LPCocoaLumberjack.h"
+#import "LPJSONUtils.h"
+
+@implementation LPClearTextRoute
+
+- (BOOL) supportsMethod:(NSString *) method atPath:(NSString *) path {
+  return [method isEqualToString:@"GET"];
+}
+
+- (NSDictionary *)failureResponseWithReason:(NSString *)reason {
+    return @{
+        @"outcome" : @"FAILURE",
+        @"reason" : reason,
+        @"details" : @""
+    };
+}
+
+- (NSDictionary *)successResponseWithResult:(id)result {
+    return @{
+       @"outcome" : @"SUCCESS",
+       @"results" : @[result]
+    };
+}
+
+- (id)firstResponder {
+  NSString *query = @"* isFirstResponder:1 index:0";
+  UIScriptParser *parser = [[UIScriptParser alloc] initWithUIScript:query];
+  [parser parse];
+  NSArray *allWindows = [LPTouchUtils applicationWindows];
+  NSArray *results = [parser evalWith:allWindows];
+  if (!results || results.count == 0) {
+    return nil;
+  } else {
+    return results[0];
+  }
+}
+
+- (NSDictionary *)JSONResponseForMethod:(NSString *) method
+                                     URI:(NSString *) path
+                                    data:(NSDictionary *) data {
+  NSString *reason = @"";
+  id target = [self firstResponder];
+  if (!target) {
+    reason = [NSString stringWithFormat:@"Cannot clear text because no view is first responder"];
+    LPLogError(@"%@", reason);
+    return [self failureResponseWithReason:reason];
+  }
+
+  if (![target respondsToSelector:@selector(isFirstResponder)]) {
+    reason = [NSString stringWithFormat:@"Target %@ does not respond to 'isFirstResponder'", target];
+    return [self failureResponseWithReason:reason];
+  }
+
+  id delegate = nil;
+  if ([target respondsToSelector:@selector(delegate)]) {
+    delegate = [target performSelector:@selector(delegate)];
+  }
+
+  BOOL shouldClearText = YES;
+  NSString *existingText = @"";
+  if ([target respondsToSelector:@selector(text)]) {
+    id currentText = [target performSelector:@selector(text)];
+    if (currentText) {
+      existingText = (NSString *)currentText;
+    }
+  }
+
+  NSRange textRange = NSRangeFromString(existingText);
+  if ([target respondsToSelector:@selector(setText:)]) {
+    shouldClearText = [self shouldClearTextInRange:textRange WithDelegate:delegate withTarget:target];
+    if (shouldClearText) {
+      [target performSelector:@selector(setText:) withObject:@""];
+    }
+  } else {
+    // Check if it's UIKeyInput protocol
+    LPLogDebug(@"Target class %@ does not respond to setText checking UIKeyInput", target);
+    if ([target conformsToProtocol:@protocol(UIKeyInput)]) {
+      LPLogDebug(@"Attempting to clearText with deleteBackward");
+      while ([target hasText]) {
+        [target deleteBackward];
+      }
+    } else {
+      reason = [NSString stringWithFormat:@"Target %@ does not respond to setText nor deleteBackward", target];
+      return [self failureResponseWithReason:reason];
+    }
+  }
+
+  [self fireTextChangeMethodsWithDelegate:delegate withTarget:target];
+
+  return [self successResponseWithResult:[LPJSONUtils jsonifyObject:target]];
+}
+
+- (BOOL)shouldClearTextInRange:(NSRange)range WithDelegate:(id)delegate withTarget:(id)target {
+  if (!delegate) { return YES; }
+
+  if ([target isKindOfClass:[UITextField class]]) {
+    if ([delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
+      return [delegate textField:target shouldChangeCharactersInRange:range replacementString:@""];
+    }
+    if ([delegate respondsToSelector:@selector(textFieldShouldClear:)]) {
+      return [delegate textFieldShouldClear:target];
+    }
+  } else if ([target isKindOfClass:[UITextView class]]) {
+    return [delegate textView:target shouldChangeTextInRange:range replacementText:@""];
+  } else if ([target isKindOfClass:[UISearchBar class]]) {
+    return [delegate searchBar:target shouldChangeTextInRange:range replacementText:@""];
+  }
+
+  return YES;
+}
+
+- (void)fireTextChangeMethodsWithDelegate:(id)delegate withTarget:(id)target {
+  if ([target isKindOfClass:[UITextField class]]) {
+    [[NSNotificationCenter defaultCenter] postNotificationName:UITextFieldTextDidChangeNotification object:target];
+  } else if ([target isKindOfClass:[UITextView class]]) {
+    if (delegate) {
+      if ([delegate respondsToSelector:@selector(textViewDidChangeSelection:)]) {
+        [delegate textViewDidChangeSelection:target];
+      }
+
+      if ([delegate respondsToSelector:@selector(textViewDidChange:)]) {
+        [delegate textViewDidChange:target];
+      }
+    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:target];
+  } else if ([target isKindOfClass:[UISearchBar class]]) {
+    if (delegate && [delegate respondsToSelector:@selector(searchBar:textDidChange:)]) {
+      [delegate searchBar:target textDidChange:@""];
+    }
+  }
+}
+
+@end

--- a/calabash/Classes/Utils/LPMachClock.h
+++ b/calabash/Classes/Utils/LPMachClock.h
@@ -1,0 +1,25 @@
+#include <Foundation/Foundation.h>
+
+/**
+ An object wrapper around mach_absolute_time()
+
+ This is a singleton class.  Calling `init` will raise an exception.
+ */
+@interface LPMachClock : NSObject
+
+/**
+ The shared clock.
+
+ This is a singleton class.  Calling init will throw an exception.
+ @return the MachClock
+ */
++ (instancetype)sharedClock;
+
+/**
+ What is the time right now?
+
+ @return the mach absolute time as an NSTimeInterval
+ */
+- (NSTimeInterval)absoluteTime;
+
+@end

--- a/calabash/Classes/Utils/LPMachClock.m
+++ b/calabash/Classes/Utils/LPMachClock.m
@@ -1,0 +1,55 @@
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#import <mach/mach.h>
+#import <mach/mach_time.h>
+#import "LPMachClock.h"
+
+// http://stackoverflow.com/questions/889380/how-can-i-get-a-precise-time-for-example-in-milliseconds-in-objective-c
+
+@interface LPMachClock()
+
+- (NSTimeInterval)machAbsoluteToTimeInterval:(uint64_t)machAbsolute;
+- (instancetype)initPrivate;
+
+@end
+
+@implementation LPMachClock
+
+mach_timebase_info_data_t _clock_timebase;
+
++ (instancetype)sharedClock {
+  static LPMachClock *clock;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    clock = [[LPMachClock alloc] initPrivate];
+  });
+  return clock;
+}
+
+- (instancetype)initPrivate {
+  self = [super init];
+  if (self) {
+    mach_timebase_info(&_clock_timebase);
+  }
+  return self;
+}
+
+- (id)init {
+  @throw [NSException exceptionWithName:@"SingletonException"
+                                 reason:@"This is a singleton class. init is not available."
+                               userInfo:nil];
+}
+
+- (NSTimeInterval)machAbsoluteToTimeInterval:(uint64_t)machAbsolute {
+  uint64_t nanos = (machAbsolute * _clock_timebase.numer) / _clock_timebase.denom;
+  return nanos/1.0e9;
+}
+
+- (NSTimeInterval)absoluteTime {
+  uint64_t machTime = mach_absolute_time();
+  return [self machAbsoluteToTimeInterval:machTime];
+}
+
+@end

--- a/cucumber/config/xtc-profiles.yml
+++ b/cucumber/config/xtc-profiles.yml
@@ -16,4 +16,4 @@ iphone:      -p tags -p args -p iphone_only
 ipad:        -p tags -p args -p ipad_only
 crash:       -p tags -p args --tags @expect_crash
 acquaint:    -p tags -p args --tags @acquaint
-
+da_test_app: -p tags -p args --tags @device_agent_test_app --tags ~@safari

--- a/cucumber/features/device_agent_test_app.feature
+++ b/cucumber/features/device_agent_test_app.feature
@@ -1,0 +1,47 @@
+@device_agent_test_app
+Feature: DeviceAgent TestApp
+
+The Calabash and UITest iOS stacks use several test applications to
+document and test their behaviors.  For various reasons, there is no
+single test app that has all the views required for testing every
+feature of the Calabash and UITest iOS stacks.
+
+The DeviceAgent TestApp happens to contain almost every Text Input
+Field required to test the LPServer's ability to trigger delegate
+methods and post notifications while clearing test.
+
+@lpserver_clear_text
+Scenario: LPServer GET /clearText
+Given the TestApp has launched
+And I am looking at the Misc tab
+And I am looking at the Text Input page
+When I use the LPServer to clear text
+And there is no visible keyboard on the Text Input page
+Then an error is raised about clear text requiring a first responder
+Then I clear text with the LPServer in the UITextField
+Then I clear text with the LPServer in the UITextView
+Then I clear text with the LPServer in the UIKeyInput view
+Given I am looking at the Pan tab
+And I am looking at the Company table
+Then I clear text with the LPServer in the UISearchBar
+
+@webview
+@lpserver_set_text
+Scenario:  LPServer POST /setText to clear INPUT fields on web views
+Given I am looking at the Misc tab
+And I am looking at the UIWebView page
+And I scroll down to the login portion of the web page
+Then I clear text with the LPServer in the web view text input field
+Given I am looking at the Misc tab
+And I am looking at the WKWebView page
+And I scroll down to the login portion of the web page
+Then I clear text with the LPServer in the web view text input field
+
+@webview
+@safari
+@device_agent
+Scenario: DeviceAgent clear text in a Safari Web Controller
+Given I am looking at the Misc tab
+And I am looking at the SafariWebController page
+And I scroll down to the login portion of the web page
+Then I clear text with the DeviceAgent in a Safari Web Controller

--- a/cucumber/features/steps/device_agent_test_app.rb
+++ b/cucumber/features/steps/device_agent_test_app.rb
@@ -1,0 +1,292 @@
+module DeviceAgent
+  module Shared
+
+    def wait_for_app
+      ["Touch", "Pan", "Rotate/Pinch", "Misc", "Tao"].each do |mark|
+        wait_for_element_exists("* marked:'#{mark}'")
+      end
+
+      RunLoop.log_debug("Waiting for app to start responding to touches")
+
+      start = Time.now
+
+      timeout = 30
+      message = %Q[Waited #{timeout} second for the app to start responding to touches.]
+      query = "* marked:'That was touching.'"
+      touch_count = 0
+      wait_for({timeout: timeout, timeout_message: message}) do
+        touch("* marked:'gesture performed'")
+        touch_count = touch_count + 1
+        !query(query).empty?
+        sleep(0.4)
+      end
+
+      RunLoop.log_debug("Waited #{Time.now - start} seconds for the app to respond to touches")
+      RunLoop.log_debug("Performed #{touch_count} touches while waiting")
+    end
+
+    def touch_tab(tabname)
+      # Dismiss the keyboard if it is showing
+      if keyboard_visible?
+        if ipad?
+          dismiss_ipad_keyboard
+        else
+          touch("* marked:'Done'")
+        end
+
+        wait_for_none_animating
+      end
+
+      touch("* marked:'#{tabname}'")
+      wait_for_none_animating
+
+      # Get back to the root view controller of the tab.
+      if tabname == "Pan" || tabname == "Misc"
+        touch("* marked:'#{tabname}'")
+        wait_for_none_animating
+      end
+
+      mark = "#{tabname.downcase} page"
+      wait_for_element_exists("* marked:'#{mark}'")
+    end
+  end
+end
+
+World(DeviceAgent::Shared)
+
+Given(/^the TestApp has launched$/) do
+  wait_for_app
+  rotate_home_button_to(:down)
+end
+
+Given(/^I am looking at the (Touch|Pan|Rotate\/Pinch|Misc|Tao) tab$/) do |tabname|
+  touch_tab(tabname)
+end
+
+Given(/^I am looking at the Text Input page$/) do
+  touch("* marked:'text input row'")
+  wait_for_element_exists("* marked:'Misc Menu'")
+  wait_for_none_animating
+end
+
+Given(/^I am looking at the Company table$/) do
+  touch("* marked:'table row'")
+  wait_for_none_animating
+  wait_for_element_exists("* marked:'table page'")
+end
+
+Given(/^I am looking at the (UIWebView|WKWebView|SafariWebController) page$/) do |name|
+  @webview_class = name
+  if name == "UIWebView"
+    mark = "uiwebview row"
+  elsif name == "WKWebView"
+    mark = "wkwebview row"
+  else
+    mark = "safari web controller row"
+  end
+
+  touch("* marked:'#{mark}'")
+  wait_for_none_animating
+
+  if @webview_class == "SafariWebController"
+    wait_for do
+      !device_agent.query({marked: "H1 Header!"}).empty?
+    end
+    wait_for_none_animating
+    if xamarin_test_cloud?
+      sleep(20.0)
+    else
+      sleep(2.0)
+    end
+  else
+    wait_for_element_exists("* xpath:'//h1'")
+  end
+end
+
+When(/^I use the LPServer to clear text$/) do
+  # documentation step
+end
+
+And(/^there is no visible keyboard on the Text Input page$/) do
+  wait_for_no_keyboard
+end
+
+Then(/^an error is raised about clear text requiring a first responder$/) do
+  expect do
+    clear_text_in_first_responder
+  end.to raise_error(RuntimeError,
+                     /Cannot clear text because no view is first responder/)
+end
+
+Then(/^I clear text with the LPServer in the UITextField$/) do
+  touch("* marked:'text field'")
+  wait_for_keyboard
+  keyboard_enter_text("abc")
+  query("* marked:'text delegate'", {setText:""})
+  clear_text_in_first_responder
+  text = query("* marked:'text field'", :text).first
+  expect(text).to be == ""
+
+  text = query("* marked:'text delegate'", :text).first
+  expected = "textField:shouldChangeCharactersInRange:replacementString:"
+  expect(text).to be == expected
+
+  text = query("* marked:'key input'", :text).first
+  expected = "TextField: GET /clearText generated notification"
+  expect(text).to be == expected
+
+  touch("* marked:'clear key input button'")
+  tap_keyboard_action_key
+end
+
+Then(/^I clear text with the LPServer in the UITextView$/) do
+  touch("* marked:'text view'")
+  wait_for_keyboard
+  keyboard_enter_text("abc")
+  query("* marked:'text delegate'", {setText:""})
+  clear_text_in_first_responder
+  text = query("* marked:'text view'", :text).first
+  expect(text).to be == ""
+
+  text = query("* marked:'text delegate'", :text).first
+  expected = "textViewDidChange:"
+  expect(text).to be == expected
+
+  text = query("* marked:'key input'", :text).first
+  expected = "TextView: GET /clearText generated notification"
+  expect(text).to be == expected
+
+  touch("* marked:'dismiss text view keyboard'")
+  wait_for_no_keyboard
+  touch("* marked:'clear key input button'")
+end
+
+Then(/^I clear text with the LPServer in the UIKeyInput view$/) do
+  touch("* marked:'key input'")
+  wait_for_keyboard
+  keyboard_enter_text("abc")
+  clear_text_in_first_responder
+  text = query("* marked:'key input'", :text).first
+  expect(text).to be == ""
+
+  touch("* marked:'dismiss key input keyboard'")
+  wait_for_no_keyboard
+end
+
+Then(/^I clear text with the LPServer in the UISearchBar$/) do
+
+  query("UITableView", :clearSearchBarDelegateMethodCalls)
+
+  touch("* marked:'Search'")
+  wait_for_keyboard
+  keyboard_enter_text("abc")
+  actual = query("UISearchBar").first["text"]
+  expect(actual).to be == "abc"
+
+  clear_text_in_first_responder
+
+  actual = query("UISearchBar").first["text"]
+  expect(actual).to be == ""
+
+  json = query("UITableView", :JSONSearchBarDelegateMethodCalls).first
+  calls = JSON.parse(json).reverse
+
+  last_call = calls[0]
+  expect(last_call[0]).to be == "searchBar:textDidChange:"
+  expect(last_call[1][1]).to be == ""
+
+  penultimate_call = calls[1]
+  expect(penultimate_call[0]).to be == "searchBar:shouldChangeTextInRange:replacementText:"
+  expect(penultimate_call[1][1]).to be == "{0, 0}"
+  expect(penultimate_call[1][2]).to be == ""
+
+  touch("* marked:'Cancel'")
+end
+
+
+And(/^I scroll down to the login portion of the web page$/) do
+  start = Calabash::Cucumber::Automator::Coordinates.bottom_point_for_full_screen_pan
+  finish = Calabash::Cucumber::Automator::Coordinates.top_point_for_full_screen_pan
+
+  if @webview_class == "SafariWebController"
+    start[:y] = start[:y] - 60
+    finish[:y] = 80
+  end
+
+  pan_coordinates(start, finish)
+
+  if @webview_class == "SafariWebController"
+    expect(device_agent.query({marked: "First name:"}).count).to be == 1
+  else
+    expect(query("* css:'input#firstname'").count).to be == 1
+  end
+  sleep(0.5)
+end
+
+Then(/^I clear text with the DeviceAgent in a Safari Web Controller$/) do
+  device_agent.touch({type: "TextField", index: 0})
+  wait_for do
+    device_agent.keyboard_visible?
+  end
+
+  device_agent.enter_text("abc")
+
+  actual = device_agent.query({type: "TextField", index: 0}).first["value"]
+  expect(actual).to be == "abc"
+
+  device_agent.clear_text
+
+  actual = device_agent.query({type: "TextField", index: 0}).first["value"]
+  expect(actual).to be == nil
+
+  if ipad?
+    dismiss_ipad_keyboard
+  else
+    device_agent.touch({marked: "Done"})
+  end
+
+  wait_for do
+    !device_agent.keyboard_visible?
+  end
+
+  start = Calabash::Cucumber::Automator::Coordinates.left_point_for_full_screen_pan
+  finish = Calabash::Cucumber::Automator::Coordinates.right_point_for_full_screen_pan
+
+  pan_coordinates(start, finish)
+  wait_for_none_animating
+
+  sleep(0.5)
+
+  pan_coordinates(start, finish)
+  wait_for_none_animating
+end
+
+
+Then(/^I clear text with the LPServer in the web view text input field$/) do
+  touch("* css:'input#firstname'")
+  wait_for_keyboard
+  keyboard_enter_text("abc")
+
+  js = "document.getElementById('firstname').value"
+  text = query(@webview_class, {calabashStringByEvaluatingJavaScript: js}).first
+  expect(text).to be == "abc"
+
+  sleep(0.5)
+
+  if ipad?
+    dismiss_ipad_keyboard
+  else
+    touch("* marked:'Done'")
+  end
+
+  wait_for_no_keyboard
+
+  clear_text("* css:'input#firstname'")
+  text = query(@webview_class, {calabashStringByEvaluatingJavaScript: js}).first
+  expect(text).to be == ""
+
+  touch("* marked:'Misc Menu'")
+  wait_for_none_animating
+end
+
+

--- a/cucumber/features/support/01_launch.rb
+++ b/cucumber/features/support/01_launch.rb
@@ -24,7 +24,13 @@ end
 
 Before("@acquaint") do
   if !xamarin_test_cloud?
-    @acquaint_options = Acquaint.sim_options
+    @acquaint_options = Acquaint.options
+  end
+end
+
+Before("@device_agent_test_app") do
+  if !xamarin_test_cloud?
+    @device_agent_test_app_options = TestApp.options
   end
 end
 
@@ -47,6 +53,8 @@ Before do |scenario|
 
   if @acquaint_options
     options = @acquaint_options
+  elsif @device_agent_test_app_options
+    options = @device_agent_test_app_options
   else
     options = {
       # Add launch options here.
@@ -96,6 +104,7 @@ end
 After do |scenario|
   @no_relaunch = false
   @acquaint_options = nil
+  @device_agent_test_app_options = nil
 
   # Calabash can shutdown the app cleanly by calling the app life cycle methods
   # in the UIApplicationDelegate.  This is really nice for CI environments, but

--- a/cucumber/features/support/acquaint.rb
+++ b/cucumber/features/support/acquaint.rb
@@ -49,7 +49,7 @@ module Acquaint
     lib
   end
 
-  def self.sim_options
+  def self.options
     if RunLoop::Environment.device_target
       device = RunLoop::Environment.device_target
       inject = nil

--- a/cucumber/features/support/device_agent_test_app.rb
+++ b/cucumber/features/support/device_agent_test_app.rb
@@ -1,0 +1,35 @@
+
+module TestApp
+  require "calabash-cucumber"
+  require "run_loop"
+
+  def self.app
+    app = File.expand_path(File.join("device-agent-test-app",
+                                     "TestApp.app"))
+    RunLoop::App.new(app)
+  end
+
+  def self.ipa
+    app = File.expand_path(File.join("device-agent-test-app",
+                                     "TestApp.ipa"))
+    RunLoop::Ipa.new(app)
+  end
+
+  def self.options
+    xcode = RunLoop::Xcode.new
+    simctl = RunLoop::Simctl.new
+    instruments = RunLoop::Instruments.new
+    device = RunLoop::Device.detect_device({}, xcode, simctl, instruments)
+
+    if device.simulator?
+      app = TestApp.app
+    else
+      app = TestApp.ipa.bundle_identifier
+    end
+    {
+      :app => app,
+      :device => device
+    }
+  end
+end
+

--- a/cucumber/features/support/patches/calabash.rb
+++ b/cucumber/features/support/patches/calabash.rb
@@ -1,0 +1,21 @@
+module Calabash
+  module Cucumber
+    module Core
+       def clear_text_in_first_responder
+         response = http({method: :get, path: "clearText"}, {})
+         hash = JSON.parse(response)
+         if hash["outcome"] != "SUCCESS"
+           message = %Q[
+http GET /clearText failed for:
+
+ reason: #{hash["reason"]}
+details: #{hash["details"]}
+]
+
+           screenshot_and_raise(message)
+         end
+         hash
+       end
+    end
+  end
+end

--- a/cucumber/xtc-submit-device-agent-test-app.rb
+++ b/cucumber/xtc-submit-device-agent-test-app.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+require "run_loop"
+require "bundler"
+
+# ACQ_* are defined in Jenkins.
+XTC_API_TOKEN=ENV["ACQ_XTC_API_TOKEN"] || ENV["XTC_API_TOKEN"] || ARGV[0]
+XTC_ACCOUNT=ENV["ACQ_XTC_ACCOUNT"] || ENV["XTC_ACCOUNT"] || ARGV[1]
+
+DEVICE_SET = ARGV[2] || ["0adda5bd", "553e29d2", "b4fbb17e"].sample
+
+WORKING_DIR=File.expand_path("xtc-submit-device-agent-test-app")
+
+FileUtils.rm_rf(WORKING_DIR)
+FileUtils.mkdir(WORKING_DIR)
+
+FileUtils.cp_r("device-agent-test-app/TestApp.ipa", WORKING_DIR)
+FileUtils.cp_r("device-agent-test-app/TestApp.app.dSYM", WORKING_DIR)
+FileUtils.cp_r("features", WORKING_DIR)
+FileUtils.cp_r("config/xtc-profiles.yml", "#{WORKING_DIR}/cucumber.yml")
+
+GEMFILE=File.join(WORKING_DIR, "Gemfile")
+OTHER_GEMS=File.readlines("config/xtc-other-gems")
+
+File.open(GEMFILE, "w") do |file|
+  file.puts(%Q[gem "calabash-cucumber"])
+  OTHER_GEMS.each do |line|
+    file.puts(line)
+  end
+end
+
+Dir.chdir(WORKING_DIR) do
+  Bundler.with_clean_env do
+
+    system("bundle update")
+
+    args = [
+       "exec", "test-cloud", "submit",
+       "TestApp.ipa",
+       XTC_API_TOKEN,
+       "--user", XTC_ACCOUNT,
+       "-a", "TestApp",
+       "-d", DEVICE_SET,
+       "-c", "cucumber.yml",
+       "-p", "da_test_app",
+       "--series", "Clearing Text with LPServer",
+       "--dsym-file", "TestApp.app.dSYM"
+    ]
+
+    system("bundle", *args)
+  end
+end
+


### PR DESCRIPTION
**Motivation**
Currently clearing text doesn't trigger any of the appropriate delegate methods or NSNotifications - this PR attempts to address that.

**Update**  - I rebased to use the LPRoute approach.

Tested locally using `GET` on the `/clearText` route. Note - now this requires the keyboard to be open _before_ clearing text.

Accounts for possible scenarios:
**UITextField**
Calls `shouldChangeCharactersInRange` (when selecting all and cut) and `shouldClear` (when selecting the 'x' button) on delegate
Fires `UITextFieldTextDidChange` NSNotification

**UITextView**
Calls `shouldChangeTextIn`, `textViewDidChangeSelection`, `textViewDidChange` on delegate
Fires `UITextViewTextDidChange` NSNotification

**UISearchBar**
Calls `shouldChangeTextIn`, `textDidChange` on delegate
no notifications fired

**UIKeyInput**
Implements this protocol in which case it attempts to `deleteBackward` until `hasText` returns false

### TODO

- [x] Add tests. What's the most appropriate way of adding test?
- [x] Another point I was concerned with is the `while(hasText) { deleteBackward }` logic. Is there a way to do this with a timeout or what's the current best practice on that?
- [x] Shares some logic with PR #381 so we may want to refactor some if we merge both

### Tests

```
Scenario: LPServer GET /clearText
Given the TestApp has launched
And I am looking at the Misc tab
And I am looking at the Text Input page
When I use the LPServer to clear text
And there is no visible keyboard on the Text Input page
Then an error is raised about clear text requiring a first responder
Then I clear text with the LPServer in the UITextField
Then I clear text with the LPServer in the UITextView
Then I clear text with the LPServer in the UIKeyInput view
Given I am looking at the Pan tab
And I am looking at the Company table
Then I clear text with the LPServer in the UISearchBar
```

- [x] [Test Cloud](https://testcloud.xamarin.com/test/testapp_c0afb205-81db-401c-8864-5813a04f3c69/)

