### PR TITLE
Travis: add an Xcode / macOS matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: objective-c
+os: osx
 osx_image: xcode8.3
 
 before_script:
+  - gem update --system
+  - gem install bundler
   - bin/ci/travis/instruments-auth.sh
   - bin/ci/travis/install-keychain.sh
 
 script:
   - bundle install
   - make framework
-  - make frank
-  - bin/ci/travis/make-dylibs.sh
-  - bundle exec bin/test/xctest.rb
-  - bundle exec bin/test/cucumber.rb
-  - bundle exec bin/test/acquaint.rb
   - bin/ci/travis/make-ipa.sh
-  - bundle exec bin/test/test-cloud.rb
 
 notifications:
   email:

--- a/bin/ci/travis/install-keychain.sh
+++ b/bin/ci/travis/install-keychain.sh
@@ -26,16 +26,3 @@ fi
 
 (cd "${CODE_SIGN_DIR}" && ios/create-keychain.sh)
 (cd "${CODE_SIGN_DIR}" && ios/import-profiles.sh)
-
-API_TOKEN=`${CODE_SIGN_DIR}/ios/find-xtc-credential.sh api-token | tr -d '\n'`
-
-# Install the API token where briar can find it.
-mkdir -p "${HOME}/.calabash/test-cloud"
-echo $API_TOKEN > "${HOME}/.calabash/test-cloud/calabash-ios-ci"
-
-# Bug in Briar. :(
-ln -s "${HOME}/.calabash" "${HOME}/.xamarin"
-
-# Bug in Briar. :(
-touch "${HOME}/.calabash/test-cloud/ios-sets.csv"
-


### PR DESCRIPTION
### Motivation

Progress on:

* Spike: can Travis CI support an Xcode / macOS version testing matrix [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/37867)