### PR TITLE
Test: force xcpretty to write build/reports/junit.xml

### DIFF
--- a/bin/test/xctest.rb
+++ b/bin/test/xctest.rb
@@ -33,6 +33,9 @@ else
   warnings_as_errors="GCC_TREAT_WARNINGS_AS_ERRORS=NO"
 end
 
+xcpretty_cmd = "| xcpretty -tc -r junit -o build/reports/junit.xml && exit ${PIPESTATUS[0]}"
+FileUtils.rm_f "build/reports/junit.xml"
+
 args =
       [
             'test',
@@ -44,7 +47,7 @@ args =
             '-sdk iphonesimulator',
             '-configuration Debug',
             warnings_as_errors,
-            use_xcpretty ? '| xcpretty -tc --report junit && exit ${PIPESTATUS[0]}' : ''
+            use_xcpretty ? xcpretty_cmd : ""
       ]
 
 Dir.chdir(working_dir) do


### PR DESCRIPTION
### Motivation

Completes:

* Jenkins: LPServer XCTest results are not generating xml files [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/24755)

Ultimately the problem is that XCTest is not generating any test output to stdout so xcpretty cannot create a report.  I confirmed the same thing is happening in DeviceAgent.

We will have to rely on the success/failure of the `xcrun xcodebuild test` process.

Updated the Jenkins jobs accordingly.