### PR TITLE
Ignore text caret animation

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -205,9 +205,10 @@
                                                       BOOL *stop) {
             CAAnimation *animation = [view.layer animationForKey:key];
             if (animation.duration > kLPConditionRouteAnimationDurationLimit &&
-               ! [key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) { 
+                ! [key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) { 
               atLeastOneAnimating = YES;
               *stop = YES;
+            }
           }];
         }
       }

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -182,7 +182,7 @@
         UIView *view = (UIView *)match;
         NSArray *animationKeys = [[view.layer animationKeys] copy];
         for (NSString *key in animationKeys) {
-          if ([key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) {
+          if ([key isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) {
             return false;
           } else {
             CAAnimation *animation = [view.layer animationForKey:key];

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -204,7 +204,8 @@
                                                       NSUInteger idx,
                                                       BOOL *stop) {
             CAAnimation *animation = [view.layer animationForKey:key];
-            if ([key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) {
+            if (animation.duration > kLPConditionRouteAnimationDurationLimit &&
+               ! [key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) { 
               // do nothing
             } else if (animation.duration > kLPConditionRouteAnimationDurationLimit) {
               atLeastOneAnimating = YES;

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -205,7 +205,7 @@
                                                       BOOL *stop) {
             CAAnimation *animation = [view.layer animationForKey:key];
             if (animation.duration > kLPConditionRouteAnimationDurationLimit &&
-                ! [key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) { 
+                ![key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) { 
               atLeastOneAnimating = YES;
               *stop = YES;
             }

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -210,7 +210,6 @@
               atLeastOneAnimating = YES;
               *stop = YES;
             }
-            
           }];
         }
       }

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -206,11 +206,8 @@
             CAAnimation *animation = [view.layer animationForKey:key];
             if (animation.duration > kLPConditionRouteAnimationDurationLimit &&
                ! [key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) { 
-              // do nothing
-            } else if (animation.duration > kLPConditionRouteAnimationDurationLimit) {
               atLeastOneAnimating = YES;
               *stop = YES;
-            }
           }];
         }
       }

--- a/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPConditionRoute.m
@@ -173,7 +173,8 @@
   // Only consider animations with a duration greater than the defined
   // limit. This is intended to work around the parallax animation
   // attached to iOS 8 UIAlertViews and UIActionSheets
-
+  // Skip Text Caret Blink Animation, since it is unrelated to the
+  // application flow
   if ([[NSThread currentThread] isMainThread]) {
     NSArray *matches = [LPOperation performQuery:query];
     for (id match in matches) {
@@ -181,8 +182,12 @@
         UIView *view = (UIView *)match;
         NSArray *animationKeys = [[view.layer animationKeys] copy];
         for (NSString *key in animationKeys) {
-          CAAnimation *animation = [view.layer animationForKey:key];
-          return animation.duration > kLPConditionRouteAnimationDurationLimit;
+          if ([key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) {
+            return false;
+          } else {
+            CAAnimation *animation = [view.layer animationForKey:key];
+            return animation.duration > kLPConditionRouteAnimationDurationLimit;
+          }
         }
       }
     }
@@ -199,10 +204,13 @@
                                                       NSUInteger idx,
                                                       BOOL *stop) {
             CAAnimation *animation = [view.layer animationForKey:key];
-            if (animation.duration > kLPConditionRouteAnimationDurationLimit) {
+            if ([key  isEqual: @"UITextSelectionViewCaretBlinkAnimation"]) {
+              // do nothing
+            } else if (animation.duration > kLPConditionRouteAnimationDurationLimit) {
               atLeastOneAnimating = YES;
               *stop = YES;
             }
+            
           }];
         }
       }


### PR DESCRIPTION
In iOS 14 the text caret animation started to animate inside of the thread which is not expected behaviour for none animation check. This PR skips animation keys with `UITextSelectionViewCaretBlinkAnimation`