### PR TITLE
fix: prevent crash when calling search bar / textview delegate methods

### DIFF
--- a/calabash/Classes/FranklyServer/Routes/LPClearTextRoute.m
+++ b/calabash/Classes/FranklyServer/Routes/LPClearTextRoute.m
@@ -132,11 +132,11 @@
     if ([delegate respondsToSelector:@selector(textFieldShouldClear:)]) {
       return [delegate textFieldShouldClear:target];
     }
-  } else if ([target isKindOfClass:[UITextView class]]) {
+  } else if ([target isKindOfClass:[UITextView class]] && [delegate respondsToSelector: @selector(textView:shouldChangeTextInRange:replacementText:)]) {
     return [delegate textView:target
       shouldChangeTextInRange:range
               replacementText:@""];
-  } else if ([target isKindOfClass:[UISearchBar class]]) {
+  } else if ([target isKindOfClass:[UISearchBar class]] && [delegate respondsToSelector: @selector(searchBar:shouldChangeTextInRange:replacementText:)]) {
     return [delegate searchBar:target
        shouldChangeTextInRange:range
                replacementText:@""];


### PR DESCRIPTION
I just had this crash in my app with the search bar, it seems that the delegate method implementation is optional, but not checked in the server.