### PR TITLE
Jenkins: jobs push calabash artifacts to S3

### DIFF
--- a/bin/ci/jenkins/run.sh
+++ b/bin/ci/jenkins/run.sh
@@ -34,5 +34,7 @@ info "Skipping Acquaint tests cannot be run because dylib injection is failing"
 info "on macOS Sierra and Xcode 8.3.3."
 #bundle exec bin/test/acquaint.rb
 
-# Skip s3 upload with --dry-run until S3 credentials are available
-bin/ci/jenkins/s3-publish.sh --dry-run
+# Jenkins uploads artifacts based on a git commit,
+# as apposed to an adhoc artifact which is not tied
+# to a git commit.
+bin/ci/jenkins/s3-publish.sh release


### PR DESCRIPTION
### Motivation

Completes:

* Jenkins publishes LPServer dylibs to S3 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/25390)

```
$ bin/ci/jenkins/s3-publish.sh 
Usage: bin/s3-publish {release | adhoc} [--dry-run]

The first argument controls how the SHA in the S3 url is created.

release => s3://ios-lpserver/<SHA> will be the current git SHA
  adhoc => s3://ios-lpserver/<SHA> will be the SHA of the dylib
```

### Test

- [x] visually verified that the s3.{json | yaml | txt} files host on Jenkins contain the correct URL
- [x] visually verified that the files are hosted on S3