### PR TITLE
Fix logic to switch to the second tab

### DIFF
--- a/cucumber/features/dylib_injection.feature
+++ b/cucumber/features/dylib_injection.feature
@@ -23,7 +23,6 @@ Scenario: Server in the .app bundle is launched
 Given the app has launched
 Then the server identifier is from the embedded dylib
 
-@xtc_only
 Scenario: Entitlement Injector has been loaded
 Given the app has launched
 And I go to the second tab

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -9,10 +9,20 @@ module LPTestTarget
       response_body_to_hash(body)
     end
 
-    def switch_to_second_tab_retryable
-      begin
+    def switch_to_second_tab
+      xcode = RunLoop::Xcode.new
+      if xcode.version_gte_110?
+        # Separate case for Xcode 11 beta since it doesn't switch to the second tab sometimes
+        # retry_count = 15 minutes to make sure that simulator has stabilized
+        retry_count = 900
+        begin
+          touch("UITabBarButton index:1")
+          retry_count = retry_count - 1
+          sleep(1)
+        end while retry_count > 0 && query("view marked: 'Second View'").empty?
+      else
         touch("UITabBarButton index:1")
-      end while query("view marked: 'Second View'").empty?
+      end
     end
   end
 end
@@ -43,7 +53,7 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  switch_to_second_tab_retryable
+  switch_to_second_tab
   wait_for_none_animating
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -37,7 +37,10 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  touch("UITabBarButton index:1")
+  while query("view marked: 'Second View'").empty?
+    touch("UITabBarButton index:1")
+  end
+
   wait_for_none_animating
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -13,7 +13,7 @@ module LPTestTarget
       begin
         touch("UITabBarButton index:1")
         attempt_count = attempt_count - 1
-        sleep(0.5)
+        sleep(1)
       end while attempt_count > 0 && query("view marked: 'Second View'").empty?
     end
   end
@@ -45,7 +45,7 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  switch_to_second_tab_retryable(20)
+  switch_to_second_tab_retryable(100)
   wait_for_none_animating
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -45,7 +45,7 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  switch_to_second_tab_retryable(5)
+  switch_to_second_tab_retryable(20)
   wait_for_none_animating
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -10,11 +10,8 @@ module LPTestTarget
     end
 
     def switch_to_second_tab_retryable
-      attempt_count = 1000
       begin
         touch("UITabBarButton index:1")
-        attempt_count = attempt_count - 1
-        sleep(0.5)
       end while attempt_count > 0 && query("view marked: 'Second View'").empty?
     end
   end

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -12,7 +12,7 @@ module LPTestTarget
     def switch_to_second_tab_retryable
       begin
         touch("UITabBarButton index:1")
-      end while attempt_count > 0 && query("view marked: 'Second View'").empty?
+      end while query("view marked: 'Second View'").empty?
     end
   end
 end

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -9,11 +9,12 @@ module LPTestTarget
       response_body_to_hash(body)
     end
 
-    def switch_to_second_tab_retryable(attempt_count)
+    def switch_to_second_tab_retryable
+      attempt_count = 1000
       begin
         touch("UITabBarButton index:1")
         attempt_count = attempt_count - 1
-        sleep(1)
+        sleep(0.5)
       end while attempt_count > 0 && query("view marked: 'Second View'").empty?
     end
   end
@@ -45,7 +46,7 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  switch_to_second_tab_retryable(100)
+  switch_to_second_tab_retryable
   wait_for_none_animating
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -8,6 +8,13 @@ module LPTestTarget
       body = http({:method => "GET", :path => path}, {})
       response_body_to_hash(body)
     end
+
+    def switch_to_second_tab_retryable(attempt_count)
+      begin
+        touch("UITabBarButton index:1")
+        sleep(0.5)
+      end while attempt_count > 0 && query("view marked: 'Second View'").empty?
+    end
   end
 end
 
@@ -37,10 +44,7 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  while query("view marked: 'Second View'").empty?
-    touch("UITabBarButton index:1")
-  end
-
+  switch_to_second_tab_retryable(5)
   wait_for_none_animating
 end
 

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -12,6 +12,7 @@ module LPTestTarget
     def switch_to_second_tab_retryable(attempt_count)
       begin
         touch("UITabBarButton index:1")
+        attempt_count = attempt_count - 1
         sleep(0.5)
       end while attempt_count > 0 && query("view marked: 'Second View'").empty?
     end


### PR DESCRIPTION
# Issue
2 scenarios fail on CI randomly:
1) `Scenario: Entitlement Injector has been loaded`
2) `Scenario: Touch small buttons`
Both of them fail about 4-5 times per 10 runs

# Debug process
The main issues with both tests is that they can't get some value by query
I have added request `query(*)` to failing tests to determine what elements are showed on device screen. I have found that test app still shows elements from the first tab after step `I go to the second tab`. So this step doesn't switch tabs sometimes.
The main issue is that test app sometimes is not switched to the second tab randomly.

# Fix
I have added logic to touch second tab icon until the second tab is shown.
```
while query("view marked: 'Second View'").empty?
    touch("UITabBarButton index:1")
  end
```

# How it was tested
I have run 11 builds in CI and all of them passed without issue. Both tests were green.

I am not sure that such retry logic is good solution but it works and proofs main idea.
The root cause can be related to some instability and hangs of Xcode 11 simulators since Xcode 11 is still `beta`
@jmoody , probably you can advice better solution.