### PR TITLE
Revert Xcode 11 switching tabs workaround

### DIFF
--- a/bin/test/cucumber.rb
+++ b/bin/test/cucumber.rb
@@ -134,9 +134,6 @@ Dir.chdir working_dir do
     puts ''
     Luffa.log_info "passed on '#{passed}' out of '#{sims}'"
 
-    Luffa.log_info "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '100%' so we say good enough"
-    Luffa.log_info "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
-
     # if none failed then we have success
     exit 0 if failed == 0
 
@@ -147,11 +144,11 @@ Dir.chdir working_dir do
     actual = ((passed.to_f/sims.to_f) * 100).to_i
 
     if actual >= expected
-      Luffa.log_pass "We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
-      
+      Luffa.log_info "##vso[task.logissue type=warning;]We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
+      Luffa.log_info "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
       exit 0
     else
-      Luffa.log_fail "We failed '#{failed}' sims, which is '#{actual}%' and not enough to pass"
+      Luffa.log_info "##vso[task.logissue type=error;]We failed '#{failed}' sims, which is '#{actual}%' and not enough to pass"
       exit 1
     end
   end

--- a/bin/test/cucumber.rb
+++ b/bin/test/cucumber.rb
@@ -143,8 +143,8 @@ Dir.chdir working_dir do
     expected = 75
     actual = ((passed.to_f/sims.to_f) * 100).to_i
 
-    print "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
-    print "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
+    Luffa.log_info "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
+    Luffa.log_info "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
     if actual >= expected
       Luffa.log_pass "We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
       

--- a/bin/test/cucumber.rb
+++ b/bin/test/cucumber.rb
@@ -143,8 +143,11 @@ Dir.chdir working_dir do
     expected = 75
     actual = ((passed.to_f/sims.to_f) * 100).to_i
 
+    print "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
+    print "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
     if actual >= expected
       Luffa.log_pass "We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
+      
       exit 0
     else
       Luffa.log_fail "We failed '#{failed}' sims, which is '#{actual}%' and not enough to pass"

--- a/bin/test/cucumber.rb
+++ b/bin/test/cucumber.rb
@@ -134,6 +134,9 @@ Dir.chdir working_dir do
     puts ''
     Luffa.log_info "passed on '#{passed}' out of '#{sims}'"
 
+    Luffa.log_info "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
+    Luffa.log_info "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
+
     # if none failed then we have success
     exit 0 if failed == 0
 
@@ -143,8 +146,6 @@ Dir.chdir working_dir do
     expected = 75
     actual = ((passed.to_f/sims.to_f) * 100).to_i
 
-    Luffa.log_info "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
-    Luffa.log_info "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
     if actual >= expected
       Luffa.log_pass "We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
       

--- a/bin/test/cucumber.rb
+++ b/bin/test/cucumber.rb
@@ -134,7 +134,7 @@ Dir.chdir working_dir do
     puts ''
     Luffa.log_info "passed on '#{passed}' out of '#{sims}'"
 
-    Luffa.log_info "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '#{actual}%' so we say good enough"
+    Luffa.log_info "##vso[task.logissue type=warning;]Cucumber tests - We failed '#{failed}' sims, but passed '100%' so we say good enough"
     Luffa.log_info "##vso[task.complete result=SucceededWithIssues;]Cucumber test run warning"
 
     # if none failed then we have success

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -10,19 +10,7 @@ module LPTestTarget
     end
 
     def switch_to_second_tab
-      xcode = RunLoop::Xcode.new
-      if xcode.version_gte_110?
-        # Separate case for Xcode 11 beta since it doesn't switch to the second tab sometimes
-        # retry_count = 15 minutes to make sure that simulator has stabilized
-        retry_count = 900
-        begin
-          touch("UITabBarButton index:1")
-          retry_count = retry_count - 1
-          sleep(1)
-        end while retry_count > 0 && query("view marked: 'Second View'").empty?
-      else
-        touch("UITabBarButton index:1")
-      end
+      touch("UITabBarButton index:1")
     end
   end
 end

--- a/cucumber/features/steps/shared.rb
+++ b/cucumber/features/steps/shared.rb
@@ -8,10 +8,6 @@ module LPTestTarget
       body = http({:method => "GET", :path => path}, {})
       response_body_to_hash(body)
     end
-
-    def switch_to_second_tab
-      touch("UITabBarButton index:1")
-    end
   end
 end
 
@@ -41,7 +37,7 @@ And(/^I go to the second tab$/) do
     !query("UITabBarButton").empty?
   end
 
-  switch_to_second_tab
+  touch("UITabBarButton index:1")
   wait_for_none_animating
 end
 


### PR DESCRIPTION
1) Remove retry-workaround for switching to the second tab. It became redundant because the issue was fixed in Xcode 11 beta 5. It looks like passrate with Xcode 11 beta 5 is about 100%
2) Improve logging in `cucumber.rb` script. Use `vso` prefix to report error to the summary and set job as `SucceededWithIssues` in case if some devices fail.