### PR TITLE
Can specify suiteName when making changes to user preferences endpoint

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPUserPrefRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPUserPrefRoute.m
@@ -15,7 +15,10 @@
 
 
 - (NSDictionary *) JSONResponseForMethod:(NSString *) method URI:(NSString *) path data:(NSDictionary *) data {
-  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  NSString *suiteName = [data valueForKey:@"suiteName"];
+  NSUserDefaults *ud = suiteName == nil ? [NSUserDefaults standardUserDefaults] :
+                                         [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+
   [ud synchronize];
 
   NSString *key = [data valueForKey:@"key"];


### PR DESCRIPTION
Currently only `standardUserDefaults` is supported, but for those of us who have shared preferences, specifying `suiteName` would be useful.