### PR TITLE
Publish TestCloudAgent artifacts to blob storage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   # `mainJob` variable points to the matrix case that will be the main case
-  # it will run `appcenter-cli` test step and publish artifacts to the Azure Blob
+  # it will run `appcenter-cli` test step
   mainJob: 'Mojave-Xcode-10.2.1'
 jobs:
 
@@ -73,7 +73,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['Agent.JobName'], variables['mainJob']))
+    condition: and(succeeded(), eq(variables['XCODE_VERSION'], variables['10.2.1']))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['XCODE_VERSION'], variables['10.2.1']))
+    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   # `mainJob` variable points to the matrix case that will be the main case
-  # it will run `appcenter-cli` test step
+  # it will run `appcenter-cli` test step and publish artifacts to the Azure Blob
   mainJob: 'Mojave-Xcode-10.2.1'
 jobs:
 
@@ -73,7 +73,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
+    condition: and(succeeded(), eq(variables['Agent.JobName'], variables['mainJob']), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@ variables:
   # `mainJob` variable points to the matrix case that will be the main case
   # it will run `appcenter-cli` test step and publish artifacts to the Azure Blob
   mainJob: 'Mojave-Xcode-10.2.1'
+  # `PublishFrom` variable points to the matrix case that will publish build artifacts to the blob storage
+  PublishFrom: 'Mojave-Xcode-10.2.1'
 jobs:
 
 - job:
@@ -64,6 +66,16 @@ jobs:
 
   - script: bundle exec bin/test/cucumber.rb
     displayName: "exec cucumber"
+
+  # azureStorage* env vars are defined in the pipeline UI as secret variables
+  - bash: "./bin/ci/az-publish.sh"
+    env:
+      AZURE_STORAGE_ACCOUNT: $(azureStorageAccount)
+      AZURE_STORAGE_KEY: $(azureStorageKey)
+      AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
+      SOURCE_BRANCH: $(Build.SourceBranch)
+    displayName: "Publish to Azure Blob Storage"
+    condition: and(succeeded(), eq(variables['Agent.JobName'], variables['PublishFrom']))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'))
+    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,6 @@ variables:
   # `mainJob` variable points to the matrix case that will be the main case
   # it will run `appcenter-cli` test step and publish artifacts to the Azure Blob
   mainJob: 'Mojave-Xcode-10.2.1'
-  # `PublishFrom` variable points to the matrix case that will publish build artifacts to the blob storage
-  PublishFrom: 'Mojave-Xcode-10.2.1'
 jobs:
 
 - job:
@@ -75,7 +73,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['Agent.JobName'], variables['PublishFrom']))
+    condition: and(succeeded(), eq(variables['Agent.JobName'], variables['mainJob']))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
 source bin/ditto.sh
+source bin/xcode.sh
 
 set -eo pipefail
-CONFIG=Debug
 
 # $1 => SOURCE PATH
 # $2 => TARGET NAME
 function azupload {
-    echo "Dry run: ${1} published with name: ${2}"
+  echo "Dry run: ${1} published with name: ${2}"
 # az storage blob upload \
 #   --container-name ios-test-cloud-agent \
-#   --if-none-match "*" \
 #   --file "${1}" \
 #   --name "${2}"
+  echo "${1} artifact uploaded with name ${2}"
 }
 
 # Pipeline Variables are set through the AzDevOps UI
@@ -39,6 +39,9 @@ GIT_SHA=$(git rev-parse --verify HEAD | tr -d '\n')
 # Evaluate Calabash version
 VERSION=$(xcrun strings calabash-dylibs/libCalabashFAT.dylib | grep -E "CALABASH VERSION" | cut -f3- -d" " | tr -d '\n')
 
+# Evaluate the Xcode version used to build artifacts
+XC_VERSION=$(xcode_version)
+
 az --version
 
 WORKING_DIR="${BUILD_SOURCESDIRECTORY}"
@@ -46,30 +49,25 @@ WORKING_DIR="${BUILD_SOURCESDIRECTORY}"
 # Upload `calabash.framework.zip`
 CALABASH_FRAMEWORK="${WORKING_DIR}/calabash.framework.zip"
 zip_with_ditto "${WORKING_DIR}/calabash.framework" "${CALABASH_FRAMEWORK}"
-CALABASH_FRAMEWORK_NAME="calabash.framework-${VERSION}-${GIT_SHA}.zip"
+CALABASH_FRAMEWORK_NAME="calabash.framework-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.zip"
 azupload "${CALABASH_FRAMEWORK}" "${CALABASH_FRAMEWORK_NAME}"
-echo "${CALABASH_FRAMEWORK} artifact uploaded with name ${CALABASH_FRAMEWORK_NAME}"
 
 # Upload `libCalabashFAT.dylib`
 CALABASH_FAT="${WORKING_DIR}/calabash-dylibs/libCalabashFAT.dylib"
-CALABASH_FAT_NAME="libCalabashFAT-${VERSION}-${GIT_SHA}.dylib"
+CALABASH_FAT_NAME="libCalabashFAT-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.dylib"
 azupload "${CALABASH_FAT}" "${CALABASH_FAT_NAME}"
-echo "${CALABASH_FAT} artifact uploaded with name ${CALABASH_FAT_NAME}"
 
 # Upload `libCalabashARM.dylib`
 CALABASH_ARM="${WORKING_DIR}/calabash-dylibs/libCalabashARM.dylib"
-CALABASH_ARM_NAME="libCalabashARM-${VERSION}-${GIT_SHA}.dylib"
+CALABASH_ARM_NAME="libCalabashARM-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.dylib"
 azupload "${CALABASH_ARM}" "${CALABASH_ARM_NAME}"
-echo "${CALABASH_ARM} artifact uploaded with name ${CALABASH_ARM_NAME}"
 
 # Upload `libCalabashSim.dylib`
 CALABASH_SIM="${WORKING_DIR}/calabash-dylibs/libCalabashSim.dylib"
-CALABASH_SIM_NAME="libCalabashSim-${VERSION}-${GIT_SHA}.dylib"
+CALABASH_SIM_NAME="libCalabashSim-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.dylib"
 azupload "${CALABASH_SIM}" "${CALABASH_SIM_NAME}"
-echo "${CALABASH_SIM} artifact uploaded with name ${CALABASH_SIM_NAME}"
 
 # Upload `Headers.zip`
 HEADERS_ZIP="${WORKING_DIR}/calabash-dylibs/Headers.zip"
-HEADERS_ZIP_NAME="libCalabash-Headers-${VERSION}-${GIT_SHA}.zip"
+HEADERS_ZIP_NAME="libCalabash-Headers-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.zip"
 azupload "${HEADERS_ZIP}" "${HEADERS_ZIP_NAME}"
-echo "${HEADERS_ZIP} artifact uploaded with name ${HEADERS_ZIP_NAME}"

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -8,11 +8,12 @@ CONFIG=Debug
 # $1 => SOURCE PATH
 # $2 => TARGET NAME
 function azupload {
-az storage blob upload \
-  --container-name ios-test-cloud-agent \
-  --if-none-match "*" \
-  --file "${1}" \
-  --name "${2}"
+    echo "Dry run: ${1} published with name: ${2}"
+# az storage blob upload \
+#   --container-name ios-test-cloud-agent \
+#   --if-none-match "*" \
+#   --file "${1}" \
+#   --name "${2}"
 }
 
 # Pipeline Variables are set through the AzDevOps UI

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -8,11 +8,10 @@ set -eo pipefail
 # $1 => SOURCE PATH
 # $2 => TARGET NAME
 function azupload {
-  echo "Dry run: ${1} published with name: ${2}"
-# az storage blob upload \
-#   --container-name ios-test-cloud-agent \
-#   --file "${1}" \
-#   --name "${2}"
+  az storage blob upload \
+    --container-name ios-test-cloud-agent \
+    --file "${1}" \
+    --name "${2}"
   echo "${1} artifact uploaded with name ${2}"
 }
 

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+source bin/ditto.sh
+
+set -eo pipefail
+CONFIG=Debug
+
+# $1 => SOURCE PATH
+# $2 => TARGET NAME
+function azupload {
+az storage blob upload \
+  --container-name ios-test-cloud-agent \
+  --if-none-match "*" \
+  --file "${1}" \
+  --name "${2}"
+}
+
+# Pipeline Variables are set through the AzDevOps UI
+# See also the ./azdevops-pipeline.yml
+if [[ -z "${AZURE_STORAGE_ACCOUNT}" ]]; then
+  echo "AZURE_STORAGE_ACCOUNT is required"
+  exit 1
+fi
+
+if [[ -z "${AZURE_STORAGE_KEY}" ]]; then
+  echo "AZURE_STORAGE_KEY is required"
+  exit 1
+fi
+
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+  echo "AZURE_STORAGE_CONNECTION_STRING is required"
+  exit 1
+fi
+
+# Evaluate git-sha value
+GIT_SHA=$(git rev-parse --verify HEAD | tr -d '\n')
+
+# Evaluate Calabash version
+VERSION=$(xcrun strings calabash-dylibs/libCalabashFAT.dylib | grep -E "CALABASH VERSION" | cut -f3- -d" " | tr -d '\n')
+
+az --version
+
+WORKING_DIR="${BUILD_SOURCESDIRECTORY}"
+
+# Upload `calabash.framework.zip`
+CALABASH_FRAMEWORK="${WORKING_DIR}/calabash.framework.zip"
+zip_with_ditto "${WORKING_DIR}/calabash.framework" "${CALABASH_FRAMEWORK}"
+CALABASH_FRAMEWORK_NAME="calabash.framework-${VERSION}-${GIT_SHA}.zip"
+azupload "${CALABASH_FRAMEWORK}" "${CALABASH_FRAMEWORK_NAME}"
+echo "${CALABASH_FRAMEWORK} artifact uploaded with name ${CALABASH_FRAMEWORK_NAME}"
+
+# Upload `libCalabashFAT.dylib`
+CALABASH_FAT="${WORKING_DIR}/calabash-dylibs/libCalabashFAT.dylib"
+CALABASH_FAT_NAME="libCalabashFAT-${VERSION}-${GIT_SHA}.dylib"
+azupload "${CALABASH_FAT}" "${CALABASH_FAT_NAME}"
+echo "${CALABASH_FAT} artifact uploaded with name ${CALABASH_FAT_NAME}"
+
+# Upload `libCalabashARM.dylib`
+CALABASH_ARM="${WORKING_DIR}/calabash-dylibs/libCalabashARM.dylib"
+CALABASH_ARM_NAME="libCalabashARM-${VERSION}-${GIT_SHA}.dylib"
+azupload "${CALABASH_ARM}" "${CALABASH_ARM_NAME}"
+echo "${CALABASH_ARM} artifact uploaded with name ${CALABASH_ARM_NAME}"
+
+# Upload `libCalabashSim.dylib`
+CALABASH_SIM="${WORKING_DIR}/calabash-dylibs/libCalabashSim.dylib"
+CALABASH_SIM_NAME="libCalabashSim-${VERSION}-${GIT_SHA}.dylib"
+azupload "${CALABASH_SIM}" "${CALABASH_SIM_NAME}"
+echo "${CALABASH_SIM} artifact uploaded with name ${CALABASH_SIM_NAME}"
+
+# Upload `Headers.zip`
+HEADERS_ZIP="${WORKING_DIR}/calabash-dylibs/Headers.zip"
+HEADERS_ZIP_NAME="libCalabash-Headers-${VERSION}-${GIT_SHA}.zip"
+azupload "${HEADERS_ZIP}" "${HEADERS_ZIP_NAME}"
+echo "${HEADERS_ZIP} artifact uploaded with name ${HEADERS_ZIP_NAME}"


### PR DESCRIPTION
This PR adds new build step to the `azure-pipelines.yml` file. This build step will perform publishing of build artifacts (see exact list of artifacts below) to the [Azure Blob storage](https://ms.portal.azure.com/#%40microsoft.onmicrosoft.com/resource/subscriptions/9e13100f-ca82-4813-b6ea-9c8d72655924/resourceGroups/TestCloud/providers/Microsoft.Storage/storageAccounts/xtcruntimeartifacts/containersList) (Container name: `ios-test-cloud-agent`). Artifacts from build job with macOS Mojave and Xcode 10.2.1 would be published.

List of artifacts:
```
calabash.framework.zip
calabash-dylibs/libCalabashFAT.dylib
calabash-dylibs/libCalabashARM.dylib
calabash-dylibs/libCalabashSim.dylib
calabash-dylibs/Headers.zip
```