### PR TITLE
Apply workaround for predicate assertion issue on iOS 15.5+ versions

### DIFF
--- a/calabash/Classes/UISpec/UIScriptASTPredicate.m
+++ b/calabash/Classes/UISpec/UIScriptASTPredicate.m
@@ -34,7 +34,7 @@
   NSMutableArray *res = [NSMutableArray arrayWithCapacity:8];
   for (id v in views) {
     if ([v isKindOfClass:[NSDictionary class]] || [v respondsToSelector:self.selector]) {
-      if ([self.predicate evaluateWithObject:v]) {
+      if ([self evaluatePredicateWithObject:v]) {
         [res addObject:v];
       }
     }
@@ -42,6 +42,43 @@
   return res;
 }
 
+/*
+ INFO:
+    From iOS 15.5,
+    it is added security action check that fail NSFunctionExpression with the following error:
+    "(Foundation) [com.apple.Foundation:general] NSPredicate: NSFunctionExpression with selector 'accessibilityLabel' is forbidden."
+    The issue is related to any accessibility property. However, it is used identifier and label properties in tests.
+ */
+- (BOOL)evaluatePredicateWithObject:(id)object {
+  if (@available(iOS 15.5, *)) {
+    NSString *identifier = @"accessibilityIdentifier";
+    NSString *label = @"accessibilityLabel";
+    NSString *predicateDescription = [self.predicate description];
+  
+    if ([predicateDescription containsString:identifier]) {
+      predicateDescription = [self replaceDescription:predicateDescription withObject:object andProperty:identifier];
+    }
+  
+    if ([predicateDescription containsString:label]) {
+      predicateDescription = [self replaceDescription:predicateDescription withObject:object andProperty:label];
+    }
+    
+    NSPredicate *newPredicate = [NSPredicate predicateWithFormat:predicateDescription];
+
+    return [newPredicate evaluateWithObject:object];
+  }
+  
+  return [self.predicate evaluateWithObject:object];
+}
+
+- (NSString *)replaceDescription:(NSString *) description withObject:(id) object andProperty:(NSString *) propertyName {
+  NSString *propertyValue = [object performSelector:NSSelectorFromString(propertyName)];
+  NSString *escapedPropertyValue = [propertyValue stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+  NSString *formattedString = [NSString stringWithFormat:@"\"%@\"", escapedPropertyValue];
+  NSString *newPredicateString = [description stringByReplacingOccurrencesOfString:propertyName withString:formattedString];
+  
+  return newPredicateString;
+}
 
 - (void) dealloc {
   self.predicate = nil;


### PR DESCRIPTION
From iOS 15.5, it is added security action check that fails NSFunctionExpression with the following error:
    "(Foundation) [com.apple.Foundation:general] NSPredicate: NSFunctionExpression with selector 'accessibilityLabel' is forbidden."
The issue is related to any accessibility property. However, it is used identifier and label properties in tests. In this pull request, I read accessibility id or label values first and then evaluate the predicate with these values.