### PR TITLE
LPDevice: update iPhone 8, 8+, and 10 model numbers

### DIFF
--- a/calabash/Classes/Utils/LPDevice.m
+++ b/calabash/Classes/Utils/LPDevice.m
@@ -328,9 +328,12 @@ NSString *const LPDeviceSimKeyIphoneSimulatorDevice_LEGACY = @"IPHONE_SIMULATOR_
     @"iPhone9,4" : @"iphone 6+",
 
     // iPhone 8/8+/X - derived from Simulator
+    @"iPhone10,1" : @"iphone 6",
     @"iPhone10,4" : @"iphone 6",
     @"iPhone10,5" : @"iphone 6+",
+    @"iPhone10,2" : @"iphone 6+",
     @"iPhone10,3" : @"iphone 10",
+    @"iPhone10,6" : @"iphone 10",
 
     // iPad Pro 13in
     @"iPad6,7" : @"ipad pro",


### PR DESCRIPTION
### Motivation

Latest model numbers are out.