### PR TITLE
LPDevice: add new iPad models for June 2017

### DIFF
--- a/bin/test/xctest.rb
+++ b/bin/test/xctest.rb
@@ -10,6 +10,13 @@ use_xcpretty = ENV["XCPRETTY"] != "0"
 
 xcode = RunLoop::Xcode.new
 
+args = ["killall", "-TERM", "xcodebuild"]
+RunLoop::Shell.run_shell_command(args)
+sleep(2.0)
+args = ["killall", "-KILL", "xcodebuild"]
+RunLoop::Shell.run_shell_command(args)
+sleep(2.0)
+
 default_sim_name = RunLoop::Core.default_simulator
 default_sim = RunLoop::Device.device_with_identifier(default_sim_name)
 
@@ -46,7 +53,7 @@ Dir.chdir(working_dir) do
 
   cmd = "xcrun xcodebuild #{args.join(' ')}"
 
-  tries = Luffa::Environment.travis_ci? ? 3 : 1
+  tries = Luffa::Environment.ci? ? 3 : 1
   interval = 5
 
   on_retry = Proc.new do |_, try, elapsed_time, next_interval|

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -324,7 +324,15 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 
     // iPad Pro 9in
     @"iPad6,3" : @"ipad pro",
-    @"iPad6,4" : @"ipad pro"
+    @"iPad6,4" : @"ipad pro",
+    @"iPad6,11" : @"ipad pro",
+    @"iPad6,12" : @"ipad pro",
+
+    // iPad Pro 10.5in
+    @"iPad7,4" : @"ipad pro",
+    @"iPad7,3" : @"ipad pro",
+    @"iPad7,2" : @"ipad pro",
+    @"iPad7,1" : @"ipad pro"
 
     };
 


### PR DESCRIPTION
### Motivation

Progress on:

* The LPServer should work on iPad Pro 10.5" [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/11134)
* Incorrect iPad Pro Screen Dimensions #388

Completes:

* LPServer: add iPad 10.5" and new iPad 12" model identifiers [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/11874)