### PR TITLE
Fix iPad Pro 10.5 touch coordinates for non-optimized apps

### DIFF
--- a/LPTestTarget/AppDelegate.m
+++ b/LPTestTarget/AppDelegate.m
@@ -1,4 +1,5 @@
 #import "AppDelegate.h"
+#import "MBFingerTipWindow.h"
 #import <CoreData/CoreData.h>
 #import "LPCoreDataStack.h"
 #import "CocoaLumberjack/CocoaLumberjack.h"
@@ -18,6 +19,16 @@ typedef struct {
 @end
 
 @implementation AppDelegate
+
+- (UIWindow *)window {
+    if (!_window) {
+        MBFingerTipWindow *ftWindow = [[MBFingerTipWindow alloc]
+                                       initWithFrame:[[UIScreen mainScreen] bounds]];
+        ftWindow.alwaysShowTouches = YES;
+        _window = ftWindow;
+    }
+    return _window;
+}
 
 // Calabash backdoors
 - (void) backdoorThatReturnsVoid { DDLogDebug(@"Method that returns void"); }
@@ -166,7 +177,6 @@ typedef struct {
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 
   [DDLog addLogger:[DDTTYLogger sharedInstance]];
   [DDLog addLogger:[DDASLLogger sharedInstance]];

--- a/Vendor/Fingertips/Fingertips.LICENSE
+++ b/Vendor/Fingertips/Fingertips.LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2011-2015, Mapbox, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of MapBox, Inc., nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Vendor/Fingertips/MBFingerTipWindow.h
+++ b/Vendor/Fingertips/MBFingerTipWindow.h
@@ -1,0 +1,32 @@
+//
+//  MBFingerTipWindow.h
+//
+//  Copyright 2011-2015 Mapbox, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+/** A MBFingerTipWindow gives you automatic presentation mode in your iOS app. Note that currently, this is only designed for the iPad 2 and iPhone 4S (or later), which feature hardware video mirroring support. This library does not do the mirroring for you!
+*
+*   Use MBFingerTipWindow in place of UIWindow and your app will automatically determine when an external screen is available. It will show every touch on-screen with a nice partially-transparent graphic that automatically fades out when the touch ends. */
+@interface MBFingerTipWindow : UIWindow
+
+/** A custom image to use to show touches on screen. If unset, defaults to a partially-transparent stroked circle. */
+@property (nonatomic, strong) UIImage *touchImage;
+
+/** The alpha transparency value to use for the touch image. Defaults to 0.5. */
+@property (nonatomic, assign) CGFloat touchAlpha;
+
+/** The time over which to fade out touch images. Defaults to 0.3. */
+@property (nonatomic, assign) NSTimeInterval fadeDuration;
+
+/** If using the default touchImage, the color with which to stroke the shape. Defaults to black. */
+@property (nonatomic, strong) UIColor *strokeColor;
+
+/** If using the default touchImage, the color with which to fill the shape. Defaults to white. */
+@property (nonatomic, strong) UIColor *fillColor;
+
+/** Sets whether touches should always show regardless of whether the display is mirroring. Defaults to NO. */
+@property (nonatomic, assign) BOOL alwaysShowTouches;
+
+@end

--- a/Vendor/Fingertips/MBFingerTipWindow.m
+++ b/Vendor/Fingertips/MBFingerTipWindow.m
@@ -1,0 +1,406 @@
+//
+//  MBFingerTipWindow.m
+//
+//  Copyright 2011-2015 Mapbox, Inc. All rights reserved.
+//
+
+#import "MBFingerTipWindow.h"
+
+// This file must be built with ARC.
+//
+#if !__has_feature(objc_arc)
+    #error "ARC must be enabled for MBFingerTipWindow.m"
+#endif
+
+@interface MBFingerTipView : UIImageView
+
+@property (nonatomic, assign) NSTimeInterval timestamp;
+@property (nonatomic, assign) BOOL shouldAutomaticallyRemoveAfterTimeout;
+@property (nonatomic, assign, getter=isFadingOut) BOOL fadingOut;
+
+@end
+
+#pragma mark -
+
+@interface MBFingerTipOverlayWindow : UIWindow
+@end
+
+#pragma mark -
+
+@interface MBFingerTipWindow ()
+
+@property (nonatomic, strong) UIWindow *overlayWindow;
+@property (nonatomic, assign) BOOL active;
+@property (nonatomic, assign) BOOL fingerTipRemovalScheduled;
+
+- (void)MBFingerTipWindow_commonInit;
+- (BOOL)anyScreenIsMirrored;
+- (void)updateFingertipsAreActive;
+- (void)scheduleFingerTipRemoval;
+- (void)cancelScheduledFingerTipRemoval;
+- (void)removeInactiveFingerTips;
+- (void)removeFingerTipWithHash:(NSUInteger)hash animated:(BOOL)animated;
+- (BOOL)shouldAutomaticallyRemoveFingerTipForTouch:(UITouch *)touch;
+
+@end
+
+#pragma mark -
+
+@implementation MBFingerTipWindow
+
+@synthesize touchImage=_touchImage;
+
+- (id)initWithCoder:(NSCoder *)decoder
+{
+    // This covers NIB-loaded windows.
+    //
+    self = [super initWithCoder:decoder];
+
+    if (self != nil)
+        [self MBFingerTipWindow_commonInit];
+    
+    return self;
+}
+
+- (id)initWithFrame:(CGRect)rect
+{
+    // This covers programmatically-created windows.
+    //
+    self = [super initWithFrame:rect];
+    
+    if (self != nil)
+        [self MBFingerTipWindow_commonInit];
+    
+    return self;
+}
+
+- (void)MBFingerTipWindow_commonInit
+{
+    self.strokeColor = [UIColor blackColor];
+    self.fillColor = [UIColor whiteColor];
+    
+    self.touchAlpha   = 0.5;
+    self.fadeDuration = 0.3;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(screenConnect:)
+                                                 name:UIScreenDidConnectNotification
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(screenDisconnect:)
+                                                 name:UIScreenDidDisconnectNotification
+                                               object:nil];
+
+    // Set up active now, in case the screen was present before the window was created (or application launched).
+    //
+    [self updateFingertipsAreActive];
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIScreenDidConnectNotification    object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIScreenDidDisconnectNotification object:nil];
+}
+
+#pragma mark -
+
+- (UIWindow *)overlayWindow
+{
+    if ( ! _overlayWindow)
+    {
+        _overlayWindow = [[MBFingerTipOverlayWindow alloc] initWithFrame:self.frame];
+        
+        _overlayWindow.userInteractionEnabled = NO;
+        _overlayWindow.windowLevel = UIWindowLevelStatusBar;
+        _overlayWindow.backgroundColor = [UIColor clearColor];
+        _overlayWindow.hidden = NO;
+    }
+    
+    return _overlayWindow;
+}
+
+- (UIImage *)touchImage
+{
+    if ( ! _touchImage)
+    {
+        UIBezierPath *clipPath = [UIBezierPath bezierPathWithRect:CGRectMake(0, 0, 50.0, 50.0)];
+        
+        UIGraphicsBeginImageContextWithOptions(clipPath.bounds.size, NO, 0);
+
+        UIBezierPath *drawPath = [UIBezierPath bezierPathWithArcCenter:CGPointMake(25.0, 25.0) 
+                                                                radius:22.0
+                                                            startAngle:0
+                                                              endAngle:2 * M_PI
+                                                             clockwise:YES];
+
+        drawPath.lineWidth = 2.0;
+        
+        [self.strokeColor setStroke];
+        [self.fillColor setFill];
+
+        [drawPath stroke];
+        [drawPath fill];
+        
+        [clipPath addClip];
+        
+        _touchImage = UIGraphicsGetImageFromCurrentImageContext();
+        
+        UIGraphicsEndImageContext();
+    }
+        
+    return _touchImage;
+}
+
+#pragma mark - Setter
+
+- (void)setAlwaysShowTouches:(BOOL)flag
+{
+	if (_alwaysShowTouches != flag)
+	{
+		_alwaysShowTouches = flag;
+
+        [self updateFingertipsAreActive];
+	}
+}
+
+#pragma mark -
+#pragma mark Screen notifications
+
+- (void)screenConnect:(NSNotification *)notification
+{
+    [self updateFingertipsAreActive];
+}
+
+- (void)screenDisconnect:(NSNotification *)notification
+{
+    [self updateFingertipsAreActive];
+}
+
+- (BOOL)anyScreenIsMirrored
+{
+    if ( ! [UIScreen instancesRespondToSelector:@selector(mirroredScreen)])
+        return NO;
+
+    for (UIScreen *screen in [UIScreen screens])
+    {
+        if ([screen mirroredScreen] != nil)
+            return YES;
+    }
+
+    return NO;
+}
+
+- (void)updateFingertipsAreActive;
+{
+    if (self.alwaysShowTouches || ([[[[NSProcessInfo processInfo] environment] objectForKey:@"DEBUG_FINGERTIP_WINDOW"] boolValue]))
+    {
+        self.active = YES;
+    }
+    else
+    {
+        self.active = [self anyScreenIsMirrored];
+    }
+}
+
+#pragma mark -
+#pragma mark UIWindow overrides
+
+- (void)sendEvent:(UIEvent *)event
+{
+    if (self.active)
+    {
+        NSSet *allTouches = [event allTouches];
+        
+        for (UITouch *touch in [allTouches allObjects])
+        {
+            switch (touch.phase)
+            {
+                case UITouchPhaseBegan:
+                case UITouchPhaseMoved:
+                case UITouchPhaseStationary:
+                {
+                    MBFingerTipView *touchView = (MBFingerTipView *)[self.overlayWindow viewWithTag:touch.hash];
+
+                    if (touch.phase != UITouchPhaseStationary && touchView != nil && [touchView isFadingOut])
+                    {
+                        [touchView removeFromSuperview];
+                        touchView = nil;
+                    }
+                    
+                    if (touchView == nil && touch.phase != UITouchPhaseStationary)
+                    {
+                        touchView = [[MBFingerTipView alloc] initWithImage:self.touchImage];
+                        [self.overlayWindow addSubview:touchView];
+                    }
+            
+                    if ( ! [touchView isFadingOut])
+                    {
+                        touchView.alpha = self.touchAlpha;
+                        touchView.center = [touch locationInView:self.overlayWindow];
+                        touchView.tag = touch.hash;
+                        touchView.timestamp = touch.timestamp;
+                        touchView.shouldAutomaticallyRemoveAfterTimeout = [self shouldAutomaticallyRemoveFingerTipForTouch:touch];
+                    }
+                    break;
+                }
+
+                case UITouchPhaseEnded:
+                case UITouchPhaseCancelled:
+                {
+                    [self removeFingerTipWithHash:touch.hash animated:YES];
+                    break;
+                }
+            }
+        }
+    }
+        
+    [super sendEvent:event];
+
+    [self scheduleFingerTipRemoval]; // We may not see all UITouchPhaseEnded/UITouchPhaseCancelled events.
+}
+
+#pragma mark -
+#pragma mark Private
+
+- (void)scheduleFingerTipRemoval
+{
+    if (self.fingerTipRemovalScheduled)
+        return;
+    
+    self.fingerTipRemovalScheduled = YES;
+    [self performSelector:@selector(removeInactiveFingerTips) withObject:nil afterDelay:0.1];
+}
+
+- (void)cancelScheduledFingerTipRemoval
+{
+    self.fingerTipRemovalScheduled = YES;
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(removeInactiveFingerTips) object:nil];
+}
+
+- (void)removeInactiveFingerTips
+{
+    self.fingerTipRemovalScheduled = NO;
+
+    NSTimeInterval now = [[NSProcessInfo processInfo] systemUptime];
+    const CGFloat REMOVAL_DELAY = 0.2;
+
+    for (MBFingerTipView *touchView in [self.overlayWindow subviews])
+    {
+        if ( ! [touchView isKindOfClass:[MBFingerTipView class]])
+            continue;
+        
+        if (touchView.shouldAutomaticallyRemoveAfterTimeout && now > touchView.timestamp + REMOVAL_DELAY)
+            [self removeFingerTipWithHash:touchView.tag animated:YES];
+    }
+
+    if ([[self.overlayWindow subviews] count] > 0)
+        [self scheduleFingerTipRemoval];
+}
+
+- (void)removeFingerTipWithHash:(NSUInteger)hash animated:(BOOL)animated;
+{
+    MBFingerTipView *touchView = (MBFingerTipView *)[self.overlayWindow viewWithTag:hash];
+    if ( ! [touchView isKindOfClass:[MBFingerTipView class]])
+        return;
+    
+    if ([touchView isFadingOut])
+        return;
+        
+    BOOL animationsWereEnabled = [UIView areAnimationsEnabled];
+
+    if (animated)
+    {
+        [UIView setAnimationsEnabled:YES];
+        [UIView beginAnimations:nil context:nil];
+        [UIView setAnimationDuration:self.fadeDuration];
+    }
+
+    touchView.frame = CGRectMake(touchView.center.x - touchView.frame.size.width, 
+                                 touchView.center.y - touchView.frame.size.height, 
+                                 touchView.frame.size.width  * 2, 
+                                 touchView.frame.size.height * 2);
+    
+    touchView.alpha = 0.0;
+
+    if (animated)
+    {
+        [UIView commitAnimations];
+        [UIView setAnimationsEnabled:animationsWereEnabled];
+    }
+    
+    touchView.fadingOut = YES;
+    [touchView performSelector:@selector(removeFromSuperview) withObject:nil afterDelay:self.fadeDuration];
+}
+
+- (BOOL)shouldAutomaticallyRemoveFingerTipForTouch:(UITouch *)touch;
+{
+    // We don't reliably get UITouchPhaseEnded or UITouchPhaseCancelled
+    // events via -sendEvent: for certain touch events. Known cases
+    // include swipe-to-delete on a table view row, and tap-to-cancel
+    // swipe to delete. We automatically remove their associated
+    // fingertips after a suitable timeout.
+    //
+    // It would be much nicer if we could remove all touch events after
+    // a suitable time out, but then we'll prematurely remove touch and
+    // hold events that are picked up by gesture recognizers (since we
+    // don't use UITouchPhaseStationary touches for those. *sigh*). So we
+    // end up with this more complicated setup.
+
+    UIView *view = [touch view];
+    view = [view hitTest:[touch locationInView:view] withEvent:nil];
+
+    while (view != nil)
+    {
+        if ([view isKindOfClass:[UITableViewCell class]])
+        {
+            for (UIGestureRecognizer *recognizer in [touch gestureRecognizers])
+            {
+                if ([recognizer isKindOfClass:[UISwipeGestureRecognizer class]])
+                    return YES;
+            }
+        }
+
+        if ([view isKindOfClass:[UITableView class]])
+        {
+            if ([[touch gestureRecognizers] count] == 0)
+                return YES;
+        }
+
+        view = view.superview;
+    }
+
+    return NO;
+}
+
+@end
+
+#pragma mark -
+
+@implementation MBFingerTipView
+
+@end
+
+#pragma mark -
+
+@implementation MBFingerTipOverlayWindow
+
+// UIKit tries to get the rootViewController from the overlay window.
+// Instead, try to find the rootViewController on some other application window.
+// Fixes problems with status bar hiding, because it considers the overlay window a candidate for controlling the status bar.
+
+- (UIViewController *)rootViewController
+{
+    for (UIWindow *window in [[UIApplication sharedApplication] windows])
+    {
+        if (self == window)
+            continue;
+
+        UIViewController *realRootViewController = window.rootViewController;
+        if (realRootViewController != nil)
+            return realRootViewController;
+    }
+    return [super rootViewController];
+}
+
+@end

--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -332,6 +332,24 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
   OCMVerifyAll(mock);
 }
 
+- (void) testIsIpadPro10point5inchYES {
+  id mock = OCMPartialMock(self.device);
+  OCMExpect([mock modelIdentifier]).andReturn(@"iPad7");
+
+  expect([mock isIPadPro10point5inch]).to.equal(YES);
+
+  OCMVerifyAll(mock);
+}
+
+- (void) testIsIpadPro10point5inchNO {
+  id mock = OCMPartialMock(self.device);
+  OCMExpect([mock modelIdentifier]).andReturn(@"iPad");
+
+  expect([mock isIPadPro10point5inch]).to.equal(NO);
+
+  OCMVerifyAll(mock);
+}
+
 - (void) testIsIPhone6LikeYES {
   id mock = OCMPartialMock(self.device);
   OCMExpect([mock formFactor]).andReturn(@"iphone 6");

--- a/calabash.xcodeproj/project.pbxproj
+++ b/calabash.xcodeproj/project.pbxproj
@@ -239,6 +239,8 @@
 		E2F8025E1BE207670000A0E4 /* LPShakeRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025A1BE207670000A0E4 /* LPShakeRoute.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		E2F802601BE21C690000A0E4 /* LPShakeRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F8025F1BE21C690000A0E4 /* LPShakeRouteTest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F50292971ACAD4FE00D07D31 /* LPWebViewUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F5F2D5E11ACACF2F0027937B /* LPWebViewUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F502B7B81F1E2813002D430F /* MBFingerTipWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = F502B7B61F1E2813002D430F /* MBFingerTipWindow.m */; };
+		F502B7B91F1E2888002D430F /* Fingertips.LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = F502B7B41F1E2813002D430F /* Fingertips.LICENSE */; };
 		F5091BDD18C4E1D700C85307 /* LPGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = B184FD9114B6DB2B002A744C /* LPGCDAsyncSocket.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDE18C4E1D700C85307 /* LPHTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B314E6565500663205 /* LPHTTPAuthenticationRequest.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F5091BDF18C4E1D700C85307 /* LPHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B116C9B514E6565500663205 /* LPHTTPConnection.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -872,6 +874,9 @@
 		E2F8025A1BE207670000A0E4 /* LPShakeRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPShakeRoute.m; sourceTree = "<group>"; };
 		E2F8025F1BE21C690000A0E4 /* LPShakeRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPShakeRouteTest.m; sourceTree = "<group>"; };
 		F500459D17D249D000B72386 /* LPGitVersionDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPGitVersionDefines.h; sourceTree = "<group>"; };
+		F502B7B41F1E2813002D430F /* Fingertips.LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Fingertips.LICENSE; sourceTree = "<group>"; };
+		F502B7B51F1E2813002D430F /* MBFingerTipWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBFingerTipWindow.h; sourceTree = "<group>"; };
+		F502B7B61F1E2813002D430F /* MBFingerTipWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBFingerTipWindow.m; sourceTree = "<group>"; };
 		F5091C4618C4E1D700C85307 /* libcalabash.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcalabash.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F5097CF51B6A377E00326D6A /* LPKeyboardLanguageRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPKeyboardLanguageRoute.h; sourceTree = "<group>"; };
 		F5097CF61B6A377E00326D6A /* LPKeyboardLanguageRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPKeyboardLanguageRoute.m; sourceTree = "<group>"; };
@@ -1629,6 +1634,17 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		F502B7B31F1E2813002D430F /* Fingertips */ = {
+			isa = PBXGroup;
+			children = (
+				F502B7B41F1E2813002D430F /* Fingertips.LICENSE */,
+				F502B7B51F1E2813002D430F /* MBFingerTipWindow.h */,
+				F502B7B61F1E2813002D430F /* MBFingerTipWindow.m */,
+			);
+			name = Fingertips;
+			path = Vendor/Fingertips;
+			sourceTree = SOURCE_ROOT;
+		};
 		F50CBF5F1A03F222004AC9DA /* XCTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -1969,6 +1985,7 @@
 				F58C9F581B6F802D007D307B /* CocoaHTTPServer */,
 				F58C9F541B6F7EB9007D307B /* CocoaAsyncSocket */,
 				F58C9F3F1B6F79BA007D307B /* CocoaLumberjack */,
+				F502B7B31F1E2813002D430F /* Fingertips */,
 				F532C1E51AFF6A2D0024DA55 /* LPServerEntity.h */,
 				F532C1E61AFF6A2D0024DA55 /* LPServerEntity.m */,
 				F532C1DF1AFF4F240024DA55 /* LPCoreDataStack.h */,
@@ -2412,6 +2429,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F502B7B91F1E2888002D430F /* Fingertips.LICENSE in Resources */,
 				F5E2A5EE1BFEF8590068DFAD /* change-sha.plist in Resources */,
 				F5CF1EC81C59055900801918 /* Localizable.strings in Resources */,
 				F59CA4801A82EF40007A2F38 /* Images.xcassets in Resources */,
@@ -3215,6 +3233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F58C9F571B6F7EB9007D307B /* GCDAsyncSocket.m in Sources */,
+				F502B7B81F1E2813002D430F /* MBFingerTipWindow.m in Sources */,
 				F58C9F901B6F802D007D307B /* WebSocket.m in Sources */,
 				F58C9F871B6F802D007D307B /* MultipartFormDataParser.m in Sources */,
 				F50E87651BFEEAAB002F0E8D /* DDContextFilterLogFormatter.m in Sources */,

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -37,6 +37,7 @@ extern NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY;
 - (BOOL) isIPhone6PlusLike;
 - (BOOL) isIPad;
 - (BOOL) isIPadPro;
+- (BOOL) isIPadPro10point5inch;
 - (BOOL) isIPhone4Like;
 - (BOOL) isIPhone5Like;
 - (BOOL) isLetterBox;

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -205,6 +205,8 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
   // This is sufficient for touching a 2x2 pixel button.
   CGFloat iphone6p_legacy_app_sample = 1.296917;
 
+  CGFloat ipad_pro_10dot5_sample = 1.0859375;
+
   UIScreenMode *screenMode = [screen currentMode];
   CGSize screenSizeForMode = screenMode.size;
   CGFloat pixelAspectRatio = screenMode.pixelAspectRatio;
@@ -246,6 +248,13 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
       LPLogDebug(@"iPhone 6: Zoomed display mode - sampleFactor remains the same");
     } else {
       LPLogDebug(@"iPhone 6: Standard display and app optimized for screen size - sampleFactor remains the same");
+    }
+  } else if ([self isIPadPro10point5inch]) {
+    if (screenHeight == 1024) {
+      LPLogDebug(@"iPad 10.5 inch: app is not optimized for screen size - adjusting sampleFactor");
+      _sampleFactor = ipad_pro_10dot5_sample;
+    } else {
+      LPLogDebug(@"iPad 10.5 inch: app is optimized for screen size");
     }
   }
 
@@ -440,6 +449,10 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 
 - (BOOL) isIPadPro {
   return [[self formFactor] isEqualToString:@"ipad pro"];
+}
+
+- (BOOL) isIPadPro10point5inch {
+  return [[self modelIdentifier] containsString:@"iPad7"];
 }
 
 - (BOOL) isIPhone4Like {

--- a/third-party-licenses/Fingertips.LICENSE
+++ b/third-party-licenses/Fingertips.LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2011-2015, Mapbox, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of MapBox, Inc., nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
### Motivation

Completes:

* LPServer needs to detect apps and correct touch coordinates that are not optimized for iPad Pro 10.5 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/12641)

### Notes:

Apps that do not contain the correctly sized Launch Images and Icons are displayed in sample mode on iPhone 6 and 6+ form factors.  Apparently, the same is true for the iPad Pro 10.5" form factor.

When applications contain the correct image assets, the LPServer has 2 pixel accuracy on iPad Pro 10.5.  When testing non-optimized apps, the LPServer needs to scale the touch coordinates.