### PR TITLE
Bin: respond to changes in Calabash.keychain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,7 @@ framework:
 	bin/make/framework.sh
 
 dylibs:
-	# The argument is the sha of the cert used to resign the dylib.
-	# $ cd ~/.calabash/calabash-codesign
-	# $ sha256 apple/certs/calabash-developer.p12
-	bin/make/dylibs.sh 4d5868ea6f8778abaf31b56703ebd8d2f45dfb0aabaf767fa9cbd85203f395c1
+	bin/make/dylibs.sh
 
 webquery_headers:
 	bundle exec bin/make/insert-js-into-webquery-headers.rb

--- a/bin/ci/jenkins/appcenter.sh
+++ b/bin/ci/jenkins/appcenter.sh
@@ -18,21 +18,24 @@ else
   exit 1
 fi
 
-CAL_CODESIGN="${HOME}/.calabash/calabash-codesign"
-if [ -e "${CAL_CODESIGN}" ]; then
-  AC_TOKEN=$("${CAL_CODESIGN}/apple/find-appcenter-credential.sh" api-token)
-else
-  if [ "${AC_TOKEN}" = "" ]; then
-    error "Expected calabash-codesign to be installed to:"
-    error "  ${CAL_CODESIGN}"
-    error "or AC_TOKEN environment variable to be defined."
-    error ""
-    error "Need an AppCenter API Token to proceed"
+if [ "${AC_TOKEN}" = "" ]; then
+  KEYCHAIN="${HOME}/.calabash/Calabash.keychain"
+
+  if [ ! -e "${KEYCHAIN}" ]; then
+    echo "Cannot find AppCenter token: there is no Calabash.keychain"
+    echo "  ${KEYCHAIN}"
     exit 1
   fi
-fi
 
-info "Will use token: ${AC_TOKEN}"
+  if [ ! -e "${HOME}/.calabash/find-keychain-credential.sh" ]; then
+    echo "Cannot find AppCenter token: no find-keychain-credential.sh script"
+    echo "  ${HOME}/.calabash/find-keychain-credential.sh"
+    exit 1
+  fi
+
+  info "Fetching AppCenter token from Calabash.keychain"
+  AC_TOKEN=$("${HOME}/.calabash/find-keychain-credential.sh" api-token)
+fi
 
 WORKSPACE="${HOME}/.calabash/xtc/calabash-ios-server/submit"
 

--- a/bin/ci/jenkins/s3-publish.sh
+++ b/bin/ci/jenkins/s3-publish.sh
@@ -24,6 +24,27 @@ fi
 source bin/log.sh
 source bin/ditto.sh
 
+KEYCHAIN="${HOME}/.calabash/Calabash.keychain"
+
+if [ ! -e "${KEYCHAIN}" ]; then
+  echo "Cannot find S3 credentials: there is no Calabash.keychain"
+  echo "  ${KEYCHAIN}"
+  exit 1
+fi
+
+if [ ! -e "${HOME}/.calabash/find-keychain-credential.sh" ]; then
+  echo "Cannot find S3 credentials: no find-keychain-credential.sh script"
+  echo "  ${HOME}/.calabash/find-keychain-credential.sh"
+  exit 1
+fi
+
+export AWS_ACCESS_KEY_ID=$(
+"${HOME}/.calabash/find-keychain-credential.sh" s3-access-key
+)
+export AWS_SECRET_ACCESS_KEY=$(
+"${HOME}/.calabash/find-keychain-credential.sh" s3-secret
+)
+
 DYLIB="calabash-dylibs/libCalabashFAT.dylib"
 HEADERS_ZIP="calabash-dylibs/Headers.zip"
 

--- a/bin/make/dylibs.sh
+++ b/bin/make/dylibs.sh
@@ -156,49 +156,58 @@ zip_with_ditto "${INSTALL_DIR}/Headers" "${INSTALL_DIR}/Headers.zip"
 
 banner "Dylib Code Signing"
 
-CODE_SIGN_DIR="${HOME}/.calabash/calabash-codesign"
-RESIGN_TOOL="${CODE_SIGN_DIR}/apple/resign-ios-dylib.rb"
-SHA_TOOL="${CODE_SIGN_DIR}/sha256"
-
-CERT="${CODE_SIGN_DIR}/apple/certs/calabash-developer.p12"
-
-echo ${KEYCHAIN_TOOL}
-
-if [ ! -e ${CODE_SIGN_DIR} ]; then
-  warn "Skipping dylib codesiging!"
-  warn "If you are not a maintainer, you can ignore this warning"
-  warn "If you are maintainer, you should be resigning!"
-  warn "See: https://github.com/calabash/calabash-codesign"
-  exit 0
-
-else
-
-  EXPECTED_SHA=$1
-  ACTUAL_SHA=`$SHA_TOOL $CERT`
-
-  if [ "${EXPECTED_SHA}" != "${ACTUAL_SHA}" ]; then
-    error "Expected cert checksum: ${EXPECTED_SHA}"
-    error "  Actual cert checksum: ${ACTUAL_SHA}"
-    error ""
-    error "You must update your local code signing tool"
-    error "$ cd ~/.calabash/calabash-codesign"
-    error "$ git checkout master"
-    error "$ git pull"
-    exit 1
-  fi
-
-  info "Creating the Calabash.keychain"
-  (cd "${CODE_SIGN_DIR}" && apple/create-keychain.sh)
-
-  info "Resiging the device dylib"
-  $RESIGN_TOOL "${INSTALL_DIR}/libCalabashARM.dylib"
-
-  info "Resiging the FAT dylib"
-  $RESIGN_TOOL "${INSTALL_DIR}/libCalabashFAT.dylib"
-
-  xcrun codesign --display --verbose=2\
-    ${INSTALL_DIR}/libCalabashARM.dylib
+if [ "${KEYCHAIN}" = "" ]; then
+  KEYCHAIN="${HOME}/.calabash/Calabash.keychain"
 fi
+
+if [ -e "${KEYCHAIN}" ]; then
+  info "Will resign with keychain: ${KEYCHAIN}"
+else
+  error "Expected keychain at path:"
+  error "  ${KEYCHAIN}"
+  error "If you are signing with the Calabash.keychain,"
+  error "pull the latest from GitHub and recreate the keychain."
+  exit 1
+fi
+
+if [ "${CODE_SIGN_IDENTITY}" = "" ]; then
+  CODE_SIGN_IDENTITY="iPhone Developer: Karl Krukow (YTTN6Y2QS9)"
+fi
+
+set +e
+xcrun security find-certificate \
+  -Z -c "${CODE_SIGN_IDENTITY}" \
+  "${KEYCHAIN}" > /dev/null
+
+if [ "$?" = "0" ]; then
+  info "Will resign with identity: ${CODE_SIGN_IDENTITY}"
+else
+  error "Expected to find identity in keychain:"
+  error "            KEYCHAIN: ${KEYCHAIN}"
+  error "  CODE_SIGN_IDENTITY: ${CODE_SIGN_IDENTITY}"
+  error ""
+  error "These identities are in the keychain:"
+  xcrun security find-identity -v -p codesigning "${KEYCHAIN}"
+  exit 1
+fi
+set -e
+
+info "Resiging the device dylib"
+
+xcrun codesign \
+  --verbose \
+  --force \
+  --sign "${CODE_SIGN_IDENTITY}" \
+  --keychain "${KEYCHAIN}" \
+  "${INSTALL_DIR}/libCalabashARM.dylib"
+
+info "Resiging the FAT dylib"
+xcrun codesign \
+  --verbose \
+  --force \
+  --sign "${CODE_SIGN_IDENTITY}" \
+  --keychain "${KEYCHAIN}" \
+  "${INSTALL_DIR}/libCalabashFAT.dylib"
 
 banner "Dylib Info"
 


### PR DESCRIPTION
### Motivation

Progress on:

* DeviceAgent.iOS: can push jobs to AppCenter from Jenkins [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/39206)

To complete that ^ pull request, we updated our code signing repository.  We removed some files that our dylib signing script depended on.  This pull request removes that dependency and simplifies the signing portion of the dylib script.

### Notes

CI will fail until a pull request on Calabash Codesign is merged.