### PR TITLE
Update ruby test env and respond to Jenkins reinstall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "run_loop", github: "calabash/run_loop", branch: "develop"
+gem "json", "1.8.6"
 gem "luffa", :github => "calabash/luffa", :branch => "develop"
 
 gem "retriable", "~> 2.0"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
   environment {
     DEVELOPER_DIR='/Xcode/9.4.1/Xcode.app/Contents/Developer'
-    XCPRETTY=0
+    XCPRETTY=1
 
     SLACK_COLOR_DANGER  = '#E01563'
     SLACK_COLOR_INFO    = '#6ECADC'
@@ -15,7 +15,6 @@ pipeline {
   }
   options {
     disableConcurrentBuilds()
-    timestamps()
     buildDiscarder(logRotator(numToKeepStr: '10'))
     timeout(time: 60, unit: 'MINUTES')
   }

--- a/bin/make/ipa-cal.sh
+++ b/bin/make/ipa-cal.sh
@@ -119,6 +119,8 @@ cat >"${XTC_DIR}/Gemfile" <<EOF
 source "https://rubygems.org"
 
 gem "calabash-cucumber"
+gem "cucumber", "2.99.0"
+gem "json", "1.8.6"
 gem "rspec", "~> 3.0"
 gem "xamarin-test-cloud"
 EOF

--- a/cucumber/Gemfile
+++ b/cucumber/Gemfile
@@ -1,11 +1,12 @@
 source "https://rubygems.org"
 
 gem "calabash-cucumber", :github => "calabash/calabash-ios", :branch => "develop"
+gem "cucumber", "2.99.0"
 gem "run_loop", :github => "calabash/run_loop", :branch => "develop"
+gem "json", "1.8.6"
 
 # Sync with config/xtc-other-gems
 gem "rspec", "~> 3.0"
-gem "cucumber", "~> 2.0"
 gem "xamarin-test-cloud", "~> 2.0"
 
 gem "pry"


### PR DESCRIPTION
### Motivation

Jenkins has been reinstalled and the timestamper plug-in removed.

Calabash iOS will soon be agnostic re: the cucumber version.

run_loop will soon be agnostic re: the json version