### PR TITLE
Prepare for Jenkins to stage artifacts to S3

### DIFF
--- a/bin/ci/jenkins/run.sh
+++ b/bin/ci/jenkins/run.sh
@@ -41,7 +41,6 @@ bin/ci/jenkins/make-dylibs.sh
 bin/ci/jenkins/make-ipa.sh
 bundle exec bin/test/test-cloud.rb
 
-# Restart CoreSimulator processes
 bundle install
 
 banner "Run Tests"
@@ -51,3 +50,5 @@ bundle exec bin/test/cucumber.rb
 banner "Test iPhone 6+ touch coordinates"
 bundle exec bin/test/acquaint.rb
 
+# Skip s3 upload with --dry-run until S3 credentials are available
+bin/ci/jenkins/s3-publish.sh --dry-run

--- a/bin/ci/jenkins/s3-publish.sh
+++ b/bin/ci/jenkins/s3-publish.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "${1}" = "--dry-run" ]; then
+  DRY_RUN="1"
+else
+  DRY_RUN="0"
+fi
+
+source bin/log-functions.sh
+source bin/ditto.sh
+
+DYLIB="calabash-dylibs/libCalabashFAT.dylib"
+HEADERS_ZIP="calabash-dylibs/Headers.zip"
+
+if [ ! -e "${DYLIB}" ]; then
+  error "Expected ${DYLIB} to exist."
+  error "Did you run $ make dylibs first?"
+  exit 1
+fi
+
+if [ ! -e "${HEADERS_ZIP}" ]; then
+  error "Expected ${HEADERS_ZIP} to exist."
+  error "Did you run $ make dylibs first?"
+  exit 1
+fi
+
+GITREV=$(git rev-parse --verify HEAD | tr -d '\n')
+ENDPOINT="s3://calabash-files/LPServer/${GITREV}"
+DYLIB_ENDPOINT="${ENDPOINT}/libCalabashFAT.dylib"
+HEADERS_ENDPOINT="${ENDPOINT}/Headers.zip"
+
+# Waiting on special S3 permissions.
+# Until then, use --dry-run
+# Jenkins will serve the artifacts.
+if [ "${DRY_RUN}" = "1" ]; then
+  info "Skipping s3 upload"
+  info ""
+  info "aws s3 cp ${DYLIB} ${DYLIB_ENDPOINT}"
+  info "aws s3 cp ${HEADERS_ZIP} ${HEADERS_ENDPOINT}"
+  info ""
+else
+  aws s3 cp "${DYLIB}" "${DYLIB_ENDPOINT}"
+  aws s3 cp "${HEADERS_ZIP}" "${HEADERS_ENDPOINT}"
+fi
+
+BRANCH=`git rev-parse --abbrev-ref HEAD | tr -d '\n'`
+
+PRODUCTS_DIR="Products/s3"
+mkdir -p "${PRODUCTS_DIR}"
+YML_FILE="${PRODUCTS_DIR}/s3.yml"
+JSON_FILE="${PRODUCTS_DIR}/s3.json"
+TEXT_FILE="${PRODUCTS_DIR}/s3.txt"
+
+### BEGIN REMOVE when S3 permissions available
+ditto_or_exit "${DYLIB}" "${PRODUCTS_DIR}"
+ditto_or_exit "${HEADERS_ZIP}" "${PRODUCTS_DIR}"
+
+BASE_URL="http://calabash-ci.macminicolo.net:8080/job"
+S3_PATH="lastSuccessfulBuild/artifact/Products/s3"
+if [ "${BRANCH}" = "develop" ]; then
+  JOB_URL="${BASE_URL}/Calabash%20iOS%20Server%20develop"
+  DYLIB_ENDPOINT="${JOB_URL}/${S3_PATH}/libCalabashFAT.dylib"
+  HEADERS_ENDPOINT="${JOB_URL}/${S3_PATH}/Headers.zip"
+elif [ "${BRANCH}" = "master" ]; then
+  JOB_URL="${BASE_URL}/Calabash%20iOS%20Server%20master"
+  DYLIB_ENDPOINT="${JOB_URL}/${S3_PATH}/libCalabashFAT.dylib"
+  HEADERS_ENDPOINT="${JOB_URL}/${S3_PATH}/Headers.zip"
+else
+  JOB_URL="${BASE_URL}/Calabash%20iOS%20Server%20PR"
+  DYLIB_ENDPOINT="${JOB_URL}/${S3_PATH}/libCalabashFAT.dylib"
+  HEADERS_ENDPOINT="${JOB_URL}/${S3_PATH}/Headers.zip"
+fi
+### END REMOVE
+
+DATE=`date +%Y-%m-%dT%H:%M:%S%z | tr -d '\n'`
+
+cat >"${YML_FILE}" <<EOF
+branch: ${BRANCH}
+git_sha: ${GITREV}
+dylib_url: ${DYLIB_ENDPOINT}
+headers_zip_url: ${HEADERS_ENDPOINT}
+date: ${DATE}
+EOF
+
+cat >"${JSON_FILE}" <<EOF
+{
+  "branch" : "${BRANCH}",
+  "git_sha" : "${GITREV}",
+  "dylib_url" : "${DYLIB_ENDPOINT}",
+  "headers_zip_url" : "${HEADERS_ENDPOINT}",
+  "date" : "${DATE}"
+}
+EOF
+
+echo -n ${DYLIB_ENDPOINT} > "${TEXT_FILE}"

--- a/bin/ditto.sh
+++ b/bin/ditto.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+source bin/log-functions.sh
+
+function ditto_or_exit {
+  xcrun ditto "${1}" "${2}"
+  if [ "$?" != 0 ]; then
+    error "Could not copy:"
+    error "  source: ${1}"
+    error "  target: ${2}"
+    if [ ! -e "${1}" ]; then
+      error "The source file does not exist"
+      error "Did a previous xcodebuild step fail?"
+    fi
+    error "Exiting 1"
+    exit 1
+  fi
+}
+
+function ditto_to_zip {
+  xcrun ditto \
+  -ck --rsrc --sequesterRsrc --keepParent \
+  "${1}" \
+  "${2}"
+}

--- a/bin/log-functions.sh
+++ b/bin/log-functions.sh
@@ -1,0 +1,35 @@
+# Log functions for scripts.
+#
+# Suitable for Xcode Run Script Build Phase and command line scripts.
+#
+# Usage:
+#
+# source bin/log_functions.sh
+
+function info {
+  if [ "${TERM}" = "dumb" ]; then
+    echo "INFO: $1"
+  else
+    echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
+  fi
+}
+
+function error {
+  if [ "${TERM}" = "dumb" ]; then
+    echo "ERROR: $1"
+  else
+    echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
+  fi
+}
+
+function banner {
+  if [ "${TERM}" = "dumb" ]; then
+    echo ""
+    echo "######## $1 ########"
+    echo ""
+  else
+    echo ""
+    echo "$(tput setaf 5)######## $1 ########$(tput sgr0)"
+    echo ""
+  fi
+}

--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -250,3 +250,11 @@ if [ "${XC_GTE_7}"  = "true" ]; then
   fi
 fi
 
+# Legacy.  Can be changed once calabash-ios gem is updated.
+ditto_or_exit \
+  "${INSTALL_DIR}/libCalabashARM.dylib" \
+  "${INSTALL_DIR}/libCalabashDyn.dylib"
+
+ditto_or_exit \
+  "${INSTALL_DIR}/libCalabashSim.dylib" \
+  "${INSTALL_DIR}/libCalabashDynSim.dylib"

--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -142,22 +142,22 @@ ditto_or_exit "${ARM_LIBRARY}" "${ARM_PRODUCTS_DIR}/${LIBRARY_NAME}"
 
 banner "Installing Dylibs"
 
-FAT_LIBRARY="${FAT_PRODUCTS_DIR}/libCalabashDynFAT.dylib"
+FAT_LIBRARY="${FAT_PRODUCTS_DIR}/libCalabashFAT.dylib"
 
 xcrun lipo -create \
   "${SIM_PRODUCTS_DIR}/${LIBRARY_NAME}" \
   "${ARM_PRODUCTS_DIR}/${LIBRARY_NAME}" \
   -o "${FAT_LIBRARY}"
 
-TARGET_LIB="${PWD}/${INSTALL_DIR}/libCalabashDynFAT.dylib"
+TARGET_LIB="${PWD}/${INSTALL_DIR}/libCalabashFAT.dylib"
 info "Installing FAT library to ${TARGET_LIB}"
 ditto_or_exit "${FAT_LIBRARY}" "${TARGET_LIB}"
 
-TARGET_LIB="${PWD}/${INSTALL_DIR}/libCalabashDynSim.dylib"
+TARGET_LIB="${PWD}/${INSTALL_DIR}/libCalabashSim.dylib"
 info "Installing simulator library to ${TARGET_LIB}"
 ditto_or_exit "${SIM_PRODUCTS_DIR}/${LIBRARY_NAME}" "${TARGET_LIB}"
 
-TARGET_LIB="${PWD}/${INSTALL_DIR}/libCalabashDyn.dylib"
+TARGET_LIB="${PWD}/${INSTALL_DIR}/libCalabashARM.dylib"
 info "Installing ARM library to ${TARGET_LIB}"
 ditto_or_exit "${ARM_PRODUCTS_DIR}/${LIBRARY_NAME}" "${TARGET_LIB}"
 
@@ -202,46 +202,50 @@ else
   (cd "${CODE_SIGN_DIR}" && apple/create-keychain.sh)
 
   info "Resiging the device dylib"
-  $RESIGN_TOOL "${INSTALL_DIR}/libCalabashDyn.dylib"
+  $RESIGN_TOOL "${INSTALL_DIR}/libCalabashARM.dylib"
 
   info "Resiging the FAT dylib"
-  $RESIGN_TOOL "${INSTALL_DIR}/libCalabashDynFAT.dylib"
+  $RESIGN_TOOL "${INSTALL_DIR}/libCalabashFAT.dylib"
 
-  xcrun codesign --display --verbose=2 ${INSTALL_DIR}/libCalabashDyn.dylib
+  xcrun codesign --display --verbose=2\
+    ${INSTALL_DIR}/libCalabashARM.dylib
 fi
 
 banner "Dylib Info"
 
-VERSION=`xcrun strings "${INSTALL_DIR}/libCalabashDynSim.dylib" | grep -E 'CALABASH VERSION' | head -1 | grep -oEe '\d+\.\d+\.\d+' | tr -d '\n'`
+VERSION=`xcrun strings "${INSTALL_DIR}/libCalabashSim.dylib" | grep -E 'CALABASH VERSION' | head -1 | grep -oEe '\d+\.\d+\.\d+' | tr -d '\n'`
 echo "Built version:  $VERSION"
 
-lipo -info "${INSTALL_DIR}/libCalabashDyn.dylib"
-lipo -info "${INSTALL_DIR}/libCalabashDynSim.dylib"
-lipo -info "${INSTALL_DIR}/libCalabashDynFAT.dylib"
+lipo -info "${INSTALL_DIR}/libCalabashARM.dylib"
+lipo -info "${INSTALL_DIR}/libCalabashSim.dylib"
+lipo -info "${INSTALL_DIR}/libCalabashFAT.dylib"
 
 if [ "${XC_GTE_7}"  = "true" ]; then
 
-  xcrun otool-classic -arch arm64 -l "${INSTALL_DIR}/libCalabashDyn.dylib" | grep -q LLVM
+  xcrun otool-classic -arch arm64 -l \
+    "${INSTALL_DIR}/libCalabashARM.dylib" | grep -q LLVM
   if [ $? -eq 0 ]; then
-    echo "libCalabashDyn.dylib contains bitcode for arm64"
+    echo "libCalabashARM.dylib contains bitcode for arm64"
   else
-    echo "libCalabashDyn.dylib does not contain bitcode for arm64"
+    echo "libCalabashARM.dylib does not contain bitcode for arm64"
     exit 1
   fi
 
-  xcrun otool-classic -arch armv7s -l "${INSTALL_DIR}/libCalabashDyn.dylib" | grep -q LLVM
+  xcrun otool-classic -arch armv7s -l \
+    "${INSTALL_DIR}/libCalabashARM.dylib" | grep -q LLVM
   if [ $? -eq 0 ]; then
-    echo "libCalabashDyn.dylib contains bitcode for armv7s"
+    echo "libCalabashARM.dylib contains bitcode for armv7s"
   else
-    echo "libCalabashDyn.dylib does not contain bitcode for armv7s"
+    echo "libCalabashARM.dylib does not contain bitcode for armv7s"
     exit 1
   fi
 
-  xcrun otool-classic -arch armv7 -l "${INSTALL_DIR}/libCalabashDyn.dylib" | grep -q LLVM
+  xcrun otool-classic -arch armv7 -l \
+    "${INSTALL_DIR}/libCalabashARM.dylib" | grep -q LLVM
   if [ $? -eq 0 ]; then
-    echo "libCalabashDyn.dylib contains bitcode for armv7"
+    echo "libCalabashARM.dylib contains bitcode for armv7"
   else
-    echo "libCalabashDyn.dylib does not contain bitcode for armv7"
+    echo "libCalabashARM.dylib does not contain bitcode for armv7"
     exit 1
   fi
 fi

--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -163,7 +163,7 @@ ditto_or_exit "${ARM_PRODUCTS_DIR}/${LIBRARY_NAME}" "${TARGET_LIB}"
 
 info "Installing Headers to ${PWD}/${INSTALL_DIR}"
 ditto_or_exit "${HEADERS}" "${INSTALL_DIR}/Headers"
-
+ditto_to_zip "${INSTALL_DIR}/Headers" "${INSTALL_DIR}/Headers.zip"
 
 banner "Dylib Code Signing"
 

--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -2,37 +2,8 @@
 
 set -e
 
-function info {
-  echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
-}
-
-function error {
-  echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
-}
-
-function warn {
-  echo "$(tput setaf 4)WARN: $1$(tput sgr0)"
-}
-function banner {
-  echo ""
-  echo "$(tput setaf 5)######## $1 #######$(tput sgr0)"
-  echo ""
-}
-
-function ditto_or_exit {
-  ditto "${1}" "${2}"
-  if [ "$?" != 0 ]; then
-    error "Could not copy:"
-    error "  source: ${1}"
-    error "  target: ${2}"
-    if [ ! -e "${1}" ]; then
-      error "The source file does not exist"
-      error "Did a previous xcodebuild step fail?"
-    fi
-    error "Exiting 1"
-    exit 1
-  fi
-}
+source bin/log-functions.sh
+source bin/ditto.sh
 
 function xcode_gte_7 {
  XC_MAJOR=`xcrun xcodebuild -version | awk 'NR==1{print $2}' | awk -v FS="." '{ print $1 }'`


### PR DESCRIPTION
### Motivation

Progress on automatically injecting the LPServer into applications.

### Concept

Jenkins jobs will generate 3 artifacts:

```
lastSuccessfulBuild/artifact/Products/s3/s3.json
lastSuccessfulBuild/artifact/Products/s3/s3.yml
# Contains only the libCalabashFAT.dylib URL
lastSuccessfulBuild/artifact/Products/s3/s3.txt
```

Clients can connect to those endpoints to find s3 URLs for various LPServer artifacts.

There are 3 "channels":  master, develop, and pull request.

```
http://calabash-ci.macminicolo.net:8080/jobCalabash%20iOS%20Server%20master
http://calabash-ci.macminicolo.net:8080/jobCalabash%20iOS%20Server%20develop
http://calabash-ci.macminicolo.net:8080/jobCalabash%20iOS%20Server%20PR
```

Assuming this pull request passes, a client could use the following to find the dylib URL:

```
$ curl http://calabash-ci.macminicolo.net:8080/jobCalabash%20iOS%20Server%20PR/lastSuccessfulBuild/artifact/Products/s3/s3.txt
```

Clients will fetch one of the s3 resource files and extract the dylib URL.

At the moment, nothing is uploaded to s3.  The URLs point to Jenkins artifacts.  This is a temporary solution until s3 keys are generated.  In the long term, we do not want to serve artifacts from Jenkins - there is not enough bandwidth on the machine and s3 has many advantages.
