### PR TITLE
LPDevice: add iPhone X, 8, 8+ model numbers

### DIFF
--- a/XCTest/Tests/Utils/LPDeviceTest.m
+++ b/XCTest/Tests/Utils/LPDeviceTest.m
@@ -386,6 +386,20 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
   OCMVerifyAll(mock);
 }
 
+- (void) testIsIPhone10LikeYES {
+  id mock = OCMPartialMock(self.device);
+  OCMExpect([mock formFactor]).andReturn(@"iphone 10");
+
+  expect([mock isIPhone10Like]).to.equal(YES);
+}
+
+- (void) testIsIPhone10LikeNO {
+  id mock = OCMPartialMock(self.device);
+  OCMExpect([mock formFactor]).andReturn(@"garbage");
+
+  expect([mock isIPhone10Like]).to.equal(NO);
+}
+
 - (void) testIsLetterBoxNoBecauseIpad {
   id mock = OCMPartialMock(self.device);
   OCMExpect([mock isIPad]).andReturn(YES);

--- a/calabash/Classes/Utils/LPDevice.h
+++ b/calabash/Classes/Utils/LPDevice.h
@@ -41,6 +41,7 @@ extern NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY;
 - (BOOL) isIPhone4Like;
 - (BOOL) isIPhone5Like;
 - (BOOL) isLetterBox;
+- (BOOL) isIPhone10Like;
 - (NSString *) getIPAddress;
 
 @end

--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -327,6 +327,11 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
     @"iPhone9,2" : @"iphone 6+",
     @"iPhone9,4" : @"iphone 6+",
 
+    // iPhone 8/8+/X - derived from Simulator
+    @"iPhone10,4" : @"iphone 6",
+    @"iPhone10,5" : @"iphone 6+",
+    @"iPhone10,3" : @"iphone 10",
+
     // iPad Pro 13in
     @"iPad6,7" : @"ipad pro",
     @"iPad6,8" : @"ipad pro",
@@ -461,6 +466,10 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
 
 - (BOOL) isIPhone5Like {
   return [[self formFactor] isEqualToString:@"iphone 4in"];
+}
+
+- (BOOL) isIPhone10Like {
+  return [[self formFactor] isEqualToString:@"iphone 10"];
 }
 
 - (BOOL) isLetterBox {


### PR DESCRIPTION
### Motivation

Completes:

* LPServer can identify iPhone 8 and 10 models [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/21936) 

Progress on:

* Calabash iOS supports gestures on iPhone 8 and iPhone X [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/21521)